### PR TITLE
Openai Chat Completion support improvement

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -205,10 +205,10 @@ class Handler(BaseHTTPRequestHandler):
                 chat_msgs = []
 
                 for m in messages:
-                    role = m['role']
+                    role = m['role'].capitalize()
                     content = m['content']
                     # name = m.get('name', 'user')
-                    if role == 'system':
+                    if role == 'System':
                         system_msg += content.strip()+'\n'
                     else:
                         chat_msgs.extend([f"### {role}:\n{content.strip()}\n"])

--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -304,9 +304,15 @@ class Handler(BaseHTTPRequestHandler):
 
             for a in generator:
                 if isinstance(a, str):
-                    answer = a[len(prompt):]
+                    if shared.args.chat:
+                        answer = a
+                    else:
+                        answer = a[len(prompt):]
                 else:
-                    answer = a[0][len(prompt):]
+                    if shared.args.chat:
+                        answer = a[0]
+                    else:
+                        answer = a[0][len(prompt):]
 
                 stop_string_found = False
                 len_seen = len(seen_content)


### PR DESCRIPTION
Fixes:
- Uses Alpaca prompt template
- Standard stopping strings reduced to Alpaca format
- Completion no longer returns the prompt but the answer only
- Role name with first letter uppercase

Compatible and tested with Vicuna v1.1

Tested using the following python script:
```

# Makes sure the requests don't go to your local proxy
import os
os.environ['NO_PROXY'] = '127.0.0.1'

import openai

# Port can be changed with OPENEDAI_PORT env variable
openai.api_base = "http://127.0.0.1:5001/v1"

# Enter any non-empty API key to pass the client library's check.
openai.api_key = "xxx"

# Enter any non-empty model name to pass the client library's check.
completion = openai.ChatCompletion.create(
    model="Thireus_Vicuna13B-v1.1-8bit-64g", messages = [{"role": "system", "content": "Below is an instruction that describes a task. As a helpful assistant, write a response that appropriately completes the request."},{"role": "Human", "content": "What is 1+1?"},{"role": "Assistant", "content": "The sum of 1 and 1 is 2."},{"role": "Human", "content": "Why is it 2?"}], max_tokens=256, echo=False
)

# Print the completion.
print(completion.choices[0].message)
```

Will return:
```
{
  "content": "Because when you add two numbers together, the result is called their \"sum.\" The sum of 1 and 1 is therefore 2.",
  "role": "Assistant"
}
```