### PR TITLE
download custom_model menu (from hugging face) added in model tab inside server.py

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -20,17 +20,6 @@ import tqdm
 from tqdm.contrib.concurrent import thread_map
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('MODEL', type=str, default=None, nargs='?')
-parser.add_argument('--branch', type=str, default='main', help='Name of the Git branch to download from.')
-parser.add_argument('--threads', type=int, default=1, help='Number of files to download simultaneously.')
-parser.add_argument('--text-only', action='store_true', help='Only download text files (txt/json).')
-parser.add_argument('--output', type=str, default=None, help='The folder where the model should be saved.')
-parser.add_argument('--clean', action='store_true', help='Does not resume the previous download.')
-parser.add_argument('--check', action='store_true', help='Validates the checksums of model files.')
-args = parser.parse_args()
-
-
 def select_model_from_default_options():
     models = {
         "OPT 6.7B": ("facebook", "opt-6.7b", "main"),
@@ -244,6 +233,17 @@ def check_model_files(model, branch, links, sha256, output_folder):
 
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('MODEL', type=str, default=None, nargs='?')
+    parser.add_argument('--branch', type=str, default='main', help='Name of the Git branch to download from.')
+    parser.add_argument('--threads', type=int, default=1, help='Number of files to download simultaneously.')
+    parser.add_argument('--text-only', action='store_true', help='Only download text files (txt/json).')
+    parser.add_argument('--output', type=str, default=None, help='The folder where the model should be saved.')
+    parser.add_argument('--clean', action='store_true', help='Does not resume the previous download.')
+    parser.add_argument('--check', action='store_true', help='Validates the checksums of model files.')
+    args = parser.parse_args()
+
     branch = args.branch
     model = args.MODEL
     if model is None:

--- a/server.py
+++ b/server.py
@@ -15,8 +15,6 @@ from datetime import datetime
 from pathlib import Path
 
 import gradio as gr
-import requests
-from huggingface_hub import HfApi
 from PIL import Image
 
 import modules.extensions as extensions_module

--- a/server.py
+++ b/server.py
@@ -195,9 +195,9 @@ def download_model_wrapper(repo_id):
                     is_lora = True
             repo_dir_name = repo_id.replace("/", "--")
             if is_lora is True:
-                models_dir = ".loras"
+                models_dir = "loras"
             else:
-                models_dir = ".models"
+                models_dir = "models"
             if not os.path.exists(models_dir):
                 os.makedirs(models_dir)
             repo_dir = os.path.join(models_dir, repo_dir_name)


### PR DESCRIPTION
Hi. 
People were downloading models repo from huggingface.co using git and manually downloading LFS and placing in the 'model' folder.So, I added option to download.

1. textbox and a download button
2. if lora model dected, place in loras folder
3. display error if textbox is empty or invalid input
4. display progress

I was not able to import download-model.py to reuse that code and hugging face download methods were limited, so wrote inside wrapper. Im new to gradio, will be improving your repo as I learn more.

![image](https://user-images.githubusercontent.com/56207634/230770885-c710208b-971c-41bb-9e2f-63a2a93d0bd2.png)
![image](https://user-images.githubusercontent.com/56207634/230770898-572b12c1-06e6-4cbe-8bd9-ead3bde4d6f3.png)
![image](https://user-images.githubusercontent.com/56207634/230771203-d4e670fb-00d2-42ac-856f-362f93dcac92.png)
