### PR TITLE
Add truncation_length and ban_eos_token parameters to API extension

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -59,6 +59,8 @@ class Handler(BaseHTTPRequestHandler):
                 'seed': int(body.get('seed', -1)),
                 'add_bos_token': int(body.get('add_bos_token', True)),
                 'custom_stopping_strings': body.get('custom_stopping_strings', []),
+                'truncation_length': int(body.get('truncation_length', 2048)),
+                'ban_eos_token': bool(body.get('ban_eos_token', False)),
             }
 
             generator = generate_reply(


### PR DESCRIPTION
When trying to use the API extension with GPT-4chan (and possibly some other models), you'd normally get an error like this:

```
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 57384)
Traceback (most recent call last):
  File "C:\Users\Alexander\oobabooga\installer_files\env\lib\socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "C:\Users\Alexander\oobabooga\installer_files\env\lib\socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "C:\Users\Alexander\oobabooga\installer_files\env\lib\socketserver.py", line 747, in __init__
    self.handle()
  File "C:\Users\Alexander\oobabooga\installer_files\env\lib\http\server.py", line 433, in handle
    self.handle_one_request()
  File "C:\Users\Alexander\oobabooga\installer_files\env\lib\http\server.py", line 421, in handle_one_request
    method()
  File "C:\Users\Alexander\oobabooga\text-generation-webui\extensions\api\script.py", line 70, in do_POST
    for a in generator:
  File "C:\Users\Alexander\oobabooga\text-generation-webui\modules\text_generation.py", line 175, in generate_reply
    input_ids = encode(question, add_bos_token=state['add_bos_token'], truncation_length=get_max_prompt_length(state))
  File "C:\Users\Alexander\oobabooga\text-generation-webui\modules\text_generation.py", line 19, in get_max_prompt_length
    max_length = state['truncation_length'] - state['max_new_tokens']
KeyError: 'truncation_length'
----------------------------------------
```

I've found that this is caused by the API extension not sending the `truncation_length` and `ban_eos_token` parameters to the text generation module. This PR fixes that.

Repro steps:
- Start a server with the `--model gpt4chan_model_float16` and `--extensions api` flags.
- Send a request to the server. For example, using Python:
  ```python
  import requests
  import json

  url = 'http://127.0.0.1:5000/api/v1/generate'
  headers = {'Content-Type': 'application/json'}
  data = {'prompt': 'Hello, how are', 'max_length': 16, 'temperature': 0.7}

  response = requests.post(url, headers=headers, data=json.dumps(data))
  print(response.text)
  ```
- Without the patch, you should see no output from the script and the above error in the server's console. With the patch, you should see the generated text and no error.

I've also tested with LLaMA-7B to make sure this change doesn't break anything.