### PR TITLE
GPT-J and Pygmalion-6b 4bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ loras/*
 models/*
 softprompts/*
 torch-dumps/*
+repositories/*
 *pycache*
 */*pycache*
 */*/pycache*

--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -11,13 +11,16 @@ sys.path.insert(0, str(Path("repositories/GPTQ-for-LLaMa")))
 import llama
 import llama_inference_offload
 import opt
+import gptj
 
 
 def load_quantized(model_name):
     if not shared.args.gptq_model_type:
         # Try to determine model type from model name
         model_type = model_name.split('-')[0].lower()
-        if model_type not in ('llama', 'opt'):
+        if model_name.lower().startswith('pygmalion-6b'):
+            model_type = 'gptj'
+        if model_type not in ('llama', 'opt', 'gptj'):
             print("Can't determine model type from model name. Please specify it manually using --gptq-model-type "
                   "argument")
             exit()
@@ -31,6 +34,8 @@ def load_quantized(model_name):
             load_quant = llama_inference_offload.load_quant
     elif model_type == 'opt':
         load_quant = opt.load_quant
+    elif model_type == 'gptj':
+        load_quant = gptj.load_quant
     else:
         print("Unknown pre-quantized model type specified. Only 'llama' and 'opt' are supported")
         exit()

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -220,6 +220,7 @@ def generate_reply(question, max_new_tokens, do_sample, temperature, top_p, typi
             if not (shared.args.chat or shared.args.cai_chat):
                 yield formatted_outputs(original_question, shared.model_name)
             with generate_with_streaming(**generate_params) as generator:
+                reply = ''
                 for output in generator:
                     if shared.soft_prompt:
                         output = torch.cat((input_ids[0], output[filler_input_ids.shape[1]:]))


### PR DESCRIPTION
Support 4-bit GPTQ for GPT-J-6b and Pygmalion-6b.

You need my fork of GPTQ-for-LLaMA for it to work. It forked from commit 468c47c01b4fe370616747b6d69a2d3f48bab5e4, so should be compatible with current version.
```
mkdir repositories
cd repositories
git clone https://github.com/mayaeary/GPTQ-for-LLaMa
cd GPTQ-for-LLaMa
git checkout gptj
python setup_cuda.py install
```

To quantize model:
```
# from repositories/GPTQ-for-LLaMA
CUDA_VISIBLE_DEVICES=0 python gptj.py ../../models/pygmalion-6b_dev c4 --wbits 4 --save ../../models/pygmalion-6b_dev-4bit.pt
```

It seems to work, but can someone else test it?