### PR TITLE
Issue 1001: max_new_tokens maxed ignores previous conversation

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -29,7 +29,7 @@ def generate_chat_prompt(user_input, max_new_tokens, name1, name2, context, chat
     # Finding the maximum prompt size
     if shared.soft_prompt:
         chat_prompt_size -= shared.soft_prompt_tensor.shape[1]
-    max_length = min(get_max_prompt_length(max_new_tokens), chat_prompt_size)
+    max_length = min(get_max_prompt_length(0), chat_prompt_size)
 
     if is_instruct:
         prefix1 = f"{name1}\n"


### PR DESCRIPTION
Fix Issue 1001 https://github.com/oobabooga/text-generation-webui/issues/1001

The issue seems related to [this line](https://github.com/oobabooga/text-generation-webui/blob/1dc464dcb0bad8a7221bd18198c8ff50bcb00b41/modules/chat.py#:~:text=max_length%20%3D%20min(get_max_prompt_length(max_new_tokens)%2C%20chat_prompt_size))
   max_length = min(get_max_prompt_length(max_new_tokens), chat_prompt_size)

which figures out the max_length of the context to send. Calling [get_max_prompt_length](https://github.com/oobabooga/text-generation-webui/blob/1dc464dcb0bad8a7221bd18198c8ff50bcb00b41/modules/text_generation.py#L18:~:text=def-,get_max_prompt_length(,-tokens)%3A) with max_new_tokens seems wrong, as it will effectively cut down the length to almost 0 when max_new_tokens is 2000 (2048-2000). That is the opposite it was supposed to do. The method is reused, so the issue is calculating it that way in this specific call -not in the method called.

Future improvements should remove the 2048 hardcoded number inside get_max_prompt_length and put the max prompt instead. But that is outside the scope of this issue and fix.

Tested verifying that the max_new_tokens is still respected, and it also keeps context when maxed. 