### PR TITLE
Update the api-example-stream.py to use the correct fn_index value

### DIFF
--- a/api-example-stream.py
+++ b/api-example-stream.py
@@ -12,6 +12,11 @@ import string
 
 import websockets
 
+# Note, Gradio may pick a different fn value as the definition of the Gradio app changes.
+# You can always launch the web UI and inspect the websocket stream using your browser's dev tools
+# to determine what value Gradio expects here.
+GRADIO_FN = 8
+
 
 def random_hash():
     letters = string.ascii_lowercase + string.digits
@@ -47,14 +52,14 @@ async def run(context):
                 case "send_hash":
                     await websocket.send(json.dumps({
                         "session_hash": session,
-                        "fn_index": 12
+                        "fn_index": GRADIO_FN
                     }))
                 case "estimation":
                     pass
                 case "send_data":
                     await websocket.send(json.dumps({
                         "session_hash": session,
-                        "fn_index": 12,
+                        "fn_index": GRADIO_FN,
                         "data": [
                             payload
                         ]


### PR DESCRIPTION
Apparently, Gradio makes no guarantees about the fn_index values.

At some point in time, changes to the Gradio app definition have invalidated fn_index 12, and now the correct value is fn_index 8 (verified by running the webapp and using Firefox dev tools to inspect the websocket stream).

IMO the api-example-stream.py seems "wrong" on the surface, because it relies upon talking to the Gradio server, which seemingly has no guaranteed contract. I guess it expects that the Gradio webclient is the only client (which makes sense because the service and client are generated at the same time so they will always be in sync).

But I will admit, I have found this api-example-stream very useful, and I use it in my toy projects as a way to talk to llms programatically, even if it's a bit of a hack :D