### PR TITLE
Fix mobile client reusing input

### DIFF
--- a/server.py
+++ b/server.py
@@ -323,6 +323,7 @@ def create_interface():
             with gr.Tab("Text generation", elem_id="main"):
                 shared.gradio['display'] = gr.HTML(value=chat_html_wrapper(shared.history['visible'], shared.settings['name1'], shared.settings['name2'], 'cai-chat'))
                 shared.gradio['textbox'] = gr.Textbox(label='Input')
+                shared.gradio['Chat input'] = shared.gradio['textbox']
                 with gr.Row():
                     shared.gradio['Generate'] = gr.Button('Generate', elem_id='Generate')
                     shared.gradio['Stop'] = gr.Button('Stop', elem_id="stop")


### PR DESCRIPTION
This change reverts one of the changes made from 0dc6fa0 which causes mobile client to reuse input