### PR TITLE
Suppress "WARNING: Did not find..." for Whisper_STT  pip install

### DIFF
--- a/extensions/whisper_stt/requirements.txt
+++ b/extensions/whisper_stt/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Uberi/speech_recognition.git@010382b
+git+https://github.com/Uberi/speech_recognition.git@010382b80267f0f7794169fccc8e875ee7da7c19
 openai-whisper
 soundfile
 ffmpeg


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5817861/232180280-6105f835-1998-49cf-a002-1c80a1165cbc.png)

This annoying warning is caused when referencing the "short" form of a git commit. [Using the full, 40 character, version suppresses it. ](https://github.com/pypa/pip/pull/4674)