### PR TITLE
Add ssl cert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ Optionally, you can use the following command-line flags:
 | `--gradio-auth-path GRADIO_AUTH_PATH` | Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3" |
 | `--ssl-certfile`                      | If a path to a file is provided, will use this as the private key file to create a local server running on https. |
 | `--ssl-keyfile`                       | If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.|
-| `--ssl-verify`                        | If a password is provided, will use this with the ssl certificate for https. |
-| `--ssl-keyfile-password`              | If False, skips certificate validation which allows self-signed certificates to be used. |
+| `--disable-ssl-verify`                | If passed, skips certificate validation which allows self-signed certificates to be used. |
+| `--ssl-keyfile-password`              | If a password is provided, will use this with the ssl certificate for https. |
 
 #### API
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ Optionally, you can use the following command-line flags:
 | `--share`                             | Create a public URL. This is useful for running the web UI on Google Colab or similar. |
 | `--auto-launch`                       | Open the web UI in the default browser upon launch. |
 | `--gradio-auth-path GRADIO_AUTH_PATH` | Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3" |
+| `--ssl-certfile`                      | If a path to a file is provided, will use this as the private key file to create a local server running on https. |
+| `--ssl-keyfile`                       | If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.|
+| `--ssl-verify`                        | If a password is provided, will use this with the ssl certificate for https. |
+| `--ssl-keyfile-password`              | If False, skips certificate validation which allows self-signed certificates to be used. |
 
 #### API
 

--- a/extensions/sd_api_pictures/README.MD
+++ b/extensions/sd_api_pictures/README.MD
@@ -46,6 +46,8 @@ Insert the Automatic1111's WebUI address and press Enter:
 ![API-check](https://raw.githubusercontent.com/Brawlence/SD_api_pics/main/illust/API-check.gif)  
 Green mark confirms the ability to communicate with Auto1111's API on this address. Red cross means something's not right (the ext won't work).
 
+> Note: the `--ssl-verify` parameter can be used to disable tls certificate chain validation, which makes it possible to use the [SDWUI Auto TLS-HTTPS Extension](https://github.com/papuSpartan/stable-diffusion-webui-auto-tls-https)
+
 ### Persistents settings
 
 Create or modify the `settings.json` in the `text-generation-webui` root directory to override the defaults

--- a/extensions/sd_api_pictures/README.MD
+++ b/extensions/sd_api_pictures/README.MD
@@ -46,7 +46,7 @@ Insert the Automatic1111's WebUI address and press Enter:
 ![API-check](https://raw.githubusercontent.com/Brawlence/SD_api_pics/main/illust/API-check.gif)  
 Green mark confirms the ability to communicate with Auto1111's API on this address. Red cross means something's not right (the ext won't work).
 
-> Note: the `--ssl-verify` parameter can be used to disable tls certificate chain validation, which makes it possible to use the [SDWUI Auto TLS-HTTPS Extension](https://github.com/papuSpartan/stable-diffusion-webui-auto-tls-https)
+> Note: the `--disable-ssl-verify` parameter can be used to disable tls certificate chain validation, which makes it possible to use the [SDWUI Auto TLS-HTTPS Extension](https://github.com/papuSpartan/stable-diffusion-webui-auto-tls-https)
 
 ### Persistents settings
 

--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -43,23 +43,23 @@ def give_VRAM_priority(actor):
     if actor == 'SD':
         unload_model()
         print("Requesting Auto1111 to re-load last checkpoint used...")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='', verify=shared.args.ssl_verify)
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='', verify=shared.args.disable_ssl_verify)
         response.raise_for_status()
 
     elif actor == 'LLM':
         print("Requesting Auto1111 to vacate VRAM...")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='', verify=shared.args.ssl_verify)
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='', verify=shared.args.disable_ssl_verify)
         response.raise_for_status()
         reload_model()
 
     elif actor == 'set':
         print("VRAM mangement activated -- requesting Auto1111 to vacate VRAM...")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='', verify=shared.args.ssl_verify)
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='', verify=shared.args.disable_ssl_verify)
         response.raise_for_status()
 
     elif actor == 'reset':
         print("VRAM mangement deactivated -- requesting Auto1111 to reload checkpoint")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='', verify=shared.args.ssl_verify)
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='', verify=shared.args.disable_ssl_verify)
         response.raise_for_status()
 
     else:
@@ -140,7 +140,7 @@ def get_SD_pictures(description):
     }
 
     print(f'Prompting the image generator via the API on {params["address"]}...')
-    response = requests.post(url=f'{params["address"]}/sdapi/v1/txt2img', json=payload, verify=shared.args.ssl_verify)
+    response = requests.post(url=f'{params["address"]}/sdapi/v1/txt2img', json=payload, verify=shared.args.disable_ssl_verify)
     response.raise_for_status()
     r = response.json()
 
@@ -246,7 +246,7 @@ def SD_api_address_update(address):
     address = filter_address(address)
     params.update({"address": address})
     try:
-        response = requests.get(url=f'{params["address"]}/sdapi/v1/sd-models', verify=shared.args.ssl_verify)
+        response = requests.get(url=f'{params["address"]}/sdapi/v1/sd-models', verify=shared.args.disable_ssl_verify)
         response.raise_for_status()
         # r = response.json()
     except:

--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -43,23 +43,23 @@ def give_VRAM_priority(actor):
     if actor == 'SD':
         unload_model()
         print("Requesting Auto1111 to re-load last checkpoint used...")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='')
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='', verify=shared.args.ssl_verify)
         response.raise_for_status()
 
     elif actor == 'LLM':
         print("Requesting Auto1111 to vacate VRAM...")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='')
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='', verify=shared.args.ssl_verify)
         response.raise_for_status()
         reload_model()
 
     elif actor == 'set':
         print("VRAM mangement activated -- requesting Auto1111 to vacate VRAM...")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='')
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/unload-checkpoint', json='', verify=shared.args.ssl_verify)
         response.raise_for_status()
 
     elif actor == 'reset':
         print("VRAM mangement deactivated -- requesting Auto1111 to reload checkpoint")
