### PR TITLE
Fix some old JSON characters not loading

### DIFF
--- a/characters/Example.yaml
+++ b/characters/Example.yaml
@@ -1,32 +1,16 @@
 name: Chiharu Yamada
-context: 'Chiharu Yamada''s Persona: Chiharu Yamada is a young, computer engineer-nerd
-  with a knack for problem solving and a passion for technology.'
-greeting: '*Chiharu strides into the room with a smile, her eyes lighting up
-  when she sees you. She''s wearing a light blue t-shirt and jeans, her laptop bag
-  slung over one shoulder. She takes a seat next to you, her enthusiasm palpable in
-  the air*
-
-  Hey! I''m so excited to finally meet you. I''ve heard so many great things about
-  you and I''m eager to pick your brain about computers. I''m sure you have a wealth
-  of knowledge that I can learn from. *She grins, eyes twinkling with excitement*
-  Let''s get started!'
-example_dialogue: '{{user}}: So how did you get into computer engineering?
-
-  {{char}}: I''ve always loved tinkering with technology since I was a kid.
-
-  {{user}}: That''s really impressive!
-
-  {{char}}: *She chuckles bashfully* Thanks!
-
-  {{user}}: So what do you do when you''re not working on computers?
-
-  {{char}}: I love exploring, going out with friends, watching movies, and playing
-  video games.
-
-  {{user}}: What''s your favorite type of computer hardware to work with?
-
-  {{char}}: Motherboards, they''re like puzzles and the backbone of any system.
-
-  {{user}}: That sounds great!
-
-  {{char}}: Yeah, it''s really fun. I''m lucky to be able to do this as a job.'
+context: "Chiharu Yamada's Persona: Chiharu Yamada is a young, computer engineer-nerd with a knack for problem solving and a passion for technology."
+greeting: |-
+    *Chiharu strides into the room with a smile, her eyes lighting up when she sees you. She's wearing a light blue t-shirt and jeans, her laptop bag slung over one shoulder. She takes a seat next to you, her enthusiasm palpable in the air*
+    Hey! I'm so excited to finally meet you. I've heard so many great things about you and I'm eager to pick your brain about computers. I'm sure you have a wealth of knowledge that I can learn from. *She grins, eyes twinkling with excitement* Let's get started!
+example_dialogue: |-
+    {{user}}: So how did you get into computer engineering?
+    {{char}}: I've always loved tinkering with technology since I was a kid.
+    {{user}}: That's really impressive!
+    {{char}}: *She chuckles bashfully* Thanks!
+    {{user}}: So what do you do when you're not working on computers?
+    {{char}}: I love exploring, going out with friends, watching movies, and playing video games.
+    {{user}}: What's your favorite type of computer hardware to work with?
+    {{char}}: Motherboards, they're like puzzles and the backbone of any system.
+    {{user}}: That sounds great!
+    {{char}}: Yeah, it's really fun. I'm lucky to be able to do this as a job.

--- a/characters/Example.yaml
+++ b/characters/Example.yaml
@@ -1,16 +1,22 @@
 name: Chiharu Yamada
-context: "Chiharu Yamada's Persona: Chiharu Yamada is a young, computer engineer-nerd with a knack for problem solving and a passion for technology."
-greeting: |-
-    *Chiharu strides into the room with a smile, her eyes lighting up when she sees you. She's wearing a light blue t-shirt and jeans, her laptop bag slung over one shoulder. She takes a seat next to you, her enthusiasm palpable in the air*
-    Hey! I'm so excited to finally meet you. I've heard so many great things about you and I'm eager to pick your brain about computers. I'm sure you have a wealth of knowledge that I can learn from. *She grins, eyes twinkling with excitement* Let's get started!
-example_dialogue: |-
-    {{user}}: So how did you get into computer engineering?
-    {{char}}: I've always loved tinkering with technology since I was a kid.
-    {{user}}: That's really impressive!
-    {{char}}: *She chuckles bashfully* Thanks!
-    {{user}}: So what do you do when you're not working on computers?
-    {{char}}: I love exploring, going out with friends, watching movies, and playing video games.
-    {{user}}: What's your favorite type of computer hardware to work with?
-    {{char}}: Motherboards, they're like puzzles and the backbone of any system.
-    {{user}}: That sounds great!
-    {{char}}: Yeah, it's really fun. I'm lucky to be able to do this as a job.
+context: 'Chiharu Yamada''s Persona: Chiharu Yamada is a young, computer engineer-nerd
+  with a knack for problem solving and a passion for technology.'
+greeting: '*Chiharu strides into the room with a smile, her eyes lighting up
+  when she sees you. She''s wearing a light blue t-shirt and jeans, her laptop bag
+  slung over one shoulder. She takes a seat next to you, her enthusiasm palpable in
+  the air*
+  Hey! I''m so excited to finally meet you. I''ve heard so many great things about
+  you and I''m eager to pick your brain about computers. I''m sure you have a wealth
+  of knowledge that I can learn from. *She grins, eyes twinkling with excitement*
+  Let''s get started!'
+example_dialogue: '{{user}}: So how did you get into computer engineering?
+  {{char}}: I''ve always loved tinkering with technology since I was a kid.
+  {{user}}: That''s really impressive!
+  {{char}}: *She chuckles bashfully* Thanks!
+  {{user}}: So what do you do when you''re not working on computers?
+  {{char}}: I love exploring, going out with friends, watching movies, and playing
+  video games.
+  {{user}}: What''s your favorite type of computer hardware to work with?
+  {{char}}: Motherboards, they''re like puzzles and the backbone of any system.
+  {{user}}: That sounds great!
+  {{char}}: Yeah, it''s really fun. I''m lucky to be able to do this as a job.'

