### PR TITLE
moving argparse to a separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+__pycache__
+models/*
+!models/place-your-models-here.txt

--- a/argparse_module.py
+++ b/argparse_module.py
@@ -1,0 +1,26 @@
+"""
+Module containing the argument parser for the script.
+
+The purpose of this module is to provide a convenient and centralized way to
+handle the command-line arguments required by the script. It uses the argparse
+library to define and parse the following arguments:
+
+MODEL: A required positional argument, which specifies the name of the model
+to download from Hugging Face.
+--branch: An optional argument, which specifies the name of the Git branch to
+download from. The default value is 'main'.
+--threads: An optional argument, which specifies the number of files to
+download simultaneously. The default value is 1.
+
+Example usage:
+    python download-model.py MODEL --branch feature_branch --threads 4
+"""
+
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('MODEL', type=str)
+parser.add_argument('--branch', type=str, default='main', help='Name of the Git branch to download from.')
+parser.add_argument('--threads', type=int, default=1, help='Number of files to download simultaneously.')
+args = parser.parse_args()

--- a/download-model.py
+++ b/download-model.py
@@ -6,20 +6,16 @@ python download-model.py facebook/opt-1.3b
 
 '''
 
-import requests 
-from bs4 import BeautifulSoup 
-import multiprocessing
-import tqdm
 import sys
-import argparse
-from pathlib import Path
 import re
+import multiprocessing
+import requests
+from pathlib import Path
+from bs4 import BeautifulSoup
+from argparse_module import args
+import tqdm
 
-parser = argparse.ArgumentParser()
-parser.add_argument('MODEL', type=str)
-parser.add_argument('--branch', type=str, default='main', help='Name of the Git branch to download from.')
-parser.add_argument('--threads', type=int, default=1, help='Number of files to download simultaneously.')
-args = parser.parse_args()
+
 
 def get_file(args):
     url = args[0]


### PR DESCRIPTION
- Argparse was moved to a separate module.
- Imports order in `download-model.py` was changed according to PEP8
- `.gitignore` was added.