### PR TITLE
Broaden GPTQ-for-LLaMA branch support

### DIFF
--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -16,7 +16,7 @@ from modelutils import find_layers
 from quant import make_quant
 
 
-def _load_quant(model, checkpoint, wbits, groupsize=-1, exclude_layers=['lm_head']):
+def _load_quant(model, checkpoint, wbits, groupsize=-1, faster_kernel=False, exclude_layers=['lm_head'], kernel_switch_threshold=128):
     config = AutoConfig.from_pretrained(model)
     def noop(*args, **kwargs):
         pass
@@ -126,7 +126,8 @@ def load_quantized(model_name):
     if shared.args.pre_layer:
         model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize, shared.args.pre_layer)
     else:
-        model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize)
+        threshold = False if model_type == 'gptj' else 128
+        model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize, kernel_switch_threshold=threshold)
 
         # accelerate offload (doesn't work properly)
         if shared.args.gpu_memory:

--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -1,7 +1,7 @@
+import inspect
 import re
 import sys
 from pathlib import Path
-import inspect
 
 import accelerate
 import torch


### PR DESCRIPTION
Conditionalized the keyword arguments passed to GPTQ-for-LLaMA's `quant.make_quant()` so we can support more branches simultaneously. Pretty simple, we just test which kwargs `quant.make_quant()` currently has available and don't try to send any invalid ones.

Tested (with varying launch.py arguments) on:
* Oobabooga's old CUDA fork: [9659310499cc7a0ea5498c1beb47bb228d65d178](https://github.com/oobabooga/GPTQ-for-LLaMa/tree/9659310499cc7a0ea5498c1beb47bb228d65d178)
* Current CUDA branch: [610fdae6588c2b17bcf2726cacaaf795cd45077e](https://github.com/qwopqwop200/GPTQ-for-LLaMa/tree/610fdae6588c2b17bcf2726cacaaf795cd45077e)
* Current triton branch: [6800a08c7a3d8d682499df5d6d96666253af8ed1](https://github.com/qwopqwop200/GPTQ-for-LLaMa/tree/6800a08c7a3d8d682499df5d6d96666253af8ed1)

I suspect it would also work with the older non-groupsize versions too, but I don't think I have any old quantizations lying around to test it.

Following up #785

Just to be clear, this still won't make a model quantized by an excessively different version of GPTQ-for-LLaMA load, so e.g. you still need the old CUDA GPTQ-for-LLaMA in your repositories directory to use the 2-week-oldish quantizations most users probably have at this point. Likewise, if you want to try the new triton branch, you'll need to grab some fresh requantizations.
This PR is just so you can use different GPTQ-for-LLaMA versions without having to _also_ fiddle with text-generation-webui code to get things cooperating.