### PR TITLE
Handle LLaMA adding extra spaces

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -163,7 +163,10 @@ def load_model(model_name):
         tokenizer = AutoTokenizer.from_pretrained(Path(f"{shared.args.model_dir}/gpt-j-6B/"))
     else:
         tokenizer = AutoTokenizer.from_pretrained(Path(f"{shared.args.model_dir}/{shared.model_name}/"))
+
     tokenizer.truncation_side = 'left'
+    if type(tokenizer) is transformers.LlamaTokenizer:
+        tokenizer.decode_with_prefix_space = True # This is to handle LLaMA adding spaces everywhere
 
     print(f"Loaded the model in {(time.time()-t0):.2f} seconds.")
     return model, tokenizer

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -28,6 +28,11 @@ def encode(prompt, tokens_to_generate=0, add_special_tokens=True):
         return input_ids
     else:
         input_ids = shared.tokenizer.encode(str(prompt), return_tensors='pt', truncation=True, max_length=get_max_prompt_length(tokens_to_generate), add_special_tokens=add_special_tokens)
+
+        # Handle LLaMA adding a space to the prompt for no reason
+        if prompt[0] != ' ' and decode(input_ids[0])[0] == ' ':
+            input_ids = input_ids[:,1:]
+
         if shared.args.cpu:
             return input_ids
         elif shared.args.flexgen:


### PR DESCRIPTION
I don't know if this is the right way to handle this.

Related to https://github.com/oobabooga/text-generation-webui/issues/559: the extra spaces prevent the stopping criteria in chat mode from being applied correctly 