### PR TITLE
Use updated docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ As an alternative to the recommended WSL method, you can install the web UI nati
 
 ```
 cp .env.example .env
-docker-compose up --build
+docker compose up --build
 ```
 
 Make sure to edit `.env.example` and set the appropriate CUDA version for your GPU.


### PR DESCRIPTION
Using the `docker-compose` command is outdated and will give version 1 of docker compose. Instead it should be `docker compose` to get version 2.17+ as specified in the requirements.

This is also marked down wrongly in the Wiki.