### PR TITLE
Support the GPTCache to reduce the model Response Time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ img_bot*
 img_me*
 prompts/[0-9]*
 models/config-user.yaml
+cache_data/*
+.idea

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Optionally, you can use the following command-line flags:
 | `--xformers`                                | Use xformer's memory efficient attention. This should increase your tokens/s. |
 | `--sdp-attention`                           | Use torch 2.0's sdp attention. |
 | `--trust-remote-code`                       | Set trust_remote_code=True while loading a model. Necessary for ChatGLM. |
+| `--enable-init-gptcache`                    | Enable the [GPTCache](https://github.com/zilliztech/GPTCache) to reduce similar llm request response time. |
 
 #### llama.cpp
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -73,7 +73,9 @@ settings = {
     'lora_prompts': {
         'default': 'QA',
         '.*alpaca': "Alpaca",
-    }
+    },
+    'enable_cache': True,
+    'cache_skip': False,
 }
 
 
@@ -104,6 +106,7 @@ parser.add_argument('--no-stream', action='store_true', help='Don\'t stream the 
 parser.add_argument('--settings', type=str, help='Load the default interface settings from this json file. See settings-template.json for an example. If you create a file called settings.json, this file will be loaded by default without the need to use the --settings flag.')
 parser.add_argument('--extensions', type=str, nargs="+", help='The list of extensions to load. If you want to load more than one extension, write the names separated by spaces.')
 parser.add_argument('--verbose', action='store_true', help='Print the prompts to the terminal.')
+parser.add_argument('--enable-init-gptcache', action='store_true', help='Enable to init GPTCache for using cache')
 
 # Accelerate/transformers
 parser.add_argument('--cpu', action='store_true', help='Use the CPU to generate text. Warning: Training on CPU is extremely slow.')

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -33,7 +33,7 @@ def list_model_elements():
 
 
 def list_interface_input_elements(chat=False):
-    elements = ['max_new_tokens', 'seed', 'temperature', 'top_p', 'top_k', 'typical_p', 'repetition_penalty', 'encoder_repetition_penalty', 'no_repeat_ngram_size', 'min_length', 'do_sample', 'penalty_alpha', 'num_beams', 'length_penalty', 'early_stopping', 'add_bos_token', 'ban_eos_token', 'truncation_length', 'custom_stopping_strings', 'skip_special_tokens', 'preset_menu']
+    elements = ['max_new_tokens', 'seed', 'temperature', 'top_p', 'top_k', 'typical_p', 'repetition_penalty', 'encoder_repetition_penalty', 'no_repeat_ngram_size', 'min_length', 'do_sample', 'penalty_alpha', 'num_beams', 'length_penalty', 'early_stopping', 'add_bos_token', 'ban_eos_token', 'truncation_length', 'custom_stopping_strings', 'skip_special_tokens', 'preset_menu', 'enable_cache', 'cache_skip']
     if chat:
         elements += ['name1', 'name2', 'greeting', 'context', 'end_of_turn', 'chat_prompt_size', 'chat_generation_attempts', 'stop_at_newline', 'mode', 'instruction_template', 'character_menu']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ transformers==4.28.1
 bitsandbytes==0.38.1; platform_system != "Windows"
 llama-cpp-python==0.1.36; platform_system != "Windows"
 https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.36/llama_cpp_python-0.1.36-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+gptcache==0.1.16


### PR DESCRIPTION
Added a cache function to LLM, which can reduce request response time if the cache is hit. This feature is disabled by default and can be enabled through the `--enable-init-gptcache` configuration. Hope this feature will improve the current project

By default, the ui will not be changed, and there will be two checkboxes after opening.
![image](https://user-images.githubusercontent.com/21985684/233350681-cf94074b-283f-48e0-9ded-f0bc0946e6c7.png)

testing
![WZOAHYqc7q](https://user-images.githubusercontent.com/21985684/233350745-ac97aac5-62d2-4959-8940-f38e727cd2eb.jpg)
