### PR TITLE
Escape regexp in message extraction

### DIFF
--- a/server.py
+++ b/server.py
@@ -559,8 +559,8 @@ def extract_message_from_reply(question, reply, current, other, check, extension
     next_character_found = False
     substring_found = False
 
-    previous_idx = [m.start() for m in re.finditer(f"(^|\n){current}:", question)]
-    idx = [m.start() for m in re.finditer(f"(^|\n){current}:", reply)]
+    previous_idx = [m.start() for m in re.finditer(f"(^|\n){re.escape(current)}:", question)]
+    idx = [m.start() for m in re.finditer(f"(^|\n){re.escape(current)}:", reply)]
     idx = idx[len(previous_idx)-1]
 
     if extensions:


### PR DESCRIPTION
## The problem
Users were unable to send messages if the character's name contained parentheses. [Example of 'broken' character card](https://media.discordapp.net/attachments/1076630264433872896/1076630345069379604/Fem-Death_Muerte.card.png)

The following exception was present in console logs:

![image](https://user-images.githubusercontent.com/18619528/219943798-0c454379-ef07-4a34-9129-5292a6210883.png)

## The solution
Escape the value inserted into the regexp used for extracting a reply. Now I'm able to get a reply.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/18619528/219943933-884ff969-31a5-438e-8689-b8b8d9c84f6a.png">
