### PR TITLE
Fix openai extension script.py - TypeError: '_Environ' object is not …

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -8,7 +8,7 @@ from modules import shared
 from modules.text_generation import encode, generate_reply
 
 params = {
-    'port': int(os.environ('OPENEDAI_PORT')) if 'OPENEDAI_PORT' in os.environ else 5001,
+    'port': int(os.environ.get('OPENEDAI_PORT')) if 'OPENEDAI_PORT' in os.environ else 5001,
 }
 
 debug = True if 'OPENEDAI_DEBUG' in os.environ else False


### PR DESCRIPTION
…callable

Fixes the following issue:

Traceback (most recent call last):
  File "text-generation-webui/modules/extensions.py", line 33, in load_extensions
    exec(f"import extensions.{name}.script")
  File "<string>", line 1, in <module>
  File "text-generation-webui/extensions/openai/script.py", line 11, in <module>
    'port': int(os.environ('OPENEDAI_PORT')) if 'OPENEDAI_PORT' in os.environ else 5001,
TypeError: '_Environ' object is not callable