### PR TITLE
Thread-safe API switch

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -159,6 +159,7 @@ parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authent
 # API
 parser.add_argument('--api', action='store_true', help='Enable the API extension.')
 parser.add_argument('--public-api', action='store_true', help='Create a public URL for the API using Cloudfare.')
+parser.add_argument('--thread-safe', action='store_true', help='Queue requests to API. Useful if multiple clients accessing API.')
 
 
 args = parser.parse_args()


### PR DESCRIPTION
## Current behaviour
If an API request comes while processing another one, first request will be aborted.
<details>
<summary>Error log</summary>

```
100.75.108.28 - - [24/Apr/2023 23:26:48] "POST /api/v1/generate HTTP/1.1" 200 -
Invalidate trace cache @ step 11: expected module 15, but got module 0
Invalidate trace cache @ step 0: expected module 146, but got module 0
Traceback (most recent call last):
  File "/home/ivga/TasyaPugAI/text-generation-webui/modules/callbacks.py", line 66, in gentask
    ret = self.mfunc(callback=_callback, **self.kwargs)
  File "/home/ivga/TasyaPugAI/text-generation-webui/modules/text_generation.py", line 257, in generate_with_callback
    shared.model.generate(**kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/transformers/generation/utils.py", line 1485, in generate
    return self.sample(
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/transformers/generation/utils.py", line 2524, in sample
    outputs = self(
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1538, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/transformers/models/opt/modeling_opt.py", line 938, in forward
    outputs = self.model.decoder(
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1538, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/transformers/models/opt/modeling_opt.py", line 704, in forward
    layer_outputs = decoder_layer(
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1538, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/transformers/models/opt/modeling_opt.py", line 329, in forward
    hidden_states, self_attn_weights, present_key_value = self.self_attn(
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1538, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/transformers/models/opt/modeling_opt.py", line 186, in forward
    key_states = self._shape(self.k_proj(hidden_states), -1, bsz)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    result = hook(self, args)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/deepspeed/utils/nvtx.py", line 15, in wrapped_fn
    ret_val = func(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/deepspeed/runtime/zero/parameter_offload.py", line 366, in _pre_forward_module_hook
    self.pre_sub_module_forward_function(module)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/deepspeed/runtime/zero/parameter_offload.py", line 478, in pre_sub_module_forward_function
    param_coordinator.fetch_sub_module(sub_module)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/deepspeed/utils/nvtx.py", line 15, in wrapped_fn
    ret_val = func(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/ivga/TasyaPugAI/.venv/lib/python3.10/site-packages/deepspeed/runtime/zero/partitioned_param_coordinator.py", line 288, in fetch_sub_module
    raise RuntimeError(
RuntimeError: tracing error at step 0:
module id: 131, training: False
expected the next 2 parameters in the parameter fetch queue to be ({'id': 'name=model.decoder.layers.11.self_attn.k_proj.weight id=180', 'status': 'AVAILABLE', 'numel': 1048576, 'ds_numel': 1048576, 'shape': (1024, 1024), 'ds_shape': (1024, 1024), 'requires_grad': True, 'grad_shape': None, 'persist': False, 'active_sub_modules': {131}}, {'id': 'name=model.decoder.layers.11.self_attn.k_proj.bias id=181', 'status': 'AVAILABLE', 'numel': 1024, 'ds_numel': 1024, 'shape': (1024,), 'ds_shape': (1024,), 'requires_grad': True, 'grad_shape': None, 'persist': True, 'active_sub_modules': {131}})
but got
 ({'id': 'name=model.decoder.layers.12.fc2.weight id=208', 'status': 'NOT_AVAILABLE', 'numel': 0, 'ds_numel': 4194304, 'shape': (0,), 'ds_shape': (1024, 4096), 'requires_grad': True, 'grad_shape': None, 'persist': False, 'active_sub_modules': set()}, {'id': 'name=model.decoder.layers.12.fc2.bias id=209', 'status': 'NOT_AVAILABLE', 'numel': 0, 'ds_numel': 1024, 'shape': (0,), 'ds_shape': (1024,), 'requires_grad': True, 'grad_shape': None, 'persist': True, 'active_sub_modules': set()}).
Output generated in 2.25 seconds (1.33 tokens/s, 3 tokens, context 15, seed 940471260)
```

</details>

## Expected behaviour
Both requests should be completed. Ideally in parallel, but I think it's not possible within one model.

## Changes
- Addition of the flag `--thread-safe`. It instructs API to queue requests and process them one-by-one.

## Notes
This is useful if your model API is used by multiple applications.  
Without owner control, long trash requests can block model from answering. There must be a switch that controls requests queuing.