### PR TITLE
Update graduo to 3.25 for #819

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 accelerate==0.18.0
 datasets
 flexgen==0.1.7
-gradio==3.24.1
+gradio==3.25
 markdown
 numpy
 Pillow>=9.5.0


### PR DESCRIPTION
gradio update 3.25:

> Fix bug where http token was not accessed over websocket connections by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3735](https://github.com/gradio-app/gradio/pull/3735)

this fixes https://github.com/oobabooga/text-generation-webui/issues/819