### PR TITLE
Fix loading of character jsons with non-ascii symbols.

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -332,7 +332,7 @@ def load_character(_character, name1, name2):
     shared.history['visible'] = []
     if _character != 'None':
         shared.character = _character
-        data = json.loads(open(Path(f'characters/{_character}.json'), 'r').read())
+        data = json.loads(open(Path(f'characters/{_character}.json'), 'r', encoding='utf-8').read())
         name2 = data['char_name']
         if 'char_persona' in data and data['char_persona'] != '':
             context += f"{data['char_name']}'s Persona: {data['char_persona']}\n"


### PR DESCRIPTION
Small patch to fix loading of character jsons. Now it correctly reads non-ascii characters.

![image](https://user-images.githubusercontent.com/16204504/224533602-75b1caaa-3f37-4953-871a-17fb22b3e3e2.png)

![image](https://user-images.githubusercontent.com/16204504/224533529-769e2f4d-92ab-4c4a-8f7f-924e28e1298f.png)

