### PR TITLE
Prevent first part of KoboldAI API responses from getting cut off with --chat enabled

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -73,7 +73,7 @@ class Handler(BaseHTTPRequestHandler):
 
             response = json.dumps({
                 'results': [{
-                    'text': answer if shared.args.chat else answer[len(prompt):]
+                    'text': answer if shared.args.is_chat() else answer[len(prompt):]
                 }]
             })
             self.wfile.write(response.encode('utf-8'))

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -73,7 +73,7 @@ class Handler(BaseHTTPRequestHandler):
 
             response = json.dumps({
                 'results': [{
-                    'text': answer[len(prompt):]
+                    'text': answer
                 }]
             })
             self.wfile.write(response.encode('utf-8'))

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -70,19 +70,14 @@ class Handler(BaseHTTPRequestHandler):
                     answer = a
                 else:
                     answer = a[0]
-            if shared.args.chat:
-                response = json.dumps({
-                    'results': [{
-                        'text': answer
-                    }]
-                })
-            else:
-                response = json.dumps({
-                    'results': [{
-                        'text': answer[len(prompt):]
-                    }]
-                })
+
+            response = json.dumps({
+                'results': [{
+                    'text': answer if shared.args.chat else answer[len(prompt):]
+                }]
+            })
             self.wfile.write(response.encode('utf-8'))
+
         elif self.path == '/api/v1/token-count':
             # Not compatible with KoboldAI api
             self.send_response(200)
@@ -96,6 +91,7 @@ class Handler(BaseHTTPRequestHandler):
                 }]
             })
             self.wfile.write(response.encode('utf-8'))
+
         else:
             self.send_error(404)
 

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -70,12 +70,18 @@ class Handler(BaseHTTPRequestHandler):
                     answer = a
                 else:
                     answer = a[0]
-
-            response = json.dumps({
-                'results': [{
-                    'text': answer
-                }]
-            })
+            if shared.args.chat:
+                response = json.dumps({
+                    'results': [{
+                        'text': answer
+                    }]
+                })
+            else:
+                response = json.dumps({
+                    'results': [{
+                        'text': answer[len(prompt):]
+                    }]
+                })
             self.wfile.write(response.encode('utf-8'))
         elif self.path == '/api/v1/token-count':
             # Not compatible with KoboldAI api


### PR DESCRIPTION
This is related to issue [1053](https://github.com/oobabooga/text-generation-webui/issues/1053)

I'm not sure what the intent of the [len(prompt):] part was, but it causes the first part of API responses to be cut off.