### PR TITLE
add n_batch support for llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Optionally, you can use the following command-line flags:
 | Flag        | Description |
 |-------------|-------------|
 | `--threads` | Number of threads to use in llama.cpp. |
+| `--nbatch` | Processing batch size for llama.cpp. |
 
 #### GPTQ
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Optionally, you can use the following command-line flags:
 | Flag        | Description |
 |-------------|-------------|
 | `--threads` | Number of threads to use in llama.cpp. |
-| `--nbatch` | Processing batch size for llama.cpp. |
+| `--n_batch` | Processing batch size for llama.cpp. |
 
 #### GPTQ
 

--- a/modules/llamacpp_model_alternative.py
+++ b/modules/llamacpp_model_alternative.py
@@ -25,7 +25,7 @@ class LlamaCppModel:
             'n_ctx': 2048,
             'seed': 0,
             'n_threads': shared.args.threads or None,
-            'n_batch': shared.args.nbatch
+            'n_batch': shared.args.n_batch
         }
         self.model = Llama(**params)
 

--- a/modules/llamacpp_model_alternative.py
+++ b/modules/llamacpp_model_alternative.py
@@ -24,7 +24,8 @@ class LlamaCppModel:
             'model_path': str(path),
             'n_ctx': 2048,
             'seed': 0,
-            'n_threads': shared.args.threads or None
+            'n_threads': shared.args.threads or None,
+            'n_batch': shared.args.nbatch
         }
         self.model = Llama(**params)
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -111,6 +111,7 @@ parser.add_argument('--sdp-attention', action='store_true', help="Use torch 2.0'
 
 # llama.cpp
 parser.add_argument('--threads', type=int, default=0, help='Number of threads to use in llama.cpp.')
+parser.add_argument('--nbatch', type=int, default=8, help='Processing batch size for llama.cpp.')
 
 # GPTQ
 parser.add_argument('--wbits', type=int, default=0, help='GPTQ: Load a pre-quantized model with specified precision in bits. 2, 3, 4 and 8 are supported.')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -111,7 +111,7 @@ parser.add_argument('--sdp-attention', action='store_true', help="Use torch 2.0'
 
 # llama.cpp
 parser.add_argument('--threads', type=int, default=0, help='Number of threads to use in llama.cpp.')
-parser.add_argument('--nbatch', type=int, default=8, help='Processing batch size for llama.cpp.')
+parser.add_argument('--n_batch', type=int, default=8, help='Processing batch size for llama.cpp.')
 
 # GPTQ
 parser.add_argument('--wbits', type=int, default=0, help='GPTQ: Load a pre-quantized model with specified precision in bits. 2, 3, 4 and 8 are supported.')


### PR DESCRIPTION
This PR adds support for the *n_batch* option in llama.cpp. Increasing this number from the default 8 can be beneficial when ingesting large prompts and it must be >32 if you want to use OpenBLAS.