### PR TITLE
fix random seeds to actually randomize

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -1,3 +1,4 @@
+import random
 import re
 import time
 import traceback
@@ -97,10 +98,11 @@ def formatted_outputs(reply, model_name):
 
 
 def set_manual_seed(seed):
-    if seed != -1:
-        torch.manual_seed(seed)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(seed)
+    if seed == -1:
+        seed = random.randint(1, 2**31)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
 
 
 def stop_everything_event():

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -98,11 +98,13 @@ def formatted_outputs(reply, model_name):
 
 
 def set_manual_seed(seed):
+    seed = int(seed)
     if seed == -1:
         seed = random.randint(1, 2**31)
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
+    return seed
 
 
 def stop_everything_event():
@@ -111,7 +113,7 @@ def stop_everything_event():
 
 def generate_reply(question, generate_state, eos_token=None, stopping_strings=[]):
     clear_torch_cache()
-    set_manual_seed(generate_state['seed'])
+    seed = set_manual_seed(generate_state['seed'])
     shared.stop_everything = False
     generate_params = {}
     t0 = time.time()
@@ -153,7 +155,7 @@ def generate_reply(question, generate_state, eos_token=None, stopping_strings=[]
             t1 = time.time()
             original_tokens = len(encode(original_question)[0])
             new_tokens = len(encode(output)[0]) - original_tokens
-            print(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens})')
+            print(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens}, seed {seed})')
             return
 
     input_ids = encode(question, generate_state['max_new_tokens'])
@@ -274,5 +276,5 @@ def generate_reply(question, generate_state, eos_token=None, stopping_strings=[]
         t1 = time.time()
         original_tokens = len(original_input_ids[0])
         new_tokens = len(output) - original_tokens
-        print(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens})')
+        print(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens}, seed {seed})')
         return


### PR DESCRIPTION
Without this fix, manual seeds get locked in.

Background: a user on Discord commented that `-1` doesn't seem to randomize, but typing different manual seeds did, I looked into it and - yeah if `seed` is `-1` it just does nothing, meaning any seed ever set in theory just gets locked in place after the first time one is set.

This code change adapts so that when `seed` is `-1`, a random seed is generated within the valid range, and manually fed in - thus every call to generate gets a seed freshly applied.

In testing, this works exactly as intended, results with seed `-1` are randomized properly now when regenerating.
