### PR TITLE
Improve CSS in default and notebook mode

### DIFF
--- a/css/html_readable_style.css
+++ b/css/html_readable_style.css
@@ -18,3 +18,11 @@
 .container li > p {
     display: inline !important;
 }
+
+.container code {
+    overflow-x: auto;
+}
+
+.container :not(pre) > code {
+    white-space: normal !important;
+}

--- a/css/html_readable_style.css
+++ b/css/html_readable_style.css
@@ -12,3 +12,7 @@
     margin-bottom: 22px;
     line-height: 1.4 !important;
 }
+
+.container li > p {
+    display: inline !important;
+}

--- a/css/html_readable_style.css
+++ b/css/html_readable_style.css
@@ -4,6 +4,8 @@
     margin-right: auto;
     background-color: rgb(31, 41, 55);
     padding:3em;
+    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .container p {


### PR DESCRIPTION
These changes should improve the styling in the HTML display container in default and notebook interface mode

<details>
  <summary>Comparison</summary>
 
  ### Before
  
  ![nb-1](https://user-images.githubusercontent.com/31524206/232177364-d5b26523-c4ab-480d-a3cf-57293d4eef02.png)

  ---
  ### After
  
  ![nb-2](https://user-images.githubusercontent.com/31524206/232177368-8ec21f6a-c96c-477d-a2fe-31f4709a93b0.png)

</details>