### PR TITLE
Allow downloading model from HF branch via UI

### DIFF
--- a/server.py
+++ b/server.py
@@ -183,8 +183,11 @@ def download_model_wrapper(repo_id):
     try:
         downloader = importlib.import_module("download-model")
 
-        model = repo_id
-        branch = "main"
+        repo_id_parts = repo_id.split(":")
+
+        model = repo_id_parts[0] if len(repo_id_parts) > 0 else repo_id
+        branch = repo_id_parts[1] if len(repo_id_parts) > 1 else "main"
+
         check = False
 
         yield ("Cleaning up the model/branch names")


### PR DESCRIPTION
A simple fix that allows the user to download models from HF branches, using `repo/model:branch` notation.

Eg a user could enter `TheBloke/stable-vicuna-13B-GPTQ:latest` to download from https://huggingface.co/TheBloke/stable-vicuna-13B-GPTQ/tree/latest

This is useful for me as I've started using HF branches to create separate versions of my GPTQ models.

eg in stable-vicuna-13B-GPT:
* main branch = GPTQ 4bit 128g without act-order
* 'latest' branch = GPTQ 4bit 128g with --act-order, requiring recent GPTQ-for-LLaMa code

It'd be great if I could tell users in my README that they can use the text-generation-webui download feature for whatever branch they want.