-        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='')
+        response = requests.post(url=f'{params["address"]}/sdapi/v1/reload-checkpoint', json='', verify=shared.args.ssl_verify)
         response.raise_for_status()
 
     else:
@@ -140,7 +140,7 @@ def get_SD_pictures(description):
     }
 
     print(f'Prompting the image generator via the API on {params["address"]}...')
-    response = requests.post(url=f'{params["address"]}/sdapi/v1/txt2img', json=payload)
+    response = requests.post(url=f'{params["address"]}/sdapi/v1/txt2img', json=payload, verify=shared.args.ssl_verify)
     response.raise_for_status()
     r = response.json()
 
@@ -246,7 +246,7 @@ def SD_api_address_update(address):
     address = filter_address(address)
     params.update({"address": address})
     try:
-        response = requests.get(url=f'{params["address"]}/sdapi/v1/sd-models')
+        response = requests.get(url=f'{params["address"]}/sdapi/v1/sd-models', verify=shared.args.ssl_verify)
         response.raise_for_status()
         # r = response.json()
     except:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -155,6 +155,10 @@ parser.add_argument('--listen-port', type=int, help='The listening port that the
 parser.add_argument('--share', action='store_true', help='Create a public URL. This is useful for running the web UI on Google Colab or similar.')
 parser.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
+parser.add_argument("--ssl-keyfile", type=str, help="If a path to a file is provided, will use this as the private key file to create a local server running on https.", default=None)
+parser.add_argument("--ssl-certfile", type=str, help="If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.", default=None)
+parser.add_argument("--ssl-keyfile-password", type=str, help="If a password is provided, will use this with the ssl certificate for https.", default=None)
+parser.add_argument("--ssl-verify", type=bool, help="If False, skips certificate validation which allows self-signed certificates to be used.", default=None)
 
 # API
 parser.add_argument('--api', action='store_true', help='Enable the API extension.')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -158,7 +158,7 @@ parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authent
 parser.add_argument("--ssl-keyfile", type=str, help="If a path to a file is provided, will use this as the private key file to create a local server running on https.", default=None)
 parser.add_argument("--ssl-certfile", type=str, help="If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.", default=None)
 parser.add_argument("--ssl-keyfile-password", type=str, help="If a password is provided, will use this with the ssl certificate for https.", default=None)
-parser.add_argument("--ssl-verify", type=bool, help="If False, skips certificate validation which allows self-signed certificates to be used.", default=None)
+parser.add_argument("--disable-ssl-verify", action="store_false", help="If passed, skips certificate validation which allows self-signed certificates to be used.", default=None)
 
 # API
 parser.add_argument('--api', action='store_true', help='Enable the API extension.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate==0.18.0
 colorama
 datasets
 flexgen==0.1.7
-gradio==3.25.0
+gradio==3.28.0
 markdown
 numpy
 pandas

--- a/server.py
+++ b/server.py
@@ -847,9 +847,9 @@ def create_interface():
     # Launch the interface
     shared.gradio['interface'].queue()
     if shared.args.listen:
-        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_name=shared.args.listen_host or '0.0.0.0', server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth, ssl_keyfile=shared.args.ssl_keyfile, ssl_certfile=shared.args.ssl_certfile, ssl_keyfile_password=shared.args.ssl_keyfile_password, ssl_verify=shared.args.ssl_verify)
+        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_name=shared.args.listen_host or '0.0.0.0', server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth, ssl_keyfile=shared.args.ssl_keyfile, ssl_certfile=shared.args.ssl_certfile, ssl_keyfile_password=shared.args.ssl_keyfile_password, ssl_verify=shared.args.disable_ssl_verify)
     else:
-        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth, ssl_keyfile=shared.args.ssl_keyfile, ssl_certfile=shared.args.ssl_certfile, ssl_keyfile_password=shared.args.ssl_keyfile_password, ssl_verify=shared.args.ssl_verify)
+        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth, ssl_keyfile=shared.args.ssl_keyfile, ssl_certfile=shared.args.ssl_certfile, ssl_keyfile_password=shared.args.ssl_keyfile_password, ssl_verify=shared.args.disable_ssl_verify)
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -847,9 +847,9 @@ def create_interface():
     # Launch the interface
     shared.gradio['interface'].queue()
     if shared.args.listen:
-        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_name=shared.args.listen_host or '0.0.0.0', server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth)
+        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_name=shared.args.listen_host or '0.0.0.0', server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth, ssl_keyfile=shared.args.ssl_keyfile, ssl_certfile=shared.args.ssl_certfile, ssl_keyfile_password=shared.args.ssl_keyfile_password, ssl_verify=shared.args.ssl_verify)
     else:
-        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth)
+        shared.gradio['interface'].launch(prevent_thread_lock=True, share=shared.args.share, server_port=shared.args.listen_port, inbrowser=shared.args.auto_launch, auth=auth, ssl_keyfile=shared.args.ssl_keyfile, ssl_certfile=shared.args.ssl_certfile, ssl_keyfile_password=shared.args.ssl_keyfile_password, ssl_verify=shared.args.ssl_verify)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds CLI args to enable use of TLS when running the web UI. Inspired by Automatic1111 extension [SDWUI Auto TLS-HTTPS Extension](https://github.com/papuSpartan/stable-diffusion-webui-auto-tls-https).

Tested by running the same changes locally w/ self-signed certificates.