### PR TITLE
Add support for custom stopping strings in RWKV models

### DIFF
--- a/api-example-stream.py
+++ b/api-example-stream.py
@@ -42,7 +42,7 @@ async def run(context):
         'early_stopping': False,
         'seed': -1,
         'add_bos_token': True,
-        'custom_stopping_strings': [],
+        'custom_stopping_strings': '',
         'truncation_length': 2048,
         'ban_eos_token': False,
         'skip_special_tokens': True,

--- a/api-example-stream.py
+++ b/api-example-stream.py
@@ -42,7 +42,7 @@ async def run(context):
         'early_stopping': False,
         'seed': -1,
         'add_bos_token': True,
-        'custom_stopping_strings': '',
+        'custom_stopping_strings': [],
         'truncation_length': 2048,
         'ban_eos_token': False,
         'skip_special_tokens': True,

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -160,13 +160,19 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
             else:
                 if not shared.is_chat():
                     yield formatted_outputs(question, shared.model_name)
-
+                evaluated_stopping_strings = ast.literal_eval(f"[{state['custom_stopping_strings']}]")
                 # RWKV has proper streaming, which is very nice.
                 # No need to generate 8 tokens at a time.
                 for reply in shared.model.generate_with_streaming(context=question, **generate_params):
                     output = original_question + reply
+                    original_reply = reply
                     if not shared.is_chat():
-                        reply = original_question + apply_extensions(reply, 'output')
+                        original_reply = apply_extensions(reply, 'output')
+                        reply = original_question + original_reply
+                    found_stop_string = next((s for s in stopping_strings + evaluated_stopping_strings if s in original_reply), None)
+                    if found_stop_string:
+                        yield formatted_outputs(str(reply).rsplit(found_stop_string, 1)[0], shared.model_name)
+                        break
                     yield formatted_outputs(reply, shared.model_name)
 
         except Exception:


### PR DESCRIPTION
Addresses a comment in #903 

Breaks from the generation if any stopping string is in the output. It should also work if an extension modifies the reply where the stopping string is in the modified reply but not in the original reply, or vice versa.

Works in all modes (e.g. --chat, --notebook). Testing it with --chat is kind of weird because the mode already handles stopping.

Tested with RWKV-4-Pile-1B5-Instruct-test2-20230209.pth (instruct-test model)