### PR TITLE
Add LLaMA 4-bit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Optionally, you can use the following command-line flags:
 | `--cai-chat`  | Launch the web UI in chat mode with a style similar to Character.AI's. If the file `img_bot.png` or `img_bot.jpg` exists in the same folder as server.py, this image will be used as the bot's profile picture. Similarly, `img_me.png` or `img_me.jpg` will be used as your profile picture. |
 | `--cpu`       | Use the CPU to generate text.|
 | `--load-in-8bit`  | Load the model with 8-bit precision.|
+| `--load-in-4bit`  |  Load the model with 4-bit precision. Currently only works with LLaMA. |
 | `--bf16`  | Load the model with bfloat16 precision. Requires NVIDIA Ampere GPU. |
 | `--auto-devices` | Automatically split the model across the available GPU(s) and CPU.|
 | `--disk` | If the model is too large for your GPU(s) and CPU combined, send the remaining layers to the disk. |

--- a/modules/models.py
+++ b/modules/models.py
@@ -102,6 +102,10 @@ def load_model(model_name):
         if path_to_model.name.lower().startswith('llama-30b'):
             pt_model = 'llama-30b-4bit.pt'
 
+        if not Path(f"models/{pt_model}").exists():
+            print(f"Could not find models/{pt_model}, exiting...")
+            exit()
+
         model = load_quant(path_to_model, Path(f"models/{pt_model}"), 4)
         model = model.to(torch.device('cuda:0'))
 
@@ -178,4 +182,3 @@ def load_soft_prompt(name):
         shared.soft_prompt_tensor = tensor
 
     return name
-

--- a/modules/models.py
+++ b/modules/models.py
@@ -89,7 +89,7 @@ def load_model(model_name):
 
     # 4-bit LLaMA
     elif shared.args.load_in_4bit:
-        sys.path.append(os.path.abspath(Path("repositories/GPTQ-for-LLaMa")))
+        sys.path.insert(0, os.path.abspath(Path("repositories/GPTQ-for-LLaMa")))
 
         from llama import load_quant
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -68,6 +68,7 @@ parser.add_argument('--chat', action='store_true', help='Launch the web UI in ch
 parser.add_argument('--cai-chat', action='store_true', help='Launch the web UI in chat mode with a style similar to Character.AI\'s. If the file img_bot.png or img_bot.jpg exists in the same folder as server.py, this image will be used as the bot\'s profile picture. Similarly, img_me.png or img_me.jpg will be used as your profile picture.')
 parser.add_argument('--cpu', action='store_true', help='Use the CPU to generate text.')
 parser.add_argument('--load-in-8bit', action='store_true', help='Load the model with 8-bit precision.')
+parser.add_argument('--load-in-4bit', action='store_true', help='Load the model with 4-bit precision. Currently only works with LLaMA.')
 parser.add_argument('--bf16', action='store_true', help='Load the model with bfloat16 precision. Requires NVIDIA Ampere GPU.')
 parser.add_argument('--auto-devices', action='store_true', help='Automatically split the model across the available GPU(s) and CPU.')
 parser.add_argument('--disk', action='store_true', help='If the model is too large for your GPU(s) and CPU combined, send the remaining layers to the disk.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ numpy
 rwkv==0.1.0
 safetensors==0.2.8
 sentencepiece
-git+https://github.com/oobabooga/transformers@llama_push
+git+https://github.com/zphang/transformers@llama_push


### PR DESCRIPTION
Usage:

```
python server.py --model llama-7b --load-in-4bit
```

Requirements:

1. Clone [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa) into the `text-generation-webui/repositories` subfolder and install it:

```
mkdir repositories
git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa
cd GPTQ-for-LLaMa
python setup_cuda.py install
```

2. Install the newest LLaMA-patched transformers:

```
pip uninstall transformers
pip install git+https://github.com/zphang/transformers@llama_push
```

3. Place the desired LLaMA model converted using the newest [convert_llama_weights_to_hf.py](https://github.com/zphang/transformers/blob/llama_push/src/transformers/models/llama/convert_llama_weights_to_hf.py) script into your `models` folder. For instance, `models/llama-7b`.

4. Place the corresponding 4-bit model directly into your `models` folder. For instance, `models/llama-7b-4bit.pt`. https://huggingface.co/decapoda-research

