### PR TITLE
flask_cloudflared for shared tunnels

### DIFF
--- a/extensions/api/requirements.txt
+++ b/extensions/api/requirements.txt
@@ -1,0 +1,1 @@
+flask_cloudflared==0.0.12

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -75,7 +75,15 @@ class Handler(BaseHTTPRequestHandler):
 def run_server():
     server_addr = ('0.0.0.0' if shared.args.listen else '127.0.0.1', params['port'])
     server = ThreadingHTTPServer(server_addr, Handler)
-    print(f'Starting KoboldAI compatible api at http://{server_addr[0]}:{server_addr[1]}/api')
+    if shared.args.share: 
+        try:
+            from flask_cloudflared import  _run_cloudflared
+            public_url = _run_cloudflared(params['port'], params['port'] + 1)
+            print(f'Starting KoboldAI compatible api at {public_url}/api')
+        except ImportError:
+            print('You should install flask_cloudflared manually')
+    else:
+        print(f'Starting KoboldAI compatible api at http://{server_addr[0]}:{server_addr[1]}/api')
     server.serve_forever()
 
 def ui():


### PR DESCRIPTION
Response to request https://github.com/oobabooga/text-generation-webui/pull/342#issuecomment-1470917370

Now it uses cloudflare tunnels when `--share` flag is set. 
I'm not tested it in colab environment, but on my local machine it works.

You need to `pip install flask_cloudflared` to use this feature. 
To run locally it's not necessary