### PR TITLE
Wrong argument for no mmap in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Optionally, you can use the following command-line flags:
 |-------------|-------------|
 | `--threads` | Number of threads to use. |
 | `--n_batch` | Maximum number of prompt tokens to batch together when calling llama_eval. |
-| `--no-mmap` | Prevent mmap from being used. |
+| `--no_mmap` | Prevent mmap from being used. |
 | `--mlock`   | Force the system to keep the model in RAM. |
 
 #### GPTQ


### PR DESCRIPTION
Change | `--no-mmap` | to | `--no_mmap` |

as per:

```
usage: server.py [-h] [--notebook] [--chat] [--cai-chat] [--character CHARACTER] [--model MODEL]
                 [--lora LORA [LORA ...]] [--model-dir MODEL_DIR] [--lora-dir LORA_DIR] [--model-menu] [--no-stream]
                 [--settings SETTINGS] [--extensions EXTENSIONS [EXTENSIONS ...]] [--verbose] [--cpu] [--auto-devices]
                 [--gpu-memory GPU_MEMORY [GPU_MEMORY ...]] [--cpu-memory CPU_MEMORY] [--disk]
                 [--disk-cache-dir DISK_CACHE_DIR] [--load-in-8bit] [--bf16] [--no-cache] [--xformers]
                 [--sdp-attention] [--trust-remote-code] [--threads THREADS] [--n_batch N_BATCH] [--no_mmap] [--mlock]
                 [--wbits WBITS] [--model_type MODEL_TYPE] [--groupsize GROUPSIZE] [--pre_layer PRE_LAYER]
                 [--monkey-patch] [--quant_attn] [--warmup_autotune] [--fused_mlp] [--flexgen]
                 [--percent PERCENT [PERCENT ...]] [--compress-weight] [--pin-weight [PIN_WEIGHT]] [--deepspeed]
                 [--nvme-offload-dir NVME_OFFLOAD_DIR] [--local_rank LOCAL_RANK] [--rwkv-strategy RWKV_STRATEGY]
                 [--rwkv-cuda-on] [--listen] [--listen-host LISTEN_HOST] [--listen-port LISTEN_PORT] [--share]
                 [--auto-launch] [--gradio-auth-path GRADIO_AUTH_PATH] [--api] [--public-api]
```