### PR TITLE
Add LLaMA-Precise preset

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -44,6 +44,7 @@ settings = {
     'chat_default_extensions': ["gallery"],
     'presets': {
         'default': 'NovelAI-Sphinx Moth',
+        '.*(alpaca|llama)': "LLaMA-Precise",
         '.*pygmalion': 'NovelAI-Storywriter',
         '.*RWKV': 'Naive',
     },

--- a/presets/LLaMA-Precise.txt
+++ b/presets/LLaMA-Precise.txt
@@ -1,0 +1,6 @@
+do_sample=True
+top_p=0.1
+top_k=40
+temperature=0.7
+repetition_penalty=1.18
+typical_p=1.0


### PR DESCRIPTION
[Comparing LLaMA and Alpaca PRESETS deterministically](https://www.reddit.com/r/LocalLLaMA/comments/12az7ah/comparing_llama_and_alpaca_presets/) shows that the LLaMA-Precise preset (as originally recommended in the [How to install LLaMA: 8-bit and 4-bit : LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/comments/11o6o3f/how_to_install_llama_8bit_and_4bit/) guide) is distinct and useful enough to warrant official inclusion in oobabooga/text-generation-webui. In fact, I recommend this to be the default for LLaMA/Alpaca models, since it outperformed all other presets in the aforementioned comparison.