### PR TITLE
Add support for GPTQ-triton using the --gptq-triton flag.

### DIFF
--- a/modules/GPTQ_triton_loader.py
+++ b/modules/GPTQ_triton_loader.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import gptq_triton
+import modules.shared as shared
+import torch
+
+
+def load_quantized(model_name):
+    # Find the model type
+    if not shared.args.model_type:
+        name = model_name.lower()
+        if any((k in name for k in ['llama', 'alpaca', 'vicuna'])):
+            model_type = 'llama'
+        elif any((k in name for k in ['opt-', 'galactica'])):
+            model_type = 'opt'
+        elif any((k in name for k in ['gpt-j', 'pygmalion-6b'])):
+            model_type = 'gptj'
+        else:
+            print("Can't determine model type from model name. Please specify it manually using --model_type "
+                  "argument")
+            exit()
+    else:
+        model_type = shared.args.model_type.lower()
+
+    # Check if the model type is supported
+    if shared.args.pre_layer:
+        print("Error: --pre_layer is not supported for gptq_triton.")
+        exit()
+    elif model_type not in ('llama',):
+        print("Error: gptq_triton only supports llama models.")
+        exit()
+    
+    # Load the model
+    model = gptq_triton.load_quant(Path(shared.args.model_dir) / model_name)
+    model = model.to(torch.device('cuda'))
+
+    return model

--- a/modules/models.py
+++ b/modules/models.py
@@ -46,7 +46,7 @@ def load_model(model_name):
     shared.is_llamacpp = len(list(Path(f'{shared.args.model_dir}/{model_name}').glob('ggml*.bin'))) > 0
 
     # Load the model in simple 16-bit mode by default
-    if not any([shared.args.cpu, shared.args.load_in_8bit, shared.args.wbits, shared.args.auto_devices, shared.args.disk, shared.args.gpu_memory is not None, shared.args.cpu_memory is not None, shared.args.deepspeed, shared.args.flexgen, shared.is_RWKV, shared.is_llamacpp]):
+    if not any([shared.args.cpu, shared.args.load_in_8bit, shared.args.wbits, shared.args.gptq_triton, shared.args.auto_devices, shared.args.disk, shared.args.gpu_memory is not None, shared.args.cpu_memory is not None, shared.args.deepspeed, shared.args.flexgen, shared.is_RWKV, shared.is_llamacpp]):
         model = AutoModelForCausalLM.from_pretrained(Path(f"{shared.args.model_dir}/{shared.model_name}"), low_cpu_mem_usage=True, torch_dtype=torch.bfloat16 if shared.args.bf16 else torch.float16)
         if torch.has_mps:
             device = torch.device('mps')
@@ -92,6 +92,12 @@ def load_model(model_name):
         tokenizer = RWKVTokenizer.from_pretrained(Path(shared.args.model_dir))
 
         return model, tokenizer
+
+    # GPTQ-triton quantized model
+    elif shared.args.gptq_triton:
+        from modules.GPTQ_triton_loader import load_quantized
+
+        model = load_quantized(model_name)
 
     # Quantized model
     elif shared.args.wbits > 0:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -122,6 +122,7 @@ parser.add_argument('--model_type', type=str, help='GPTQ: Model type of pre-quan
 parser.add_argument('--groupsize', type=int, default=-1, help='GPTQ: Group size.')
 parser.add_argument('--pre_layer', type=int, default=0, help='GPTQ: The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models.')
 parser.add_argument('--no-warmup_autotune', action='store_true', help='GPTQ: Disable warmup autotune for triton.')
+parser.add_argument('--gptq-triton', action='store_true', help='GPTQ: Use GPTQ-triton.')
 
 # FlexGen
 parser.add_argument('--flexgen', action='store_true', help='Enable the use of FlexGen offloading.')


### PR DESCRIPTION
GPTQ-triton is my WIP implementation of the GPTQ kernels in Triton, which improve inference speed on GPTQ quantized models.  On short prompts it provides on average a 10% boost in performance relative to the CUDA kernels.  On large prompts it is over 10x faster.  It's the source of the Triton branch in GPTQ-for-LLaMa.

While GPTQ-triton is still a work in progress, I did integrate support for it in text-generation-webui and thought it might be useful to share the code, since it's a relatively simple addition.  So far I've tested this integration against the latest transformers, llama 7B at 4-bit quantization and groupsize -1.  Support for multi-gpu, other wbit settings, and Flash attention are not yet implemented.

If you don't feel comfortable integrating support yet, that's totally fine, just let me know what features are blockers.

Thank you.