### PR TITLE
silero_tts streaming fix

### DIFF
--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -26,6 +26,7 @@ current_params = params.copy()
 voices_by_gender = ['en_99', 'en_45', 'en_18', 'en_117', 'en_49', 'en_51', 'en_68', 'en_0', 'en_26', 'en_56', 'en_74', 'en_5', 'en_38', 'en_53', 'en_21', 'en_37', 'en_107', 'en_10', 'en_82', 'en_16', 'en_41', 'en_12', 'en_67', 'en_61', 'en_14', 'en_11', 'en_39', 'en_52', 'en_24', 'en_97', 'en_28', 'en_72', 'en_94', 'en_36', 'en_4', 'en_43', 'en_88', 'en_25', 'en_65', 'en_6', 'en_44', 'en_75', 'en_91', 'en_60', 'en_109', 'en_85', 'en_101', 'en_108', 'en_50', 'en_96', 'en_64', 'en_92', 'en_76', 'en_33', 'en_116', 'en_48', 'en_98', 'en_86', 'en_62', 'en_54', 'en_95', 'en_55', 'en_111', 'en_3', 'en_83', 'en_8', 'en_47', 'en_59', 'en_1', 'en_2', 'en_7', 'en_9', 'en_13', 'en_15', 'en_17', 'en_19', 'en_20', 'en_22', 'en_23', 'en_27', 'en_29', 'en_30', 'en_31', 'en_32', 'en_34', 'en_35', 'en_40', 'en_42', 'en_46', 'en_57', 'en_58', 'en_63', 'en_66', 'en_69', 'en_70', 'en_71', 'en_73', 'en_77', 'en_78', 'en_79', 'en_80', 'en_81', 'en_84', 'en_87', 'en_89', 'en_90', 'en_93', 'en_100', 'en_102', 'en_103', 'en_104', 'en_105', 'en_106', 'en_110', 'en_112', 'en_113', 'en_114', 'en_115']
 voice_pitches = ['x-low', 'low', 'medium', 'high', 'x-high']
 voice_speeds = ['x-slow', 'slow', 'medium', 'fast', 'x-fast']
+streaming_state = shared.args.no_stream # remember if chat streaming was enabled
 
 # Used for making text xml compatible, needed for voice pitch and speed control
 table = str.maketrans({
@@ -77,6 +78,7 @@ def input_modifier(string):
         shared.history['visible'][-1] = [shared.history['visible'][-1][0], shared.history['visible'][-1][1].replace('controls autoplay>','controls>')]
 
     shared.processing_message = "*Is recording a voice message...*"
+    shared.args.no_stream = True # Disable streaming cause otherwise the audio output will stutter and begin anew every time the message is being updated
     return string
 
 def output_modifier(string):
@@ -84,7 +86,7 @@ def output_modifier(string):
     This function is applied to the model outputs.
     """
 
-    global model, current_params
+    global model, current_params, streaming_state
 
     for i in params:
         if params[i] != current_params[i]:
@@ -116,6 +118,7 @@ def output_modifier(string):
             string += f'\n\n{original_string}'
 
     shared.processing_message = "*Is typing...*"
+    shared.args.no_stream = streaming_state # restore the streaming option to the previous value
     return string
 
 def bot_prefix_modifier(string):


### PR DESCRIPTION
Temporarily suppress the streaming during the audio response as it would interfere with the audio (making it stutter and play anew)

Demonstrating the issue:
![Issue_demo](https://user-images.githubusercontent.com/42910943/227735472-86ba08cb-13e2-488a-86ba-a2d2c2645f95.gif)
As one can see, every time the streamed text is updated, currently a new voice line is generated and played, resulting in stutters.

Suppressing the streaming fixes it.