### PR TITLE
Load and save character files and chat history in UTF-8

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -321,7 +321,7 @@ def load_history(file, name1, name2):
 
 def load_default_history(name1, name2):
     if Path('logs/persistent.json').exists():
-        load_history(open(Path('logs/persistent.json'), 'rb', encoding='utf-8').read(), name1, name2)
+        load_history(open(Path('logs/persistent.json'), 'rb').read(), name1, name2)
     else:
         shared.history['internal'] = []
         shared.history['visible'] = []
@@ -355,7 +355,7 @@ def load_character(_character, name1, name2):
         name2 = shared.settings['name2_pygmalion']
 
     if Path(f'logs/{shared.character}_persistent.json').exists():
-        load_history(open(Path(f'logs/{shared.character}_persistent.json'), 'rb', encoding='utf-8').read(), name1, name2)
+        load_history(open(Path(f'logs/{shared.character}_persistent.json'), 'rb').read(), name1, name2)
 
     if shared.args.cai_chat:
         return name2, context, generate_chat_html(shared.history['visible'], name1, name2, shared.character)

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -332,7 +332,7 @@ def load_character(_character, name1, name2):
     shared.history['visible'] = []
     if _character != 'None':
         shared.character = _character
-        data = json.loads(open(Path(f'characters/{_character}.json'), 'r').read())
+        data = json.loads(open(Path(f'characters/{_character}.json'), 'r', encoding='utf-8').read())
         name2 = data['char_name']
         if 'char_persona' in data and data['char_persona'] != '':
             context += f"{data['char_name']}'s Persona: {data['char_persona']}\n"
@@ -372,7 +372,7 @@ def upload_character(json_file, img, tavern=False):
         i += 1
     if tavern:
         outfile_name = f'TavernAI-{outfile_name}'
-    with open(Path(f'characters/{outfile_name}.json'), 'w') as f:
+    with open(Path(f'characters/{outfile_name}.json'), 'w', encoding='utf-8') as f:
         f.write(json_file)
     if img is not None:
         img = Image.open(io.BytesIO(img))

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -291,7 +291,7 @@ def save_history(timestamp=True):
         fname = f"{prefix}persistent.json"
     if not Path('logs').exists():
         Path('logs').mkdir()
-    with open(Path(f'logs/{fname}'), 'w') as f:
+    with open(Path(f'logs/{fname}'), 'w', encoding='utf-8') as f:
         f.write(json.dumps({'data': shared.history['internal'], 'data_visible': shared.history['visible']}, indent=2))
     return Path(f'logs/{fname}')
 
@@ -321,7 +321,7 @@ def load_history(file, name1, name2):
 
 def load_default_history(name1, name2):
     if Path('logs/persistent.json').exists():
-        load_history(open(Path('logs/persistent.json'), 'rb').read(), name1, name2)
+        load_history(open(Path('logs/persistent.json'), 'rb', encoding='utf-8').read(), name1, name2)
     else:
         shared.history['internal'] = []
         shared.history['visible'] = []
@@ -355,7 +355,7 @@ def load_character(_character, name1, name2):
         name2 = shared.settings['name2_pygmalion']
 
     if Path(f'logs/{shared.character}_persistent.json').exists():
-        load_history(open(Path(f'logs/{shared.character}_persistent.json'), 'rb').read(), name1, name2)
+        load_history(open(Path(f'logs/{shared.character}_persistent.json'), 'rb', encoding='utf-8').read(), name1, name2)
 
     if shared.args.cai_chat:
         return name2, context, generate_chat_html(shared.history['visible'], name1, name2, shared.character)


### PR DESCRIPTION
For some reason all the files were getting loaded and saved as cp1252 by default. Changing to UTF allows us to do things like (づ｡◕‿‿◕｡)づ and 🧀 and better multilingual support. 

<img width="597" alt="Screenshot 2023-03-11 212239" src="https://user-images.githubusercontent.com/1486609/224526109-7e40afdb-e74e-4287-81d2-e7030fd800f3.png">
