### PR TITLE
Add support for reading options from configuration files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ venv/
 *.bak
 *.ipynb
 *.log
-
+webui.conf
 settings.json
 img_bot*
 img_me*

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ To save configuration options for `server.py` and ensure their persistence acros
 
 | Flag                                  | Description |
 |---------------------------------------|-------------|
+| `--config CONFIG_PATH`                | Path(s) to configuration files to source options from. |
 | `--no-config`                         | Ignore the default configuration file `webui.conf`. |
-| `--config`                            | Locations of configuration files to source options from. |
 
 Out of memory errors? [Check the low VRAM guide](https://github.com/oobabooga/text-generation-webui/wiki/Low-VRAM-guide).
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ Optionally, you can use the following command-line flags:
 | `--auto-launch`                       | Open the web UI in the default browser upon launch. |
 | `--gradio-auth-path GRADIO_AUTH_PATH` | Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3" |
 
+#### Configuration
+
+To save configuration options for `server.py` and ensure their persistence across different sessions, create a file named `webui.conf` within the project directory.
+
+| Flag                                  | Description |
+|---------------------------------------|-------------|
+| `--no-config`                         | Ignore the default configuration file `webui.conf`. |
+| `--config`                            | Locations of configuration files to source options from. |
+
 Out of memory errors? [Check the low VRAM guide](https://github.com/oobabooga/text-generation-webui/wiki/Low-VRAM-guide).
 
 ## Presets

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 
+# Function to read options from .conf files
 def get_args_from_file(filepath):
     args_list = []
     if os.path.exists(filepath):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -8,6 +8,7 @@ def get_args_from_file(filepath):
         with open(filepath, 'r') as f:
             for line in f:
                 line_args = line.split()
+                line_args = [arg.strip('\'\"') for arg in line_args]
                 args_list.extend(line_args)
     return args_list
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -11,7 +11,6 @@ soft_prompt_tensor = None
 soft_prompt = False
 is_RWKV = False
 is_llamacpp = False
-no_config = False
 
 # Chat variables
 history = {'internal': [], 'visible': []}
@@ -155,8 +154,8 @@ parser.add_argument('--auto-launch', action='store_true', default=False, help='O
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
 
 # Configuration
-parser.add_argument('--no-config', action='store_true', help='Ignore the default configuration file')
-parser.add_argument('--config', nargs='+', help='Locations of configuration files to source')
+parser.add_argument('--no-config', action='store_true', default=False, help='Ignore the default configuration file.')
+parser.add_argument('--config', nargs='+', help='Locations of configuration files to source.')
 
 args = parser.parse_args()
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -78,7 +78,7 @@ def str2bool(v):
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
 # Function to read options from .conf files
-def get_args_from_file(filepath):
+def get_args_from_file(filepath, verbose):
     args_list = []
     with open(filepath, 'r') as f:
         for line in f:
@@ -87,6 +87,10 @@ def get_args_from_file(filepath):
             line_args = line.split()
             line_args = [arg.strip('\'\"') for arg in line_args]
             args_list.extend(line_args)
+
+    if verbose:
+        print(f"Loaded arguments from {filepath}")
+
     return args_list
 
 
@@ -175,7 +179,7 @@ for config_file in config_files:
     if not os.path.exists(config_file):
         print(f"Error: Configuration file {config_file} does not exist.")
         sys.exit(1)
-    combined_args = combined_args + get_args_from_file(config_file)
+    combined_args = combined_args + get_args_from_file(config_file, args.verbose)
 
 # Add command line arguments to combined_args
 combined_args = combined_args + sys.argv[1:]

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -7,7 +7,8 @@ def get_args_from_file(filepath):
     if os.path.exists(filepath):
         with open(filepath, 'r') as f:
             for line in f:
-                args_list.extend(line.split())
+                line_args = line.split()
+                args_list.extend(line_args)
     return args_list
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -8,6 +8,8 @@ def get_args_from_file(filepath):
     if os.path.exists(filepath):
         with open(filepath, 'r') as f:
             for line in f:
+                if line.startswith('#'):
+                    continue
                 line_args = line.split()
                 line_args = [arg.strip('\'\"') for arg in line_args]
                 args_list.extend(line_args)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -11,6 +11,7 @@ soft_prompt_tensor = None
 soft_prompt = False
 is_RWKV = False
 is_llamacpp = False
+no_config = False
 
 # Chat variables
 history = {'internal': [], 'visible': []}

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -150,6 +150,10 @@ parser.add_argument('--share', action='store_true', help='Create a public URL. T
 parser.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
 
+# Configuration
+parser.add_argument('--no-config', action='store_true', help='Ignore the default configuration file')
+parser.add_argument('--config', nargs='+', help='Locations of configuration files to source')
+
 args = parser.parse_args()
 
 # Build config_files array

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -2,19 +2,6 @@ import argparse
 import os
 import sys
 
-# Function to read options from .conf files
-def get_args_from_file(filepath):
-    args_list = []
-    if os.path.exists(filepath):
-        with open(filepath, 'r') as f:
-            for line in f:
-                if line.startswith('#'):
-                    continue
-                line_args = line.split()
-                line_args = [arg.strip('\'\"') for arg in line_args]
-                args_list.extend(line_args)
-    return args_list
-
 # Default settings
 model = None
 tokenizer = None
@@ -78,6 +65,7 @@ settings = {
 }
 
 
+# Function to convert a string to a boolean value.
 def str2bool(v):
     if isinstance(v, bool):
         return v
@@ -87,6 +75,18 @@ def str2bool(v):
         return False
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
+
+# Function to read options from .conf files
+def get_args_from_file(filepath):
+    args_list = []
+    with open(filepath, 'r') as f:
+        for line in f:
+            if line.startswith('#'):
+                continue
+            line_args = line.split()
+            line_args = [arg.strip('\'\"') for arg in line_args]
+            args_list.extend(line_args)
+    return args_list
 
 
 parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=54))

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -1,4 +1,15 @@
 import argparse
+import os
+import sys
+
+def get_args_from_file(filepath):
+    args_list = []
+    if os.path.exists(filepath):
+        with open(filepath, 'r') as f:
+            for line in f:
+                args_list.extend(line.split())
+    return args_list
+
 
 model = None
 tokenizer = None
@@ -133,7 +144,12 @@ parser.add_argument('--share', action='store_true', help='Create a public URL. T
 parser.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
 
-args = parser.parse_args()
+webui_args = get_args_from_file('webui.conf')
+cli_args = sys.argv[1:]
+
+combined_args = webui_args + cli_args
+
+args = parser.parse_args(combined_args)
 
 # Deprecation warnings for parameters that have been renamed
 deprecated_dict = {'gptq_bits': ['wbits', 0], 'gptq_model_type': ['model_type', None], 'gptq_pre_layer': ['prelayer', 0]}

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -149,10 +149,32 @@ parser.add_argument('--share', action='store_true', help='Create a public URL. T
 parser.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
 
-# Get and parse arguments
-webui_args = get_args_from_file('webui.conf')
-cli_args = sys.argv[1:]
-combined_args = webui_args + cli_args
+args = parser.parse_args()
+
+# Build config_files array
+if not args.no_config and os.path.exists('webui.conf'):
+    # webui.conf exists & no_config = False
+    config_files = ['webui.conf']
+else:
+    # webui.conf is missing or no_config = True
+    config_files = []
+
+if args.config:
+    # Append any files provided with --config
+    config_files.extend(args.config)
+
+# Build combined_args from contents of config_files
+combined_args = []
+for config_file in config_files:
+    # Ensure config file exist
+    if not os.path.exists(config_file):
+        print(f"Error: Configuration file {config_file} does not exist.")
+        sys.exit(1)
+    combined_args = combined_args + get_args_from_file(config_file)
+
+# Add command line arguments to combined_args
+combined_args = combined_args + sys.argv[1:]
+
 args = parser.parse_args(combined_args)
 
 # Deprecation warnings for parameters that have been renamed

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -15,7 +15,7 @@ def get_args_from_file(filepath):
                 args_list.extend(line_args)
     return args_list
 
-
+# Default settings
 model = None
 tokenizer = None
 model_name = "None"
@@ -149,11 +149,10 @@ parser.add_argument('--share', action='store_true', help='Create a public URL. T
 parser.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
 
+# Get and parse arguments
 webui_args = get_args_from_file('webui.conf')
 cli_args = sys.argv[1:]
-
 combined_args = webui_args + cli_args
-
 args = parser.parse_args(combined_args)
 
 # Deprecation warnings for parameters that have been renamed


### PR DESCRIPTION
This commit introduces changes to the argument parsing logic in order to support reading and including command-line arguments from `webui.conf`. The updated code allows users to store frequently used arguments in `webui.conf`, which will be automatically combined with any arguments passed through the command line.

The changes made include:

1. Added a new function `get_args_from_file` that takes a file path as input and reads the file line by line. It then splits each line into arguments and returns a list of these arguments.

2. Modified the argument parsing logic to read arguments from both `webui.conf` and the command line. The arguments are combined and then passed to the `argparse.ArgumentParser` instance for parsing.

3. Updated the code to parse the combined arguments using the `parse_args` method.

This feature simplifies the process of passing common arguments and makes it more convenient for users to configure the application.