### PR TITLE
Add model-specific parameters

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -8,10 +8,10 @@ llama-[0-9]*b-4bit$:
   wbits: 4
   groupsize: -1
   model_type: 'llama'
-.*-4bit-(gr128|128g):
+.*-(4bit|int4)-(gr128|128g):
   wbits: 4
   groupsize: 128
-.*-(gr128|128g)-4bit:
+.*-(gr128|128g)-(4bit|int4):
   wbits: 4
   groupsize: 128
 .*-3bit-(gr128|128g):

--- a/models/config.yaml
+++ b/models/config.yaml
@@ -4,16 +4,22 @@
   groupsize: 'None'
   pre_layer: 0
   mode: 'cai-chat'
-.*-4bit-128g:
-  wbits: 4
-  groupsize: 128
-.*-128g-4bit:
-  wbits: 4
-  groupsize: 128
 llama-[0-9]*b-4bit$:
   wbits: 4
   groupsize: -1
   model_type: 'llama'
+.*-4bit-(gr128|128g):
+  wbits: 4
+  groupsize: 128
+.*-(gr128|128g)-4bit:
+  wbits: 4
+  groupsize: 128
+.*-3bit-(gr128|128g):
+  wbits: 4
+  groupsize: 128
+.*-(gr128|128g)-3bit:
+  wbits: 4
+  groupsize: 128
 .*oasst-sft-1-pythia-12b:
   mode: 'instruct'
   instruction_template: 'Open Assistant'

--- a/models/config.yaml
+++ b/models/config.yaml
@@ -15,10 +15,10 @@ llama-[0-9]*b-4bit$:
   wbits: 4
   groupsize: 128
 .*-3bit-(gr128|128g):
-  wbits: 4
+  wbits: 3
   groupsize: 128
 .*-(gr128|128g)-3bit:
-  wbits: 4
+  wbits: 3
   groupsize: 128
 .*oasst-sft-1-pythia-12b:
   mode: 'instruct'

--- a/models/config.yaml
+++ b/models/config.yaml
@@ -1,0 +1,19 @@
+.*-4bit-128g:
+  wbits: 4
+  groupsize: 128
+.*-128g-4bit:
+  wbits: 4
+  groupsize: 128
+llama-[0-9]*b-4bit$:
+  wbits: 4
+  groupsize: -1
+  model_type: 'llama'
+.*oasst-sft-1-pythia-12b:
+  mode: 'instruct'
+  instruction_template: 'Open Assistant'
+.*vicuna:
+  mode: 'instruct'
+  instruction_template: 'Vicuna'
+.*alpaca:
+  mode: 'instruct'
+  instruction_template: 'Alpaca'

--- a/models/config.yaml
+++ b/models/config.yaml
@@ -1,3 +1,9 @@
+.*:
+  wbits: 'None'
+  model_type: 'None'
+  groupsize: 'None'
+  pre_layer: 0
+  mode: 'cai-chat'
 .*-4bit-128g:
   wbits: 4
   groupsize: 128

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -79,7 +79,7 @@ def get_stopping_strings(state):
         stopping_strings = [f"\n{state['name1']}", f"\n{state['name2']}"]
     else:
         stopping_strings = [f"\n{state['name1']}:", f"\n{state['name2']}:"]
