### PR TITLE
Clarified "download from hugging face" and added "do not download" to download-model.py

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -50,8 +50,7 @@ def select_model_from_default_options():
     print("Input> ", end='')
     choice = input()[0].strip().upper()
     if choice == char_exit:
-        model = "EXIT"
-        branch = ""    
+        exit()
     elif choice == char_hugging:
         print("""\nThen type the name of your desired Hugging Face model in the format organization/name.
 
@@ -256,9 +255,6 @@ if __name__ == '__main__':
     model = args.MODEL
     if model is None:
         model, branch = select_model_from_default_options()
-        
-    if model == "EXIT":
-        exit()
 
     # Cleaning up the model/branch names
     try:

--- a/download-model.py
+++ b/download-model.py
@@ -41,13 +41,18 @@ def select_model_from_default_options():
         char = chr(ord('A') + i)
         choices[char] = name
         print(f"{char}) {name}")
-    char = chr(ord('A') + len(models))
-    print(f"{char}) None of the above")
+    char_hugging = chr(ord('A') + len(models))
+    print(f"{char_hugging}) Manually specify a Hugging Face model")
+    char_exit = chr(ord('A') + len(models) + 1)
+    print(f"{char_exit}) Do not download a model")
 
     print()
     print("Input> ", end='')
     choice = input()[0].strip().upper()
-    if choice == char:
+    if choice == char_exit:
+        model = "EXIT"
+        branch = ""    
+    elif choice == char_hugging:
         print("""\nThen type the name of your desired Hugging Face model in the format organization/name.
 
 Examples:
@@ -251,6 +256,9 @@ if __name__ == '__main__':
     model = args.MODEL
     if model is None:
         model, branch = select_model_from_default_options()
+        
+    if model == "EXIT":
+        exit()
 
     # Cleaning up the model/branch names
     try:


### PR DESCRIPTION
The new one-click installers are fantastic. Small nit: as the model-download.py script is now run automatically in the new install chain, there's a forced error unless a model is specified.

![image](https://user-images.githubusercontent.com/5817861/233535206-4f5d1c7b-75cc-4629-bba0-cdca2ad82da0.png)

Many LLaMa/other users will just want to install a model manually. The script currently doesn't allow no choice of download, instead assuming the user wants to specify a Hugging Face model. This PR clears it up by renaming that and adding a "_Do not download_" option (direct exit).

![image](https://user-images.githubusercontent.com/5817861/233535696-f188febe-cc62-4551-bb62-cd449ef09159.png)
