### PR TITLE
Fix text overflow in chat and instruct mode

### DIFF
--- a/css/html_cai_style.css
+++ b/css/html_cai_style.css
@@ -77,6 +77,9 @@
 .message-body code {
     overflow-x: auto;
 }
+.message-body code:not([class^='language-']) {
+    white-space: normal !important;
+}
 
 .dark .message-body p em {
     color: rgb(138, 138, 138) !important;

--- a/css/html_cai_style.css
+++ b/css/html_cai_style.css
@@ -7,6 +7,7 @@
     padding-right: 20px;
     display: flex;
     flex-direction: column-reverse;
+    word-break: break-word;
 }
 
 .message {

--- a/css/html_cai_style.css
+++ b/css/html_cai_style.css
@@ -78,7 +78,7 @@
 .message-body code {
     overflow-x: auto;
 }
-.message-body code:not([class^='language-']) {
+.message-body :not(pre) > code {
     white-space: normal !important;
 }
 

--- a/css/html_cai_style.css
+++ b/css/html_cai_style.css
@@ -11,7 +11,7 @@
 
 .message {
     display: grid;
-    grid-template-columns: 60px 1fr;
+    grid-template-columns: 60px minmax(0, 1fr);
     padding-bottom: 25px;
     font-size: 15px;
     font-family: Helvetica, Arial, sans-serif;
@@ -71,6 +71,10 @@
 
 .message-body li > p {
     display: inline !important;
+}
+
+.message-body code {
+    overflow-x: auto;
 }
 
 .dark .message-body p em {

--- a/css/html_cai_style.css
+++ b/css/html_cai_style.css
@@ -8,6 +8,7 @@
     display: flex;
     flex-direction: column-reverse;
     word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .message {

--- a/css/html_instruct_style.css
+++ b/css/html_instruct_style.css
@@ -39,6 +39,10 @@
     display: inline !important;
 }
 
+.message-body code {
+    overflow-x: auto;
+}
+
 .dark .message-body p em {
     color: rgb(138, 138, 138) !important;
 }

--- a/css/html_instruct_style.css
+++ b/css/html_instruct_style.css
@@ -41,6 +41,9 @@
 .message-body code {
     overflow-x: auto;
 }
+.message-body code:not([class^='language-']) {
+    white-space: normal !important;
+}
 
 .dark .message-body p em {
     color: rgb(138, 138, 138) !important;

--- a/css/html_instruct_style.css
+++ b/css/html_instruct_style.css
@@ -7,6 +7,7 @@
     padding-right: 20px;
     display: flex;
     flex-direction: column-reverse;
+    word-break: break-word;
 }
 
 .message {

--- a/css/html_instruct_style.css
+++ b/css/html_instruct_style.css
@@ -42,7 +42,7 @@
 .message-body code {
     overflow-x: auto;
 }
-.message-body code:not([class^='language-']) {
+.message-body :not(pre) > code {
     white-space: normal !important;
 }
 

--- a/css/html_instruct_style.css
+++ b/css/html_instruct_style.css
@@ -8,6 +8,7 @@
     display: flex;
     flex-direction: column-reverse;
     word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .message {


### PR DESCRIPTION
The modified CSS should fix the text overflow occurring in normal messages and code snippets

- In the case of messages, the text will go to a new line
- In the case of code snippets, the scroll bar will appear directly inside the code blocks instead of the whole chat

<br>

For comparison:

<details>
  <summary>Chat overflow fix</summary>
 
  ### Before
  ![text-chat-1](https://user-images.githubusercontent.com/31524206/231198164-e1355579-45c8-4048-93f1-a19f072d66d2.png)

  ![text-inst-1](https://user-images.githubusercontent.com/31524206/231199016-c9c65bca-118e-49df-8acd-cd025659aa20.png)

  ---
  ### After
  ![text-chat-2](https://user-images.githubusercontent.com/31524206/231198172-35898100-b4d6-4ec9-9135-723fce9053d8.png)

  ![text-inst-2](https://user-images.githubusercontent.com/31524206/231199290-4b813a56-cbf4-4565-b45e-fc0ff32fdb5f.png)

  
</details>


<details>
  <summary>Code snippet overflow fix</summary>
 
  ### Before
  ![code-chat-1](https://user-images.githubusercontent.com/31524206/231199469-eee33dc3-2684-490c-a510-0d4598bb0c54.gif)
  
  ![code-inst-1](https://user-images.githubusercontent.com/31524206/231199657-2151a4d3-f9f2-46f8-9f30-9cb9ffb713ae.gif)

  ---
  ### After
  ![code-chat-2](https://user-images.githubusercontent.com/31524206/231199481-53b46d7c-c09b-4e53-8dc8-4f21ac67346d.gif)

  ![code-inst-2](https://user-images.githubusercontent.com/31524206/231199724-2ce81c8f-afa7-4adf-9fc4-de396378f577.gif)
  
</details>
