### PR TITLE
Fix dtypes returned by llava extension tokenizer_modifier

### DIFF
--- a/extensions/llava/script.py
+++ b/extensions/llava/script.py
@@ -245,7 +245,9 @@ def tokenizer_modifier(state, prompt, input_ids, input_embeds):
 
     prompt, input_ids, input_embeds, total_embedded = llava_embedder.forward(prompt, images, state)
     print(f'LLaVA - Embedded {total_embedded} image(s) in {time.time()-start_ts:.2f}s')
-    return prompt, input_ids.unsqueeze(0).to(shared.model.device), input_embeds.unsqueeze(0).to(shared.model.device)
+    return (prompt,
+        input_ids.unsqueeze(0).to(shared.model.device, dtype=torch.int64),
+        input_embeds.unsqueeze(0).to(shared.model.device, dtype=shared.model.dtype))
 
 
 def ui():


### PR DESCRIPTION
LLaVA extension was returning the `input_embeds` in dtype of the `mm_projector`, while it worked for standard attention/xformers it didn't with sdp_attention. 
This fixes #1520, I also made sure token_ids are int64, possibly fixing the crash @Ph0rk0z reported in this comment: https://github.com/oobabooga/text-generation-webui/pull/1487#issuecomment-1520110777 (but I couldn't reproduce it)