### PR TITLE
Fix stopping_string issue by Creating RegxStoppingCriteria and use Re…

### DIFF
--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -30,6 +30,21 @@ class _SentinelTokenStoppingCriteria(transformers.StoppingCriteria):
                         return True
         return False
 
+class RegxStoppingCriteria(transformers.StoppingCriteria):
+    def __init__(self, regx_string_list: list, starting_idx: int):
+        import re
+        from .text_generation import decode
+        self.regex_list = [re.compile(regx_string) for regx_string in regx_string_list]
+        self.decode = decode
+        self.starting_idx = starting_idx
+
+    def __call__(self, input_ids: torch.LongTensor, _scores: torch.FloatTensor):
+        output_ids = input_ids[0][self.starting_idx:]
+        output_text = self.decode(output_ids)
+        for regex in self.regex_list:
+            if regex.search(output_text):
+                return True
+        return False
 
 class Stream(transformers.StoppingCriteria):
     def __init__(self, callback_func=None):

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -10,6 +10,7 @@ import transformers
 
 import modules.shared as shared
 from modules.callbacks import (Iteratorize, Stream,
+                               RegxStoppingCriteria,
                                _SentinelTokenStoppingCriteria)
 from modules.extensions import apply_extensions
 from modules.html_generator import generate_4chan_html, generate_basic_html
@@ -240,8 +241,7 @@ def generate_reply(question, state, eos_token=None, stopping_strings=[]):
     stopping_criteria_list = transformers.StoppingCriteriaList()
     for st in (stopping_strings, ast.literal_eval(f"[{state['custom_stopping_strings']}]")):
         if type(st) is list and len(st) > 0:
-            sentinel_token_ids = [encode(string, add_special_tokens=False) for string in st]
-            stopping_criteria_list.append(_SentinelTokenStoppingCriteria(sentinel_token_ids=sentinel_token_ids, starting_idx=len(input_ids[0])))
+            stopping_criteria_list.append(RegxStoppingCriteria(regx_string_list=st, starting_idx=len(input_ids[0])))
             break
 
     # Update generate_params with the eos token and the stopping strings


### PR DESCRIPTION
# Fix Bug:  stopping_strings sometimes do not work
## Issue:
stopping_strings sometimes do not work
## Reason: 
In some models one word can map to multiple token
## Changes in my branch:
create a new StoppingCriteria: RegxStoppingCriteria
Use RegxStoppingCriteria instead of _SentinelTokenStoppingCriteria to process stopping string to:
1. fix the bug above
2. Apply Regular expression function in stopping_string (Sometimes it is useful, for example: if someone want to integrate AutoGPT with text_generation_webui, they can stop the generate process easily by matching the last part of the JSON format: "}\s}\s}")
## Bug Case:
### Model: 
https://huggingface.co/TheBloke/vicuna-7B-1.1-GPTQ-4bit-128g
### GPTQ:
https://github.com/qwopqwop200/GPTQ-for-LLaMa
commit 5731aa11de56affe6e8c88cea66a171045ad1dce
### Case:
from .text_generation import decode
decode([29911])
'T'
decode([323])
'T'

## Explain: 
If my stopping_strings is 'T' When I encode my stopping_strings it is possible encode it into 323, but it is possible for model to generate 29911, as _SentinelTokenStoppingCriteria only compares token in this case stopping_strings do not work.