### PR TITLE
Feature Request: Response streaming with HTTP API

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -23,6 +23,40 @@ class Handler(BaseHTTPRequestHandler):
         else:
             self.send_error(404)
 
+    def parse_params(self, body):
+        prompt = body['prompt']
+        prompt_lines = [k.strip() for k in prompt.split('\n')]
+        max_context = body.get('max_context_length', 2048)
+        while len(prompt_lines) >= 0 and len(encode('\n'.join(prompt_lines))) > max_context:
+            prompt_lines.pop(0)
+
+        prompt = '\n'.join(prompt_lines)
+        generate_params = {
+            'max_new_tokens': int(body.get('max_length', 200)),
+            'do_sample': bool(body.get('do_sample', True)),
+            'temperature': float(body.get('temperature', 0.5)),
+            'top_p': float(body.get('top_p', 1)),
+            'typical_p': float(body.get('typical', 1)),
+            'repetition_penalty': float(body.get('rep_pen', 1.1)),
+            'encoder_repetition_penalty': 1,
+            'top_k': int(body.get('top_k', 0)),
+            'min_length': int(body.get('min_length', 0)),
+            'no_repeat_ngram_size': int(body.get('no_repeat_ngram_size', 0)),
+            'num_beams': int(body.get('num_beams', 1)),
+            'penalty_alpha': float(body.get('penalty_alpha', 0)),
+            'length_penalty': float(body.get('length_penalty', 1)),
+            'early_stopping': bool(body.get('early_stopping', False)),
+            'seed': int(body.get('seed', -1)),
+            'add_bos_token': int(body.get('add_bos_token', True)),
+            'truncation_length': int(body.get('truncation_length', 2048)),
+            'ban_eos_token': bool(body.get('ban_eos_token', False)),
+            'skip_special_tokens': bool(body.get('skip_special_tokens', True)),
+            'custom_stopping_strings': '',  # leave this blank
+            'stopping_strings': body.get('stopping_strings', []),
+        }
+
+        return prompt, generate_params
+
     def do_POST(self):
         content_length = int(self.headers['Content-Length'])
         body = json.loads(self.rfile.read(content_length).decode('utf-8'))
@@ -32,36 +66,8 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header('Content-Type', 'application/json')
             self.end_headers()
 
-            prompt = body['prompt']
-            prompt_lines = [k.strip() for k in prompt.split('\n')]
-            max_context = body.get('max_context_length', 2048)
-            while len(prompt_lines) >= 0 and len(encode('\n'.join(prompt_lines))) > max_context:
-                prompt_lines.pop(0)
+            prompt, generate_params = self.parse_params(body)
 
-            prompt = '\n'.join(prompt_lines)
-            generate_params = {
-                'max_new_tokens': int(body.get('max_length', 200)),
-                'do_sample': bool(body.get('do_sample', True)),
-                'temperature': float(body.get('temperature', 0.5)),
-                'top_p': float(body.get('top_p', 1)),
-                'typical_p': float(body.get('typical', 1)),
-                'repetition_penalty': float(body.get('rep_pen', 1.1)),
-                'encoder_repetition_penalty': 1,
-                'top_k': int(body.get('top_k', 0)),
-                'min_length': int(body.get('min_length', 0)),
-                'no_repeat_ngram_size': int(body.get('no_repeat_ngram_size', 0)),
-                'num_beams': int(body.get('num_beams', 1)),
-                'penalty_alpha': float(body.get('penalty_alpha', 0)),
-                'length_penalty': float(body.get('length_penalty', 1)),
-                'early_stopping': bool(body.get('early_stopping', False)),
-                'seed': int(body.get('seed', -1)),
-                'add_bos_token': int(body.get('add_bos_token', True)),
-                'truncation_length': int(body.get('truncation_length', 2048)),
-                'ban_eos_token': bool(body.get('ban_eos_token', False)),
-                'skip_special_tokens': bool(body.get('skip_special_tokens', True)),
-                'custom_stopping_strings': '',  # leave this blank
-                'stopping_strings': body.get('stopping_strings', []),
-            }
             stopping_strings = generate_params.pop('stopping_strings')
             generator = generate_reply(prompt, generate_params, stopping_strings=stopping_strings)
             answer = ''
@@ -77,6 +83,28 @@ class Handler(BaseHTTPRequestHandler):
                 }]
             })
             self.wfile.write(response.encode('utf-8'))
+
+        elif self.path == '/api/v1/generate_stream':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+
+            prompt, generate_params = self.parse_params(body)
+
+            stopping_strings = generate_params.pop('stopping_strings')
+            generator = generate_reply(prompt, generate_params, stopping_strings=stopping_strings)
+            answer = ''
+            strip_length = len(prompt)
+            for a in generator:
+                if isinstance(a, str):
+                    answer = a
+                else:
+                    answer = a[0]
+
+                answer = answer[strip_length:]
+                strip_length += len(answer)
+                self.wfile.write(answer.encode('utf-8'))
+                self.wfile.flush()
 
         elif self.path == '/api/v1/token-count':
             # Not compatible with KoboldAI api


### PR DESCRIPTION
This PR extends API extension with `/api/v1/generate_stream` endpoint. This endpoint takes same input as `/api/v1/generate`, but responds with plain text while outputting tokens as soon as they are ready.

This would allow 3rd party scripts and applications to stream tokens wihtout having to use websocket and guessing gradio function IDs.

It would also allow for simple way to use api from curl and shellscripts:

https://asciinema.org/a/LXzNgmMbdLEv2mg7aCbLJkbMf