-    stopping_strings += state['custom_stopping_strings']
+    stopping_strings += eval(f"[{state['custom_stopping_strings']}]")
     return stopping_strings
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -45,6 +45,7 @@ settings = {
     'truncation_length_min': 0,
     'truncation_length_max': 4096,
     'mode': 'cai-chat',
+    'instruction_template': 'None',
     'chat_prompt_size': 2048,
     'chat_prompt_size_min': 0,
     'chat_prompt_size_max': 2048,

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -1,4 +1,7 @@
 import argparse
+from pathlib import Path
+
+import yaml
 
 model = None
 tokenizer = None
@@ -158,3 +161,21 @@ if args.cai_chat:
 
 def is_chat():
     return args.chat
+
+
+# Loading model-specific settings (default)
+with Path(f'{args.model_dir}/config.yaml') as p:
+    if p.exists():
+        model_config = yaml.safe_load(open(p, 'r').read())
+    else:
+        model_config = {}
+
+# Applying user-defined model settings
+with Path(f'{args.model_dir}/config-user.yaml') as p:
+    if p.exists():
+        user_config = yaml.safe_load(open(p, 'r').read())
+        for k in user_config:
+            if k in model_config:
+                model_config[k].update(user_config[k])
+            else:
+                model_config[k] = user_config[k]

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -192,7 +192,7 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
 
     # Handling the stopping strings
     stopping_criteria_list = transformers.StoppingCriteriaList()
-    for st in [stopping_strings, state['custom_stopping_strings']]:
+    for st in [stopping_strings, eval(f"[{state['custom_stopping_strings']}]")]:
         if type(st) is list and len(st) > 0:
             sentinel_token_ids = [encode(string, add_special_tokens=False) for string in st]
             stopping_criteria_list.append(_SentinelTokenStoppingCriteria(sentinel_token_ids=sentinel_token_ids, starting_idx=len(input_ids[0])))

--- a/server.py
+++ b/server.py
@@ -43,19 +43,11 @@ if settings_file is not None:
         shared.settings[item] = new_settings[item]
 
 
-def special_sort(model_name):
-    return model_name.lower()
-    if '_' in model_name:
-        return ('_'.join(model_name.split('_')[1:])).lower()
-    else:
-        return model_name.lower()
-
-
 def get_available_models():
     if shared.args.flexgen:
-        return sorted([re.sub('-np$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if item.name.endswith('-np')], key=special_sort)
+        return sorted([re.sub('-np$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if item.name.endswith('-np')], key=str.lower)
     else:
-        return sorted([re.sub('.pth$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json'))], key=special_sort)
+        return sorted([re.sub('.pth$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json'))], key=str.lower)
 
 
 def get_available_presets():
@@ -337,11 +329,8 @@ def create_model_menus():
         with gr.Column():
             shared.gradio['model_status'] = gr.Markdown('No model is loaded' if shared.model_name == 'None' else 'Ready')
 
-    # This event handler has 6 steps:
-    # 1. Get the current values in the interface into the 'interface_state' dict
-    # 2. Update the 'interface_state' dict with model defaults (if any)
-    # 3. Update the interface values based on the updated 'interface_state' dict
-    # 4. ...
+    # In this event handler, the interface state is read and updated
+    # with the model defaults (if any), and then the model is loaded
     shared.gradio['model_menu'].change(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
         load_model_specific_settings, [shared.gradio[k] for k in ['model_menu', 'interface_state']], shared.gradio['interface_state']).then(
@@ -623,7 +612,7 @@ def create_interface():
             with gr.Tab("Parameters", elem_id="parameters"):
                 create_settings_menus(default_preset)
 
-        # Create normal (?) mode interface
+        # Create default mode interface
         else:
             shared.input_elements = ui.list_interface_input_elements(chat=False)
             shared.gradio['interface_state'] = gr.State({k: None for k in shared.input_elements})

--- a/server.py
+++ b/server.py
@@ -236,19 +236,12 @@ def update_model_parameters(state):
 def load_model_specific_settings(model, state):
     settings = shared.model_config
     model = model.lower()
-    mode_has_been_set = False
 
     for pat in settings:
         if re.match(pat, model.lower()):
             for k in settings[pat]:
                 if k in state:
                     state[k] = settings[pat][k]
-                    if k == 'mode':
-                        mode_has_been_set = True
-
-    # We want the default chat mode to be cai-chat
-    if 'mode' in state and not mode_has_been_set:
-        state['mode'] = 'cai-chat'
 
     return state
 

--- a/server.py
+++ b/server.py
@@ -195,7 +195,7 @@ def download_model_wrapper(repo_id):
         yield traceback.format_exc()
 
 
-# Model parameters: update the command-line arguments based on the interface values
+# Update the command-line arguments based on the interface values
 def update_model_parameters(state):
     elements = ui.list_model_elements()  # the names of the parameters
 
@@ -501,15 +501,18 @@ def create_interface():
                 with gr.Row():
                     shared.gradio['Generate'] = gr.Button('Generate', elem_id='Generate')
                     shared.gradio['Stop'] = gr.Button('Stop', elem_id='stop')
+
                 with gr.Row():
                     shared.gradio['Regenerate'] = gr.Button('Regenerate')
                     shared.gradio['Continue'] = gr.Button('Continue')
                     shared.gradio['Impersonate'] = gr.Button('Impersonate')
+
                 with gr.Row():
                     shared.gradio['Send dummy message'] = gr.Button('Send dummy message')
                     shared.gradio['Send dummy reply'] = gr.Button('Send dummy reply')
                     shared.gradio['Replace last reply'] = gr.Button('Replace last reply')
                     shared.gradio['Copy last reply'] = gr.Button('Copy last reply')
+
                 with gr.Row():
                     shared.gradio['Clear history'] = gr.Button('Clear history')
                     shared.gradio['Clear history-confirm'] = gr.Button('Confirm', variant='stop', visible=False)
@@ -527,9 +530,11 @@ def create_interface():
                         shared.gradio['greeting'] = gr.Textbox(value=shared.settings['greeting'], lines=4, label='Greeting')
                         shared.gradio['context'] = gr.Textbox(value=shared.settings['context'], lines=4, label='Context')
                         shared.gradio['end_of_turn'] = gr.Textbox(value=shared.settings['end_of_turn'], lines=1, label='End of turn string')
+
                     with gr.Column(scale=1):
                         shared.gradio['character_picture'] = gr.Image(label='Character picture', type='pil')
                         shared.gradio['your_picture'] = gr.Image(label='Your picture', type='pil', value=Image.open(Path('cache/pfp_me.png')) if Path('cache/pfp_me.png').exists() else None)
+
                 with gr.Row():
                     shared.gradio['character_menu'] = gr.Dropdown(choices=available_characters, value='None', label='Character', elem_id='character-menu')
                     ui.create_refresh_button(shared.gradio['character_menu'], lambda: None, lambda: {'choices': get_available_characters()}, 'refresh-button')
@@ -540,21 +545,24 @@ def create_interface():
                             with gr.Column():
                                 gr.Markdown('Upload')
                                 shared.gradio['upload_chat_history'] = gr.File(type='binary', file_types=['.json', '.txt'])
+
                             with gr.Column():
                                 gr.Markdown('Download')
                                 shared.gradio['download'] = gr.File()
                                 shared.gradio['download_button'] = gr.Button(value='Click me')
+
                     with gr.Tab('Upload character'):
                         gr.Markdown('# JSON format')
                         with gr.Row():
                             with gr.Column():
                                 gr.Markdown('1. Select the JSON file')
                                 shared.gradio['upload_json'] = gr.File(type='binary', file_types=['.json'])
+
                             with gr.Column():
                                 gr.Markdown('2. Select your character\'s profile picture (optional)')
                                 shared.gradio['upload_img_bot'] = gr.File(type='binary', file_types=['image'])
-                        shared.gradio['Upload character'] = gr.Button(value='Submit')
 
+                        shared.gradio['Upload character'] = gr.Button(value='Submit')
                         gr.Markdown('# TavernAI PNG format')
                         shared.gradio['upload_img_tavern'] = gr.File(type='binary', file_types=['image'])
 
@@ -565,6 +573,7 @@ def create_interface():
                         with gr.Column():
                             shared.gradio['max_new_tokens'] = gr.Slider(minimum=shared.settings['max_new_tokens_min'], maximum=shared.settings['max_new_tokens_max'], step=1, label='max_new_tokens', value=shared.settings['max_new_tokens'])
                             shared.gradio['chat_prompt_size'] = gr.Slider(minimum=shared.settings['chat_prompt_size_min'], maximum=shared.settings['chat_prompt_size_max'], step=1, label='Maximum prompt size in tokens', value=shared.settings['chat_prompt_size'])
+
                         with gr.Column():
                             shared.gradio['chat_generation_attempts'] = gr.Slider(minimum=shared.settings['chat_generation_attempts_min'], maximum=shared.settings['chat_generation_attempts_max'], value=shared.settings['chat_generation_attempts'], step=1, label='Generation attempts (for longer replies)')
                             shared.gradio['stop_at_newline'] = gr.Checkbox(value=shared.settings['stop_at_newline'], label='Stop generating at new line character')
@@ -580,8 +589,10 @@ def create_interface():
                     with gr.Column(scale=4):
                         with gr.Tab('Raw'):
                             shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_id="textbox", lines=27)
+
                         with gr.Tab('Markdown'):
                             shared.gradio['markdown'] = gr.Markdown()
+
                         with gr.Tab('HTML'):
                             shared.gradio['html'] = gr.HTML()
 
@@ -590,6 +601,7 @@ def create_interface():
                                 with gr.Row():
                                     shared.gradio['Generate'] = gr.Button('Generate')
                                     shared.gradio['Stop'] = gr.Button('Stop')
+
                             with gr.Column():
                                 pass
 
@@ -599,6 +611,7 @@ def create_interface():
                         with gr.Row():
                             shared.gradio['prompt_menu'] = gr.Dropdown(choices=get_available_prompts(), value='None', label='Prompt')
                             ui.create_refresh_button(shared.gradio['prompt_menu'], lambda: None, lambda: {'choices': get_available_prompts()}, 'refresh-button')
+
                         shared.gradio['save_prompt'] = gr.Button('Save prompt')
                         shared.gradio['status'] = gr.Markdown('')
 

--- a/server.py
+++ b/server.py
@@ -84,7 +84,7 @@ def get_available_softprompts():
 
 
 def get_available_loras():
-    return ['None'] + sorted([item.name for item in list(Path(shared.args.lora_dir).glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json'))], key=special_sort)
+    return ['None'] + sorted([item.name for item in list(Path(shared.args.lora_dir).glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json'))], key=str.lower)
 
 
 def load_model_wrapper(selected_model):

--- a/settings-template.json
+++ b/settings-template.json
@@ -16,6 +16,7 @@
     "truncation_length_min": 0,
     "truncation_length_max": 4096,
     "mode": "cai-chat",
+    "instruction_template": "None",
     "chat_prompt_size": 2048,
     "chat_prompt_size_min": 0,
     "chat_prompt_size_max": 2048,


### PR DESCRIPTION
These are defined through regex patterns in `models/config.yaml`.

interface parameters like `wbits`, `groupsize`, `Mode` (instruct/cai-chat) are automatically determined and set based on the model name.

Currently only works for models selected from the dropdown menu in the UI.

- [x] Make this also work for models selected through `--model` or `--model-menu`
- [ ] ~~Add a button called "Save current settings" to the Models tab that saves user settings to `model/config-user.yaml`, for user-specific stuff like always loading some model in 8-bit mode~~ I'll do this later