### PR TITLE
SD_API_Pictures: Fix default mode setting, add upscaling, denoising and faces fixing options

### DIFF
--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -25,7 +25,12 @@ params = {
     'negative_prompt': '(worst quality, low quality:1.3)',
     'width': 512,
     'height': 512,
+    'denoising_strength': 0.7,
     'restore_faces': False,
+    'enable_hr': False,
+    'hr_upscaler': 'ESRGAN_4x',
+    'override_settings_restore_afterwards': True,
+    'hr_scale': '1.0',
     'seed': -1,
     'sampler_name': 'DDIM',
     'steps': 32,
@@ -123,11 +128,16 @@ def get_SD_pictures(description):
         "prompt": params['prompt_prefix'] + description,
         "seed": params['seed'],
         "sampler_name": params['sampler_name'],
+        "enable_hr": params['enable_hr'],
+        "hr_scale": params['hr_scale'],
+        "hr_upscaler": params['hr_upscaler'],
+        "denoising_strength": params['denoising_strength'],
         "steps": params['steps'],
         "cfg_scale": params['cfg_scale'],
         "width": params['width'],
         "height": params['height'],
         "restore_faces": params['restore_faces'],
+        "override_settings_restore_afterwards": True,
         "negative_prompt": params['negative_prompt']
     }
 
@@ -246,6 +256,13 @@ def SD_api_address_update(address):
 
     return gr.Textbox.update(label=msg)
 
+def check_mode():
+    if params['mode'] == 0:
+        return "Manual"
+    elif params['mode'] == 1:
+        return "Immersive/Interactive"
+    elif params['mode'] == 2:
+        return "Picturebook/Adventure"
 
 def ui():
 
@@ -254,7 +271,7 @@ def ui():
     with gr.Accordion("Parameters", open=True):
         with gr.Row():
             address = gr.Textbox(placeholder=params['address'], value=params['address'], label='Auto1111\'s WebUI address')
-            mode = gr.Dropdown(["Manual", "Immersive/Interactive", "Picturebook/Adventure"], value="Manual", label="Mode of operation", type="index")
+            mode = gr.Dropdown(["Manual", "Immersive/Interactive", "Picturebook/Adventure"], value=check_mode, label="Mode of operation", type="index")
             with gr.Column(scale=1, min_width=300):
                 manage_VRAM = gr.Checkbox(value=params['manage_VRAM'], label='Manage VRAM')
                 save_img = gr.Checkbox(value=params['save_img'], label='Keep original images and use them in chat')
@@ -275,7 +292,14 @@ def ui():
                 steps = gr.Number(label="Steps:", value=params['steps'])
                 seed = gr.Number(label="Seed:", value=params['seed'])
                 cfg_scale = gr.Number(label="CFG Scale:", value=params['cfg_scale'])
-
+            with gr.Row():
+                with gr.Column():
+                    hr_scale = gr.Slider(1, 4, value=params['hr_scale'], step=0.1, label='Upscale by')
+                    denoising_strength = gr.Slider(0, 1, value=params['denoising_strength'], step=0.01, label='Denoising strength')
+                    hr_upscaler = gr.Textbox(placeholder=params['hr_upscaler'], value=params['hr_upscaler'], label='Upscaler')                    
+                with gr.Column():
+                    enable_hr = gr.Checkbox(value=params['enable_hr'], label='Hires. fix')
+                    restore_faces = gr.Checkbox(value=params['restore_faces'], label='Restore faces')
     # Event functions to update the parameters in the backend
     address.change(lambda x: params.update({"address": filter_address(x)}), address, None)
     mode.select(lambda x: params.update({"mode": x}), mode, None)
@@ -289,6 +313,12 @@ def ui():
     negative_prompt.change(lambda x: params.update({"negative_prompt": x}), negative_prompt, None)
     width.change(lambda x: params.update({"width": x}), width, None)
     height.change(lambda x: params.update({"height": x}), height, None)
+    hr_scale.change(lambda x: params.update({"hr_scale": x}), hr_scale, None)
+    denoising_strength.change(lambda x: params.update({"denoising_strength": x}), denoising_strength, None)
+    restore_faces.change(lambda x: params.update({"restore_faces": x}), restore_faces, None)
+    hr_upscaler.change(lambda x: params.update({"hr_upscaler": x}), hr_upscaler, None)
+    enable_hr.change(lambda x: params.update({"enable_hr": x}), enable_hr, None)
+
 
     sampler_name.change(lambda x: params.update({"sampler_name": x}), sampler_name, None)
     steps.change(lambda x: params.update({"steps": x}), steps, None)

--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -29,7 +29,6 @@ params = {
     'restore_faces': False,
     'enable_hr': False,
     'hr_upscaler': 'ESRGAN_4x',
-    'override_settings_restore_afterwards': True,
     'hr_scale': '1.0',
     'seed': -1,
     'sampler_name': 'DDIM',


### PR DESCRIPTION
Fixed default mode setting in gradio dropdown, fixed API request overwriting denoising strength default in Auto1111. Added additional API options to payload for enabling hires fix, setting hr upscaler, restoring auto1111 settings after api request, hires scaling, denoising strength. Added UI controls for them and for restore faces.

Fixes #1316 