### PR TITLE
Send_pictures small fix

### DIFF
--- a/extensions/send_pictures/script.py
+++ b/extensions/send_pictures/script.py
@@ -24,7 +24,7 @@ def caption_image(raw_image):
     return processor.decode(out[0], skip_special_tokens=True)
 
 def generate_chat_picture(picture, name1, name2):
-    text = f'*{name1} sends {name2} a picture that contains the following: "{caption_image(picture)}"*'
+    text = f'*{name1} sends {name2} a picture that contains the following: “{caption_image(picture)}”*'
     # lower the resolution of sent images for the chat, otherwise the log size gets out of control quickly with all the base64 values in visible history
     picture.thumbnail((300, 300))
     buffer = BytesIO()


### PR DESCRIPTION
Since the `text` variable is just for passing to the model instead of the picture, changed internal regular quotes to [typographical curly quotes](https://typographyforlawyers.com/straight-and-curly-quotes.html). 

The model interprets this all the same, yet curly quotes prevent possible HTML & JSON breakage down the line — as it was the case with alt-text 6 lines lower ( `visible_text = f'<img src="data:image/jpeg;base64,{img_str}"` **alt="{text}"**`>` )