### PR TITLE
Add --disk-cache-dir and --max-cpu-mem parameters (Properly pushed to github)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Optionally, you can use the following command-line flags:
 | `--load-in-8bit`  | Load the model with 8-bit precision.|
 | `--auto-devices` | Automatically split the model across the available GPU(s) and CPU.|
 | `--disk` | If the model is too large for your GPU(s) and CPU combined, send the remaining layers to the disk. |
+| `--disk-cache-dir DISK_CACHE_DIR` | If you want to specify the drive or folder for offloading to disk, specify the **full path** of your folder here. (Unless you just want to rename your cache folder) |
 | `--max-gpu-memory MAX_GPU_MEMORY` | Maximum memory in GiB to allocate to the GPU when loading the model. This is useful if you get out of memory errors while trying to generate text. Must be an integer number. |
+| `--max-cpu-mem MAX_CPU_MEMORY`    | Maximum memory in GiB to allocate to the CPU when offloading the model to ram. This parameter defaults to 99GiB. |
 | `--no-stream`   | Don't stream the text output in real time. This slightly improves the text generation performance.|
 | `--settings SETTINGS_FILE` | Load the default interface settings from this json file. See `settings-template.json` for an example.|
 | `--no-listen`   | Make the web UI unreachable from your local network.|

--- a/server.py
+++ b/server.py
@@ -31,6 +31,8 @@ parser.add_argument('--no-stream', action='store_true', help='Don\'t stream the 
 parser.add_argument('--settings', type=str, help='Load the default interface settings from this json file. See settings-template.json for an example.')
 parser.add_argument('--no-listen', action='store_true', help='Make the web UI unreachable from your local network.')
 parser.add_argument('--share', action='store_true', help='Create a public URL. This is useful for running the web UI on Google Colab or similar.')
+parser.add_argument('--max-cpu-mem', type=int, help='Maximum cpu memory in GiB to allocate to the memory for offloading.')
+parser.add_argument('--disk-cache-dir', type=str, help='Directory which you want the disk cache to load to.')
 args = parser.parse_args()
 
 loaded_preset = None
@@ -90,9 +92,15 @@ def load_model(model_name):
         else:
             settings.append("device_map='auto'")
             if args.max_gpu_memory is not None:
-                settings.append(f"max_memory={{0: '{args.max_gpu_memory}GiB', 'cpu': '99GiB'}}")
+                if args.max_cpu_mem is not None:
+                    settings.append(f"max_memory={{0: '{args.max_gpu_memory}GiB', 'cpu': '{args.max_cpu_mem}GiB'}}")
+                else:
+                    settings.append(f"max_memory={{0: '{args.max_gpu_memory}GiB', 'cpu': '99GiB'}}")
             if args.disk:
-                settings.append("offload_folder='cache'")
+                if args.disk_cache_dir is not None:
+                    settings.append("offload_folder='"+args.disk_cache_dir+"'")
+                else:
+                    settings.append("offload_folder='cache'")
             if args.load_in_8bit:
                 settings.append("load_in_8bit=True")
             else:


### PR DESCRIPTION
--disk-cache-dir allows user to specify their cache directory while --max-cpu-mem allows user to specify the amount of RAM they want to use for offloading. In windows, using ram as high as possible may cause swap space to be used. Additionally, if the user needs some spare ram to do other things, being able to adjust ram usage would also be useful. As for the cache directory, if the user have a dedicated acceleration disk for ai, it.would be useful to have the option to redirect.

**Opening a new pull request because the previous one accidentally modifies the entire file, weird.**