### PR TITLE
Support GLM-130B via external api.

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -39,6 +39,12 @@ if shared.args.deepspeed:
 
 def load_model(model_name):
     print(f"Loading {model_name}...")
+
+    shared.is_external_api = model_name.startswith("http")
+    if shared.is_external_api:
+        print(f"Using external api: {model_name}")
+        return None, None
+
     t0 = time.time()
 
     shared.is_RWKV = model_name.lower().startswith('rwkv-')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -7,6 +7,7 @@ lora_name = "None"
 soft_prompt_tensor = None
 soft_prompt = False
 is_RWKV = False
+is_external_api = False
 
 # Chat variables
 history = {'internal': [], 'visible': []}


### PR DESCRIPTION
This pr adds support for passing an http endpoint as --model, allowing textui to serve as a frontend to other models that are not currently in huggingface or complicated to setup/require special versions of dependencies.
The primary goal is to support [GLM-130B](https://github.com/THUDM/GLM-130B), which runs on custom transformers implementations. It is recommended to run GLM-130B on [FasterTransformer](https://github.com/NVIDIA/FasterTransformer) in a docker, which exposes a http api.

Run textui with
```python server.py --model http://127.0.0.1:5000```

Infilling works (GLM-130B is a masked language model that supports both infilling and appending)
![image](https://user-images.githubusercontent.com/1655353/228443359-33b43e2c-023f-4ca8-a602-1b78970fac5b.png)
![image](https://user-images.githubusercontent.com/1655353/228443374-7634e93f-f855-4a7d-a0ba-0fe874930c55.png)

Chatting also works
![image](https://user-images.githubusercontent.com/1655353/228443671-054709ab-b91a-4e20-a5ad-77b0f37bcbaf.png)

The generation speed is quite good, considering it's a 130B model running on 2080Ti 22G x 4. The word count uses `len()`, so a Chinese character takes up multiple words.
![image](https://user-images.githubusercontent.com/1655353/228443770-543bfd78-b622-40b4-a457-2d13edba6bbc.png)

I think it is worth extending external api support to:

 1. ChatGLM-6B and smaller GLM variants (requires custom code)
 2. Distributed deepspeed/torchrun, as they have a multiprocess structure too cumbersome to stuff into textui #561 
 3. The original tensor-parallel version of Llama from Meta.