### PR TITLE
add multi-gpu support for 4bit gptq LLaMA

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -112,12 +112,13 @@ def load_model(model_name):
         model = load_quant(path_to_model, Path(f"models/{pt_model}"), 4)
 
         if shared.args.gpu_memory:
+            import accelerate
+
             max_memory = {}
             for i in range(len(shared.args.gpu_memory)):
                 max_memory[i] = f"{shared.args.gpu_memory[i]}GiB"
             max_memory['cpu'] = f"{shared.args.cpu_memory or '99'}GiB"
 
-            import accelerate
             device_map = accelerate.infer_auto_device_map(model, max_memory=max_memory, no_split_module_classes=["LLaMADecoderLayer"])
             model = accelerate.dispatch_model(model, device_map=device_map)
         else:

--- a/modules/models.py
+++ b/modules/models.py
@@ -110,7 +110,18 @@ def load_model(model_name):
             exit()
 
         model = load_quant(path_to_model, Path(f"models/{pt_model}"), 4)
-        model = model.to(torch.device('cuda:0'))
+
+        if shared.args.gpu_memory:
+            max_memory = {}
+            for i in range(len(shared.args.gpu_memory)):
+                max_memory[i] = f"{shared.args.gpu_memory[i]}GiB"
+            max_memory['cpu'] = f"{shared.args.cpu_memory or '99'}GiB"
+
+            import accelerate
+            device_map = accelerate.infer_auto_device_map(model, max_memory=max_memory)
+            model = accelerate.dispatch_model(model, device_map=device_map)
+        else:
+            model = model.to(torch.device('cuda:0'))
 
     # Custom
     else:

--- a/modules/models.py
+++ b/modules/models.py
@@ -118,7 +118,7 @@ def load_model(model_name):
             max_memory['cpu'] = f"{shared.args.cpu_memory or '99'}GiB"
 
             import accelerate
-            device_map = accelerate.infer_auto_device_map(model, max_memory=max_memory)
+            device_map = accelerate.infer_auto_device_map(model, max_memory=max_memory, no_split_module_classes=["LLaMADecoderLayer"])
             model = accelerate.dispatch_model(model, device_map=device_map)
         else:
             model = model.to(torch.device('cuda:0'))


### PR DESCRIPTION
this PR adds multi-gpu support in 4-bit gptq quantized mode for LLaMA using `accelerate`.

tested and works, can easily load and run LLaMA-60B in two 3090s. behavior is unchanged if you don't provide `--gpu-memory` arg