### PR TITLE
Update character log logic

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -256,6 +256,9 @@ def clear_chat_log(name1, name2, greeting, mode):
     if greeting != '':
         shared.history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
         shared.history['visible'] += [['', apply_extensions(greeting, "output")]]
+    
+    # Save cleared logs
+    save_history(timestamp=False)
 
     return chat_html_wrapper(shared.history['visible'], name1, name2, mode)
 
@@ -406,9 +409,14 @@ def load_character(character, name1, name2, mode):
 
     if Path(f'logs/{shared.character}_persistent.json').exists():
         load_history(open(Path(f'logs/{shared.character}_persistent.json'), 'rb').read(), name1, name2)
-    elif greeting != "":
-        shared.history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
-        shared.history['visible'] += [['', apply_extensions(greeting, "output")]]
+    else:
+        # Insert greeting if it exists
+        if greeting != "":
+            shared.history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
+            shared.history['visible'] += [['', apply_extensions(greeting, "output")]]
+        
+        # Create .json log files since they don't already exist
+        save_history(timestamp=False)
 
     return name1, name2, picture, greeting, context, end_of_turn, chat_html_wrapper(shared.history['visible'], name1, name2, mode, reset_cache=True)
 


### PR DESCRIPTION
Currently, if you press the clear chat history button then refresh the page, the old logs will still be there. This PR solves that bug by saving the cleared log after the confirm button is pressed.

Additionally, this saves a character's initial log on first character load, instead of waiting for chat to happen.

* When logs are cleared, save the cleared log over the old log files
* Generate a log file when a character is loaded the first time