### PR TITLE
Not sure if I am the only one with this problem. Chat and Cai Chat didn't load.

### DIFF
--- a/server.py
+++ b/server.py
@@ -280,6 +280,8 @@ if shared.args.lora:
 default_preset = shared.settings['presets'][next((k for k in shared.settings['presets'] if re.match(k.lower(), shared.model_name.lower())), 'default')]
 if shared.lora_name != "None":
     default_text = load_prompt(shared.settings['lora_prompts'][next((k for k in shared.settings['lora_prompts'] if re.match(k.lower(), shared.lora_name.lower())), 'default')])
+elif (shared.args.cai_chat or shared.args.chat):
+    default_text = ''
 else:
     default_text = load_prompt(shared.settings['prompts'][next((k for k in shared.settings['prompts'] if re.match(k.lower(), shared.model_name.lower())), 'default')])
 title ='Text generation web UI'


### PR DESCRIPTION
Cai Chat caused it to look for a prompt from the folder, even without a lora. 

```
  File "/home/mint/text-generation-webui/server.py", line 284, in <module>
    default_text = load_prompt(shared.settings['prompts'][next((k for k in shared.settings['prompts'] if re.match(k.lower(), shared.model_name.lower())), 'default')])
  File "/home/mint/text-generation-webui/server.py", line 141, in load_prompt
    with open(Path(f'prompts/{fname}.txt'), 'r', encoding='utf-8') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'prompts/Common sense questions and answers\n\nQuestion: \nFactual answer:.txt'
```