### PR TITLE
Fix ggml downloading in download-model.py

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -142,7 +142,7 @@ def get_download_links_from_huggingface(model, branch):
             is_tokenizer = re.match("tokenizer.*\.model", fname)
             is_text = re.match(".*\.(txt|json|py|md)", fname) or is_tokenizer
 
-            if any((is_pytorch, is_safetensors, is_pt, is_tokenizer, is_text)):
+            if any((is_pytorch, is_safetensors, is_pt, is_ggml, is_tokenizer, is_text)):
                 if 'lfs' in dict[i]:
                     sha256.append([fname, dict[i]['lfs']['oid']])
                 if is_text:


### PR DESCRIPTION
I was trying to download models from Hugging Face and noticed the script wouldn't download ggml models. Turned out to be a very simple fix.