### PR TITLE
Add CSS for lists

### DIFF
--- a/css/html_cai_style.css
+++ b/css/html_cai_style.css
@@ -64,6 +64,15 @@
     line-height: 1.428571429 !important;
 }
 
+.message-body li {
+    margin-top: 0.5em !important;
+    margin-bottom: 0.5em !important;
+}
+
+.message-body li > p {
+    display: inline !important;
+}
+
 .dark .message-body p em {
     color: rgb(138, 138, 138) !important;
 }

--- a/css/html_instruct_style.css
+++ b/css/html_instruct_style.css
@@ -34,6 +34,15 @@
     line-height: 1.428571429 !important;
 }
 
+.message-body li {
+    margin-top: 0.5em !important;
+    margin-bottom: 0.5em !important;
+}
+
+.message-body li > p {
+    display: inline !important;
+}
+
 .dark .message-body p em {
     color: rgb(138, 138, 138) !important;
 }


### PR DESCRIPTION
The added styles should improve how HTML lists look in chat and instruct mode, for comparison:
<details>
  <summary>Old chat CSS on PC</summary>
  
  ![1-chat](https://user-images.githubusercontent.com/31524206/230454316-c4940a2c-3bb4-4db4-bcd0-727a68af4f3a.png)
  
</details>
<details>
  <summary>New chat CSS on PC</summary>
  
  ![2-chat](https://user-images.githubusercontent.com/31524206/230454893-a56b8280-c6fb-406d-a8ae-4f1bbdf68557.png)

</details>
<br>
<details>
  <summary>Old instruct CSS on PC</summary>
  
  ![1-instruct](https://user-images.githubusercontent.com/31524206/230455038-465db73f-b727-4b55-8ab3-269dedb0b7ee.png)
  
</details>
<details>
  <summary>New instruct CSS on PC</summary>
  
  ![2-instruct](https://user-images.githubusercontent.com/31524206/230455133-9f56c25f-f003-4116-9226-d9b4c1267272.png)
  
</details>
<br>
<details>
  <summary>Old chat CSS on mobile</summary>
  
  ![1-chat-mobile](https://user-images.githubusercontent.com/31524206/230455450-6195d9d2-370d-44cb-be1a-c274e06d0c16.png)
  
</details>
<details>
  <summary>New chat CSS on mobile</summary>
  
  ![2-chat-mobile](https://user-images.githubusercontent.com/31524206/230455550-e2347d41-73ef-41f1-89c2-f72305208159.png)
  
</details>
<br>
<details>
  <summary>Old instruct CSS on mobile</summary>
  
  ![1-instruct-phone](https://user-images.githubusercontent.com/31524206/230455789-268ab636-0e81-481a-a60c-2db0b65893cf.png)
  
</details>
<details>
  <summary>New instruct CSS on mobile</summary>
  
  ![2-instruct-phone](https://user-images.githubusercontent.com/31524206/230455806-9e355d50-558a-4cd8-8cf0-3a15140600b2.png)
  
</details>



