### PR TITLE
API: add endpoint for counting tokens

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -79,7 +79,7 @@ class Handler(BaseHTTPRequestHandler):
                 }]
             })
             self.wfile.write(response.encode('utf-8'))
-        elif self.path == '/api/v1/tokens':
+        elif self.path == '/api/v1/token-count':
             # Not compatible with KoboldAI api
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -79,6 +79,19 @@ class Handler(BaseHTTPRequestHandler):
                 }]
             })
             self.wfile.write(response.encode('utf-8'))
+        elif self.path == '/api/v1/tokens':
+            # Not compatible with KoboldAI api
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+
+            tokens = encode(body['prompt'])[0]
+            response = json.dumps({
+                'results': [{
+                    'tokens': len(tokens)
+                }]
+            })
+            self.wfile.write(response.encode('utf-8'))
         else:
             self.send_error(404)
 


### PR DESCRIPTION
Adds the ability for counting tokens of the given prompt via the API. This feature could help projects in the future integrate the use of this API like Auto-GPT.
The endpoint is unfortunately not compatible with KoboldAI API, so if that's an issue any suggestions are welcome.