### PR TITLE
Tweak COPY order in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .env
 Dockerfile
 /characters
-/extensions
 /loras
 /models
 /presets


### PR DESCRIPTION
The current ordering will cause the prequisite steps to be invalidated if any of the project files changes.

This patch first copies only the required files for the prerequisite builds, so they will only be rebuilt if those specific files change.