### PR TITLE
LLaVA: small fixes

### DIFF
--- a/extensions/llava/README.md
+++ b/extensions/llava/README.md
@@ -1,9 +1,12 @@
 # LLaVA
 
 ## Description
-Adds [LLaVA](https://github.com/haotian-liu/LLaVA) multimodality support to text-generation-webui.
+Adds [LLaVA 13B](https://github.com/haotian-liu/LLaVA) multimodality support to text-generation-webui.
 
 https://user-images.githubusercontent.com/3718215/233817203-69b57e77-0c55-4fd6-b742-3204bb13b8fc.mp4
+
+## LLaVA-7B
+7B version currently isn't supported. It will be supported if/when [more generic multimodality support](https://github.com/oobabooga/text-generation-webui/discussions/1687) gets implemented.
 
 ## Usage
 To run this extension, download LLaVA weights, for example from [here](https://huggingface.co/wojtab/llava-13b-v0-4bit-128g) (note: it's a 4-bit [GPTQ quantization](https://github.com/oobabooga/text-generation-webui/tree/main/docs/GPTQ-models-(4-bit-mode).md), done on "old CUDA" branch), and then start server.py with `--extensions llava` argument.

--- a/extensions/llava/README.md
+++ b/extensions/llava/README.md
@@ -6,9 +6,7 @@ Adds [LLaVA](https://github.com/haotian-liu/LLaVA) multimodality support to text
 https://user-images.githubusercontent.com/3718215/233817203-69b57e77-0c55-4fd6-b742-3204bb13b8fc.mp4
 
 ## Usage
-To run this extension, download LLaVA weights, for example from [here](https://huggingface.co/wojtab/llava-13b-v0-4bit-128g) (note: it's a 4-bit GPTQ quantization, so you need working GPTQ), and then start server.py with `--extensions llava` argument.
-
-When in ui, go to instruct mode, and select LLaVA template, you also should add `"\n###"` to "Custom stopping strings" in parameters tab.
+To run this extension, download LLaVA weights, for example from [here](https://huggingface.co/wojtab/llava-13b-v0-4bit-128g) (note: it's a 4-bit [GPTQ quantization](https://github.com/oobabooga/text-generation-webui/tree/main/docs/GPTQ-models-(4-bit-mode).md), done on "old CUDA" branch), and then start server.py with `--extensions llava` argument.
 
 Do note, that each image takes up 258 tokens, so adjust max_new_tokens to be at most 1700 (recommended value is between 200 to 500), so the images don't get truncated.
 

--- a/extensions/llava/README.md
+++ b/extensions/llava/README.md
@@ -6,7 +6,7 @@ Adds [LLaVA](https://github.com/haotian-liu/LLaVA) multimodality support to text
 https://user-images.githubusercontent.com/3718215/233817203-69b57e77-0c55-4fd6-b742-3204bb13b8fc.mp4
 
 ## Usage
-To run this extension, download LLaVA weights, for example from [here](https://huggingface.co/wojtab/llava-13b-v0-4bit-128g), and then start server.py with `--extensions llava` argument.
+To run this extension, download LLaVA weights, for example from [here](https://huggingface.co/wojtab/llava-13b-v0-4bit-128g) (note: it's a 4-bit GPTQ quantization, so you need working GPTQ), and then start server.py with `--extensions llava` argument.
 
 When in ui, go to instruct mode, and select LLaVA template, you also should add `"\n###"` to "Custom stopping strings" in parameters tab.
 
@@ -22,10 +22,12 @@ This extension uses following parameters (from settings.json):
 |---------|-----------|
 |`llava-clip_bits`|Number of bits to load CLIP feature extractor in (either 32 or 16, default=32)|
 |`llava-clip_device`|Torch device to run the extractor on, for example `cpu` or `cuda:0`, by default `cuda:0` if available|
+|`llava-clip_repo`|Huggingface repository of CLIP model, `openai/clip-vit-large-patch14` by default. There should be no need to change it|
 |`llava-projector_bits`|Number of bits to load CLIP->LLaMA feature projector in (either 32 or 16, default=32)|
-|`llava-projector_bits`|Torch device to run the CLIP->LLaMA feature projector on, for example `cpu` or `cuda:0`, by default `cuda:0` if available|
+|`llava-projector_device`|Torch device to run the CLIP->LLaMA feature projector on, for example `cpu` or `cuda:0`, by default `cuda:0` if available|
+|`llava-projector_repo`|Huggingface repository of multimodal projector, `liuhaotian/LLaVA-13b-delta-v0` by default. There should be no need to change it|
+|`llava-projector_filename`|The filename of multimodal projector weights, `mm_projector.bin` by default. There should be no need to change it|
 |`llava-add_all_images_to_prompt`|Default value of "Embed all images, not only the last one" checkbox|
-
 ## Technical description
 
 ### Original LLaVA


### PR DESCRIPTION
1. Haotian Liu - the author of LLaVA noticed that the projector weights I used are from before the finetuning stage (see: https://github.com/haotian-liu/LLaVA/discussions/42#discussioncomment-5725359), whereas the model weights are after finetuning. This PR fixes it, and also makes them configurable by the user. (The projector is a separate, ~10MB model, working as "glue" between vision model and LLM)
After running both versions on the same prompts, the difference isn't huge, but the model seems less likely to hallucinate objects which aren't in the images.
2. I removed the step with adding `"\n###"` to custom stopping strings from readme, as https://github.com/oobabooga/text-generation-webui/commit/d87ca8f2af2458e8b57b1ec9915c72a4ca5ca19f added it to `models/config.yaml`, and added a note that the default model needs GPTQ, per this suggestion: https://github.com/oobabooga/text-generation-webui/issues/1533#issuecomment-1522806803
3. I fixed stopping_strings in no-stream mode, `starting_idx=len(input_ids[0])` broke if we modified `input_ids` in tokenizer extensions. No idea why it works without --no-stream
4. I added example usage through API in docs
5. LLaVA 7B just got released, it requires changing a few consts, and that's it, but I'd like to make multimodality support more generic first - see: https://github.com/oobabooga/text-generation-webui/discussions/1687. For now added to readme that it isn't supported