### PR TITLE
Add support for resuming downloads

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -24,12 +24,13 @@ parser.add_argument('--branch', type=str, default='main', help='Name of the Git 
 parser.add_argument('--threads', type=int, default=1, help='Number of files to download simultaneously.')
 parser.add_argument('--text-only', action='store_true', help='Only download text files (txt/json).')
 parser.add_argument('--output', type=str, default=None, help='The folder where the model should be saved.')
+parser.add_argument('--clean', action='store_true', help='Does not resume the previous download.')
 args = parser.parse_args()
 
 def get_file(url, output_folder):
     filename = Path(url.rsplit('/', 1)[1])
     output_path = output_folder / filename
-    if output_path.exists():
+    if output_path.exists() and not args.clean:
         # Check if the file has already been downloaded completely
         r = requests.head(url)
         total_size = int(r.headers.get('content-length', 0))

--- a/download-model.py
+++ b/download-model.py
@@ -35,7 +35,7 @@ def get_file(url, output_folder):
         # Check if the file has already been downloaded completely
         r = requests.head(url)
         total_size = int(r.headers.get('content-length', 0))
-        if output_path.stat().st_size == total_size:
+        if output_path.stat().st_size >= total_size:
             return
         # Otherwise, resume the download from where it left off
         headers = {'Range': f'bytes={output_path.stat().st_size}-'}
@@ -215,7 +215,6 @@ if __name__ == '__main__':
     print(f"Downloading the model to {output_folder}")
     download_files(links, output_folder, args.threads)
     
-    print('\n')
     # Validate the checksums
     validated = True
     for i in range(len(sha256)):
@@ -228,3 +227,5 @@ if __name__ == '__main__':
     
     if validated:
         print('[+] Validated checksums of all model files!')
+    else:
+        print('[-] Rerun the download-model.py with --clean flag')

--- a/download-model.py
+++ b/download-model.py
@@ -26,6 +26,7 @@ parser.add_argument('--threads', type=int, default=1, help='Number of files to d
 parser.add_argument('--text-only', action='store_true', help='Only download text files (txt/json).')
 parser.add_argument('--output', type=str, default=None, help='The folder where the model should be saved.')
 parser.add_argument('--clean', action='store_true', help='Does not resume the previous download.')
+parser.add_argument('--check', action='store_true', help='Validates the checksums of model files.')
 args = parser.parse_args()
 
 def get_file(url, output_folder):
@@ -215,17 +216,18 @@ if __name__ == '__main__':
     print(f"Downloading the model to {output_folder}")
     download_files(links, output_folder, args.threads)
     
-    # Validate the checksums
-    validated = True
-    for i in range(len(sha256)):
-        with open(output_folder / sha256[i][0], "rb") as f:
-            bytes = f.read()
-            file_hash = hashlib.sha256(bytes).hexdigest()
-            if file_hash != sha256[i][1]:
-                print(f'[!] Checksum for {sha256[i][0]} failed!')
-                validated = False
-    
-    if validated:
-        print('[+] Validated checksums of all model files!')
-    else:
-        print('[-] Rerun the download-model.py with --clean flag')
+    if args.check:
+        # Validate the checksums
+        validated = True
+        for i in range(len(sha256)):
+            with open(output_folder / sha256[i][0], "rb") as f:
+                bytes = f.read()
+                file_hash = hashlib.sha256(bytes).hexdigest()
+                if file_hash != sha256[i][1]:
+                    print(f'[!] Checksum for {sha256[i][0]} failed!')
+                    validated = False
+        
+        if validated:
+            print('[+] Validated checksums of all model files!')
+        else:
+            print('[-] Rerun the download-model.py with --clean flag')

--- a/download-model.py
+++ b/download-model.py
@@ -197,20 +197,7 @@ if __name__ == '__main__':
     output_folder = f"{'_'.join(model.split('/')[-2:])}"
     if branch != 'main':
         output_folder += f'_{branch}'
-
-    # Creating the folder and writing the metadata
     output_folder = Path(base_folder) / output_folder
-    if not output_folder.exists():
-        output_folder.mkdir()
-    with open(output_folder / 'huggingface-metadata.txt', 'w') as f:
-        f.write(f'url: https://huggingface.co/{model}\n')
-        f.write(f'branch: {branch}\n')
-        f.write(f'download date: {str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))}\n')
-        sha256_str = ''
-        for i in range(len(sha256)):
-            sha256_str += f'    {sha256[i][1]} {sha256[i][0]}\n'
-        if sha256_str != '':
-            f.write(f'sha256sum:\n{sha256_str}')
 
     if args.check:
         # Validate the checksums
@@ -238,6 +225,20 @@ if __name__ == '__main__':
             print('[-] Invalid checksums. Rerun download-model.py with the --clean flag.')
 
     else:
+
+        # Creating the folder and writing the metadata
+        if not output_folder.exists():
+            output_folder.mkdir()
+        with open(output_folder / 'huggingface-metadata.txt', 'w') as f:
+            f.write(f'url: https://huggingface.co/{model}\n')
+            f.write(f'branch: {branch}\n')
+            f.write(f'download date: {str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))}\n')
+            sha256_str = ''
+            for i in range(len(sha256)):
+                sha256_str += f'    {sha256[i][1]} {sha256[i][0]}\n'
+            if sha256_str != '':
+                f.write(f'sha256sum:\n{sha256_str}')
+
         # Downloading the files
         print(f"Downloading the model to {output_folder}")
         download_files(links, output_folder, args.threads)

--- a/download-model.py
+++ b/download-model.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import requests
 import tqdm
 from tqdm.contrib.concurrent import thread_map
+import hashlib
 
 parser = argparse.ArgumentParser()
 parser.add_argument('MODEL', type=str, default=None, nargs='?')
@@ -213,4 +214,17 @@ if __name__ == '__main__':
     # Downloading the files
     print(f"Downloading the model to {output_folder}")
     download_files(links, output_folder, args.threads)
-    print()
+    
+    print('\n')
+    # Validate the checksums
+    validated = True
+    for i in range(len(sha256)):
+        with open(output_folder / sha256[i][0], "rb") as f:
+            bytes = f.read()
+            file_hash = hashlib.sha256(bytes).hexdigest()
+            if file_hash != sha256[i][1]:
+                print(f'[!] Checksum for {sha256[i][0]} failed!')
+                validated = False
+    
+    if validated:
+        print('[+] Validated checksums of all model files!')

--- a/download-model.py
+++ b/download-model.py
@@ -34,7 +34,7 @@ def get_file(url, output_folder):
     output_path = output_folder / filename
     if output_path.exists() and not args.clean:
         # Check if the file has already been downloaded completely
-        r = requests.head(url)
+        r = requests.get(url, stream=True)
         total_size = int(r.headers.get('content-length', 0))
         if output_path.stat().st_size >= total_size:
             return


### PR DESCRIPTION
This pull request adds the ability to resume interrupted downloads by modifying the `get_file` function. The function now uses the HTTP Range header to fetch only the remaining part of a file that wasn't downloaded yet.

With the testing I have done, resuming a partial download still produces the same checksum, (maybe an automatic checksum check would be useful later).

Note: At the moment when running the download script with multiple threads, keyboard interrupts stop individual threads rather then the program itself.