### PR TITLE
llama.cpp: Setting n_threads to os.cpu_count() to maximize utilization

### DIFF
--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -1,4 +1,5 @@
 import llamacpp
+import os
 
 from modules.callbacks import Iteratorize
 
@@ -29,6 +30,7 @@ class LlamaCppModel:
     def from_pretrained(self, path):
         params = llamacpp.InferenceParams()
         params.path_model = str(path)
+        params.n_threads = os.cpu_count()
 
         _model = llamacpp.LlamaInference(params)
 


### PR DESCRIPTION
Alternatively, we could do os.cpu_count() - 1 to not fully slow the system down, or take in an arg from the UI somewhere.