### PR TITLE
Fix a regex issue in `tokenize_dialogue`.

### DIFF
--- a/server.py
+++ b/server.py
@@ -532,7 +532,7 @@ if args.chat or args.cai_chat:
         dialogue = re.sub('<START>', '', dialogue)
         dialogue = re.sub('<start>', '', dialogue)
         dialogue = re.sub('(\n|^)[Aa]non:', '\\1You:', dialogue)
-        dialogue = re.sub('(\n|^)\[CHARACTER\]:', f'\\1{name2}:', dialogue)
+        dialogue = re.sub('(\n|^)\[CHARACTER\]:', f'\\g<1>{name2}:', dialogue)
         idx = [m.start() for m in re.finditer(f"(^|\n)({name1}|{name2}):", dialogue)]
         if len(idx) == 0:
             return _history


### PR DESCRIPTION
The existing regex would fail if using character names that start with numbers.

The issue is the formatting of the backreference using a "naked" number, meaning that any numerical value in the name will be part of the backreference.

Using the alternative format of `\\g<1>` as described [in the docs](https://docs.python.org/3/library/re.html#re.sub) solves this issue. The docs actually has this exact case as an example in the last paragraph above the version discrepancies.