### PR TITLE
Fix impersonate

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -161,7 +161,8 @@ def impersonate_wrapper(text, max_new_tokens, do_sample, temperature, top_p, typ
     if 'pygmalion' in shared.model_name.lower():
         name1 = "You"
 
-    prompt = generate_chat_prompt(text, max_new_tokens, name1, name2, context, chat_prompt_size, impersonate=True, end_of_turn=end_of_turn)
+    kwargs = {'is_instruct': mode == 'instruct', 'end_of_turn': end_of_turn, 'impersonate': True}
+    prompt = generate_chat_prompt(text, max_new_tokens, name1, name2, context, chat_prompt_size, **kwargs)
 
     # Yield *Is typing...*
     yield shared.processing_message


### PR DESCRIPTION
Fixes the impersonate feature not working after commit https://github.com/oobabooga/text-generation-webui/commit/e722c240af56aa733c576f49e663ed7cafef5784 because of a missing argument when calling the `generate_chat_prompt` function:

```
File "~\text-generation-webui\modules\chat.py", line 164, in impersonate_wrapper
    prompt = generate_chat_prompt(text, max_new_tokens, name1, name2, context, chat_prompt_size, impersonate=True, end_of_turn=end_of_turn)
TypeError: generate_chat_prompt() missing 1 required positional argument: 'is_instruct'
```