### PR TITLE
Add support for Seq2Seq LMs

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -10,8 +10,9 @@ import numpy as np
 import torch
 import transformers
 from accelerate import infer_auto_device_map, init_empty_weights
-from transformers import (AutoConfig, AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM,
-                          AutoTokenizer, BitsAndBytesConfig, LlamaTokenizer)
+from transformers import (AutoConfig, AutoModel, AutoModelForCausalLM,
+                          AutoModelForSeq2SeqLM, AutoTokenizer,
+                          BitsAndBytesConfig, LlamaTokenizer)
 
 import modules.shared as shared
 from modules import llama_attn_hijack
@@ -39,20 +40,20 @@ if shared.args.deepspeed:
 
 
 def find_model_type(model_name):
-    lower_model_name = model_name.lower()
-    if 'rwkv-' in lower_model_name:
+    model_name = model_name.lower()
+    if 'rwkv-' in model_name:
         return 'rwkv'
-    elif len(list(Path(f'{shared.args.model_dir}/{lower_model_name}').glob('*ggml*.bin'))) > 0:
+    elif len(list(Path(f'{shared.args.model_dir}/{model_name}').glob('*ggml*.bin'))) > 0:
         return 'llamacpp'
-    elif re.match('.*ggml.*\.bin', lower_model_name):
+    elif re.match('.*ggml.*\.bin', model_name):
         return 'llamacpp'
-    elif 'chatglm' in lower_model_name:
+    elif 'chatglm' in model_name:
         return 'chatglm'
-    elif 'galactica' in lower_model_name:
+    elif 'galactica' in model_name:
         return 'galactica'
-    elif 'llava' in lower_model_name:
+    elif 'llava' in model_name:
         return 'llava'
-    elif any((k in lower_model_name for k in ['gpt4chan', 'gpt-4chan'])):
+    elif any((k in model_name for k in ['gpt4chan', 'gpt-4chan'])):
         return 'gpt4chan'
     else:
         config = AutoConfig.from_pretrained(f"{shared.args.model_dir}/{model_name}")

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -58,18 +58,21 @@ def encode(prompt, add_special_tokens=True, add_bos_token=True, truncation_lengt
 
 
 def decode(output_ids, skip_special_tokens=True):
-    if skip_special_tokens:
-        reply = shared.tokenizer.decode(output_ids, skip_special_tokens=True)
-        reply = reply.replace(r'<|endoftext|>', '')
-        return reply
+    return shared.tokenizer.decode(output_ids, skip_special_tokens)
+
+
+def get_reply_from_output_ids(output_ids, input_ids, original_question, state):
+    if shared.model_type == 'HF_seq2seq':
+        reply = decode(output_ids, state['skip_special_tokens'])
+        if not shared.is_chat():
+            reply = apply_extensions('output', reply)
     else:
-        return shared.tokenizer.decode(output_ids, skip_special_tokens=False)
+        new_tokens = len(output_ids) - len(input_ids[0])
+        reply = decode(output_ids[-new_tokens:], state['skip_special_tokens'])
+        if not shared.is_chat():
+            reply = original_question + apply_extensions('output', reply)
 
-
-def decode_for_lm(output_ids, new_tokens, skip_special_tokens=True):
-    if shared.model_type != 'HF_seq2seq':
-        output_ids = output_ids[-new_tokens:]
-    return decode(output_ids, skip_special_tokens)
+    return reply
 
 
 def generate_softprompt_input_tensors(input_ids):
@@ -268,11 +271,7 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
             if shared.soft_prompt:
                 output = torch.cat((input_ids[0], output[filler_input_ids.shape[1]:]))
 
-            new_tokens = len(output) - len(input_ids[0])
-            reply = decode_for_lm(output, new_tokens, state['skip_special_tokens'])
-            if not shared.is_chat():
-                reply = original_question + apply_extensions('output', reply)
-
+            reply = get_reply_from_output_ids(output, input_ids, original_question, state)
             yield formatted_outputs(reply, shared.model_name)
 
         # Stream the reply 1 token at a time.
@@ -288,7 +287,7 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
             def generate_with_streaming(**kwargs):
                 return Iteratorize(generate_with_callback, kwargs, callback=None)
 
-            if not shared.is_chat():
+            if not shared.is_chat() and shared.model_type != 'HF_seq2seq':
                 yield formatted_outputs(original_question, shared.model_name)
 
             with generate_with_streaming(**generate_params) as generator:
@@ -296,11 +295,7 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
                     if shared.soft_prompt:
                         output = torch.cat((input_ids[0], output[filler_input_ids.shape[1]:]))
 
-                    new_tokens = len(output) - len(input_ids[0])
-                    reply = decode_for_lm(output, new_tokens, state['skip_special_tokens'])
-                    if not shared.is_chat():
-                        reply = original_question + apply_extensions('output', reply)
-
+                    reply = get_reply_from_output_ids(output, input_ids, original_question, state)
                     if output[-1] in eos_token_ids:
                         break
 
@@ -316,11 +311,7 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
                 if shared.soft_prompt:
                     output = torch.cat((input_ids[0], output[filler_input_ids.shape[1]:]))
 
-                new_tokens = len(output) - len(original_input_ids[0])
-                reply = decode_for_lm(output, new_tokens, state['skip_special_tokens'])
-                if not shared.is_chat():
-                    reply = original_question + apply_extensions('output', reply)
-
+                reply = get_reply_from_output_ids(output, input_ids, original_question, state)
                 if np.count_nonzero(np.isin(input_ids[0], eos_token_ids)) < np.count_nonzero(np.isin(output, eos_token_ids)):
                     break
 


### PR DESCRIPTION
Hi,

This PR adds support for seq2seq (encoder-decoder) models like T5, UL2 and their FLAN variants.
The FLAN models are pretty good few/zero shot learners and found it was a shame we couldn't use them here.

About the 'Not a "catch all"', I don't know for certain that all encoder-decoder models contain this key in their config. The ones I checked do. However, most decoder models also contain a "is-decoder" key, except GPT-2.

I kin of just merged the support in there, but don't think I could do much better without rewriting stuff.

Let me know what you guys think.