### PR TITLE
Add ability to load a character via args

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -414,7 +414,7 @@ def load_character(character, name1, name2, mode):
 
 
 def load_default_history(name1, name2):
-    load_character("None", name1, name2, "chat")
+    return load_character(shared.character or "None", name1, name2, "chat")
 
 
 def upload_character(json_file, img, tavern=False):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -79,6 +79,7 @@ parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpForma
 parser.add_argument('--notebook', action='store_true', help='Launch the web UI in notebook mode, where the output is written to the same text box as the input.')
 parser.add_argument('--chat', action='store_true', help='Launch the web UI in chat mode with a style similar to the Character.AI website.')
 parser.add_argument('--cai-chat', action='store_true', help='DEPRECATED: use --chat instead.')
+parser.add_argument('--character', type=str, help='Loads a character from the `characters` directory, requires --chat')
 parser.add_argument('--model', type=str, help='Name of the model to load by default.')
 parser.add_argument('--lora', type=str, help='Name of the LoRA to apply to the model by default.')
 parser.add_argument("--model-dir", type=str, default='models/', help="Path to directory with all the models")


### PR DESCRIPTION
* Add new `--character` argument to `server.py` to load a selected default character
* Also make character choice persistent, so on refresh the last chosen character will still be selected.

This PR is fulfilling the requested enhancement in #542, and adds the ability to load a character by including the filename of a character in the `characters` directory (with or without extension).

Example: `python server.py --chat --character test`
