### PR TITLE
GPTQ: Allow groupsize 1024 in the UI, helpful for larger models eg 30B to lower VRAM usage

### DIFF
--- a/server.py
+++ b/server.py
@@ -361,7 +361,7 @@ def create_model_menus():
                 with gr.Row():
                     with gr.Column():
                         shared.gradio['wbits'] = gr.Dropdown(label="wbits", choices=["None", 1, 2, 3, 4, 8], value=shared.args.wbits if shared.args.wbits > 0 else "None")
-                        shared.gradio['groupsize'] = gr.Dropdown(label="groupsize", choices=["None", 32, 64, 128], value=shared.args.groupsize if shared.args.groupsize > 0 else "None")
+                        shared.gradio['groupsize'] = gr.Dropdown(label="groupsize", choices=["None", 32, 64, 128, 1024], value=shared.args.groupsize if shared.args.groupsize > 0 else "None")
 
                     with gr.Column():
                         shared.gradio['model_type'] = gr.Dropdown(label="model_type", choices=["None", "llama", "opt", "gptj"], value=shared.args.model_type or "None")


### PR DESCRIPTION
A trivial fix to allow groupsize=1024 in the UI for GPTQ models.

1024g is already supported when one uses command line arguments, but can't be set in the UI.

I only realised this after I pushed a new models to HF that use 1024g (https://huggingface.co/TheBloke/OpenAssistant-SFT-7-Llama-30B-GPTQ) so I'd really appreciate it if this could be merged :)

I normally use 128g for my GPTQs, but at 30B it makes a useful difference in VRAM which allows the user to get longer responses before OOMing on a 24GB GPU.