### PR TITLE
Fix .pt/.safetensors not found (GPTQ_loader)

### DIFF
--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -74,7 +74,7 @@ def load_quantized(model_name):
         exit()
 
     # Now we are going to try to locate the quantized model file.
-    path_to_model = Path(f'models/{model_name}')
+    path_to_model = Path(f"{shared.args.model_dir}/{shared.model_name}")
     found_pts = list(path_to_model.glob("*.pt"))
     found_safetensors = list(path_to_model.glob("*.safetensors"))
     pt_path = None


### PR DESCRIPTION
When using GPTQ, if the models are located outside the default `models` folder and the `--model-dir` argument is used, for example:
```
python server.py --model-dir ../Models/LLaMA-HF-4bit-128g/ --model_type LLaMA --wbits 4 --groupsize 128
```
This message is displayed:
```
Could not find the quantized model in .pt or .safetensors format, exiting...
```
The files into folder are correctly listed but the model selected is not found/taken into account.
When using the default `models` folder, no problem occurs.