### PR TITLE
Fix api extension duplicating

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -8,6 +8,8 @@ params = {
     'port': 5000,
 }
 
+server = None
+
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/api/v1/model':
@@ -73,6 +75,7 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def run_server():
+    global server
     server_addr = ('0.0.0.0' if shared.args.listen else '127.0.0.1', params['port'])
     server = ThreadingHTTPServer(server_addr, Handler)
     if shared.args.share: 
@@ -87,4 +90,5 @@ def run_server():
     server.serve_forever()
 
 def ui():
-    Thread(target=run_server, daemon=True).start()
+    if server is None:
+        Thread(target=run_server, daemon=True).start()

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -8,8 +8,6 @@ params = {
     'port': 5000,
 }
 
-server = None
-
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/api/v1/model':
@@ -75,7 +73,6 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def run_server():
-    global server
     server_addr = ('0.0.0.0' if shared.args.listen else '127.0.0.1', params['port'])
     server = ThreadingHTTPServer(server_addr, Handler)
     if shared.args.share: 
@@ -89,6 +86,5 @@ def run_server():
         print(f'Starting KoboldAI compatible api at http://{server_addr[0]}:{server_addr[1]}/api')
     server.serve_forever()
 
-def ui():
-    if server is None:
-        Thread(target=run_server, daemon=True).start()
+def setup():
+    Thread(target=run_server, daemon=True).start()

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -37,6 +37,7 @@ def apply_extensions(text, typ):
     return text
 
 def create_extensions_block():
+    global setup_called
     # Updating the default values
     for extension, name in iterator():
         if hasattr(extension, 'params'):

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -46,15 +46,18 @@ def create_extensions_block():
                 if _id in shared.settings:
                     extension.params[param] = shared.settings[_id]
 
+    should_display_ui = False
     # Running setup function
     if not setup_called:
         for extension, name in iterator():
             if hasattr(extension, "setup"):
                 extension.setup()
+            if hasattr(extension, "ui"):
+                should_display_ui = True
         setup_called = True
 
     # Creating the extension ui elements
-    if len(state) > 0:
+    if should_display_ui:
         with gr.Box(elem_id="extensions"):
             gr.Markdown("Extensions")
             for extension, name in iterator():

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -5,6 +5,7 @@ import modules.shared as shared
 
 state = {}
 available_extensions = []
+setup_called = False
 
 def load_extensions():
     global state
@@ -43,6 +44,13 @@ def create_extensions_block():
                 _id = f"{name}-{param}"
                 if _id in shared.settings:
                     extension.params[param] = shared.settings[_id]
+
+    # Running setup function
+    if not setup_called:
+        for extension, name in iterator():
+            if hasattr(extension, "setup"):
+                extension.setup()
+        setup_called = True
 
     # Creating the extension ui elements
     if len(state) > 0:


### PR DESCRIPTION
Prevent server in `api` extension run multiple times, causing "Port already taken" error. 

I added new `setup()` method to extensions to run once when app is ready to initialize extensions when app is first loaded.
It also helps against empty "Extensions" block, when no actual ui is present.
