### PR TITLE
Fix: tuple object does not support item assignment

### DIFF
--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -57,7 +57,7 @@ def remove_surrounded_chars(string):
 
 def remove_tts_from_history(name1, name2):
     for i, entry in enumerate(shared.history['internal']):
-        shared.history['visible'][i][1] = entry[1]
+        shared.history['visible'][i] = [shared.history['visible'][i][0], entry[1]]
     return chat.generate_chat_output(shared.history['visible'], name1, name2, shared.character)
 
 def toggle_text_in_history(name1, name2):
@@ -66,9 +66,9 @@ def toggle_text_in_history(name1, name2):
         if visible_reply.startswith('<audio'):
             if params['show_text']:
                 reply = shared.history['internal'][i][1]
-                shared.history['visible'][i][1] = f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"
+                shared.history['visible'][i] = [shared.history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"]
             else:
-                shared.history['visible'][i][1] = f"{visible_reply.split('</audio>')[0]}</audio>"
+                shared.history['visible'][i] = [shared.history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>"]
     return chat.generate_chat_output(shared.history['visible'], name1, name2, shared.character)
 
 def input_modifier(string):
@@ -79,7 +79,7 @@ def input_modifier(string):
 
     # Remove autoplay from the last reply
     if (shared.args.chat or shared.args.cai_chat) and len(shared.history['internal']) > 0:
-        shared.history['visible'][-1][1] = shared.history['visible'][-1][1].replace('controls autoplay>','controls>')
+        shared.history['visible'][-1] = [shared.history['visible'][-1][0], shared.history['visible'][-1][1].replace('controls autoplay>','controls>')]
 
     return string
 


### PR DESCRIPTION
Fixes an error in the `silero_tts` extension.

```
  File "...\text-generation-webui\extensions\silero_tts\script.py", line 82, in input_modifier
    shared.history['visible'][-1][1] = shared.history['visible'][-1][1].replace('controls autoplay>','controls>')
TypeError: 'tuple' object does not support item assignment

  File "...\text-generation-webui\extensions\silero_tts\script.py", line 69, in toggle_text_in_history
    shared.history['visible'][i][1] = f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"
TypeError: 'tuple' object does not support item assignment
```