### PR TITLE
Use the pt_path value in load_quant call

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -116,7 +116,7 @@ def load_model(model_name):
             print(f"Could not find {pt_model}, exiting...")
             exit()
 
-        model = load_quant(path_to_model, Path(f"models/{pt_model}"), 4)
+        model = load_quant(path_to_model, pt_path, 4)
 
         # Multi-GPU setup
         if shared.args.gpu_memory:


### PR DESCRIPTION
I see you go to the effort to identify the quantized pt file, but that value doesn't ever get passed to the load_quant call.