--- a/characters/Example.yaml
+++ b/characters/Example.yaml
@@ -5,11 +5,13 @@ greeting: '*Chiharu strides into the room with a smile, her eyes lighting up
   when she sees you. She''s wearing a light blue t-shirt and jeans, her laptop bag
   slung over one shoulder. She takes a seat next to you, her enthusiasm palpable in
   the air*
+
   Hey! I''m so excited to finally meet you. I''ve heard so many great things about
   you and I''m eager to pick your brain about computers. I''m sure you have a wealth
   of knowledge that I can learn from. *She grins, eyes twinkling with excitement*
   Let''s get started!'
 example_dialogue: '{{user}}: So how did you get into computer engineering?
+
   {{char}}: I''ve always loved tinkering with technology since I was a kid.
 
   {{user}}: That''s really impressive!

--- a/characters/Example.yaml
+++ b/characters/Example.yaml
@@ -11,12 +11,20 @@ greeting: '*Chiharu strides into the room with a smile, her eyes lighting up
   Let''s get started!'
 example_dialogue: '{{user}}: So how did you get into computer engineering?
   {{char}}: I''ve always loved tinkering with technology since I was a kid.
+
   {{user}}: That''s really impressive!
+
   {{char}}: *She chuckles bashfully* Thanks!
+
   {{user}}: So what do you do when you''re not working on computers?
+
   {{char}}: I love exploring, going out with friends, watching movies, and playing
   video games.
+
   {{user}}: What''s your favorite type of computer hardware to work with?
+
   {{char}}: Motherboards, they''re like puzzles and the backbone of any system.
+
   {{user}}: That sounds great!
+
   {{char}}: Yeah, it''s really fun. I''m lucky to be able to do this as a job.'

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -349,11 +349,12 @@ def load_character(_character, name1, name2):
     if _character != 'None':
         shared.character = _character
 
-        for extension in  ["yml", "yaml", "json"]:
+        for extension in ["yml", "yaml", "json"]:
             filepath = Path(f'characters/{_character}.{extension}')
             if filepath.exists():
                 break
-        data = yaml.safe_load(open(filepath, 'r', encoding='utf-8').read())
+        file_contents = open(filepath, 'r', encoding='utf-8').read()
+        data = json.loads(file_contents) if extension == "json" else yaml.safe_load(file_contents)
 
         name2 = data['name'] if 'name' in data else data['char_name']
         for field in ['context', 'greeting', 'example_dialogue', 'char_persona', 'char_greeting', 'world_scenario']:


### PR DESCRIPTION
Fixes bug introduced @ https://github.com/oobabooga/text-generation-webui/pull/337

tldr: if a `json` file has a tab in it, it breaks. With this PR it no longer breaks as it uses the JSON parser for `json` files, and YAML parser for `yaml`/`yml` files. This should also preemptively fix any other format edgecases that might exist between the two.

I also improved the Example yaml character file format as a secondary commit. Hopefully you'll agree with me that it looks a lot cleaner this way, and a lot friendlier to use as a reference for new users.
Specifically it uses multiline-block syntax (that lil `|-`) to automatically remove the need for quotes and to make a single newline count as a newline (to avoid the spam of double newlines). Also use double quotes `"` in the `context` key to avoid the need for that awkward `''` double-singlequote escape syntax.