### PR TITLE
add optional text between generation attempts to promote better responses

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -158,6 +158,7 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False):
     # Generate
     for i in range(state['chat_generation_attempts']):
         reply = None
+        if i > 0 : cumulative_reply += state['chat_generation_improv_phrase']
         for reply in generate_reply(f"{prompt}{' ' if len(cumulative_reply) > 0 else ''}{cumulative_reply}", state, eos_token=eos_token, stopping_strings=stopping_strings):
             reply = cumulative_reply + reply
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -53,6 +53,7 @@ settings = {
     'chat_generation_attempts': 1,
     'chat_generation_attempts_min': 1,
     'chat_generation_attempts_max': 5,
+    'chat_generation_improv_phrase': '',
     'default_extensions': [],
     'chat_default_extensions': ["gallery"],
     'presets': {

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -35,7 +35,7 @@ def list_model_elements():
 def list_interface_input_elements(chat=False):
     elements = ['max_new_tokens', 'seed', 'temperature', 'top_p', 'top_k', 'typical_p', 'repetition_penalty', 'encoder_repetition_penalty', 'no_repeat_ngram_size', 'min_length', 'do_sample', 'penalty_alpha', 'num_beams', 'length_penalty', 'early_stopping', 'add_bos_token', 'ban_eos_token', 'truncation_length', 'custom_stopping_strings', 'skip_special_tokens']
     if chat:
-        elements += ['name1', 'name2', 'greeting', 'context', 'end_of_turn', 'chat_prompt_size', 'chat_generation_attempts', 'stop_at_newline', 'mode', 'instruction_template']
+        elements += ['name1', 'name2', 'greeting', 'context', 'end_of_turn', 'chat_prompt_size', 'chat_generation_attempts', 'chat_generation_improv_phrase', 'stop_at_newline', 'mode', 'instruction_template']
     elements += list_model_elements()
     return elements
 

--- a/server.py
+++ b/server.py
@@ -599,6 +599,7 @@ def create_interface():
 
                         with gr.Column():
                             shared.gradio['chat_generation_attempts'] = gr.Slider(minimum=shared.settings['chat_generation_attempts_min'], maximum=shared.settings['chat_generation_attempts_max'], value=shared.settings['chat_generation_attempts'], step=1, label='Generation attempts (for longer replies)')
+                            shared.gradio['chat_generation_improv_phrase'] = gr.Textbox(label='Improvisation phrase (appended bettween attemps to improve longer generations " and then...")', value=shared.settings['chat_generation_improv_phrase'], lines=1)
                             shared.gradio['stop_at_newline'] = gr.Checkbox(value=shared.settings['stop_at_newline'], label='Stop generating at new line character')
 
                 create_settings_menus(default_preset)


### PR DESCRIPTION
Frequently when using multiple generation attempts the second generation would not generate an additional usable tokens in chat. This will first append a string to the end of the previous generation to help the model with longer completions. Some ideas for strings to use:

- ' And then...'
- ' After that'
- '...'