### PR TITLE
Proposal to fix loading errors with elevenlabslib extension

### DIFF
--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import gradio as gr
 from elevenlabslib import ElevenLabsUser
-from elevenlabslib.helpers import save_bytes_to_path
+from elevenlabslib.helpers import *
 
 import modules.shared as shared
 


### PR DESCRIPTION
Several users have reported issues with loading the elevenlabslib extension while using the one-click installation process with the current settings. as seen from https://github.com/oobabooga/text-generation-webui/issues/1648

I propose a simple fix by changing the import statement to 'from elevenlabslib.helpers import *' to improve stability.