### PR TITLE
Add display of context when input was generated

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -270,5 +270,5 @@ def generate_reply(question, max_new_tokens, do_sample, temperature, top_p, typi
         traceback.print_exc()
     finally:
         t1 = time.time()
-        print(f"Output generated in {(t1-t0):.2f} seconds ({(len(output)-len(original_input_ids[0]))/(t1-t0):.2f} tokens/s, {len(output)-len(original_input_ids[0])} tokens)")
+        print(f"Output generated in {(t1-t0):.2f} seconds ({(len(output)-len(original_input_ids[0]))/(t1-t0):.2f} tokens/s, {len(output)-len(original_input_ids[0])} tokens, context {len(original_input_ids[0])})")
         return


### PR DESCRIPTION
Not sure if I did this right but it does move with the conversation and seems to match value.

Output generated in 12.97 seconds (15.34 tokens/s, 199 tokens, context 4)
Output generated in 4.07 seconds (2.21 tokens/s, 9 tokens, context 1848)

Easier to see for OOM and benchmarks, etc.