### PR TITLE
Make --trust-remote-code actually use trust_remote_code=True

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -56,7 +56,7 @@ def find_model_type(model_name):
     elif any((k in model_name_lower for k in ['gpt4chan', 'gpt-4chan'])):
         return 'gpt4chan'
     else:
-        config = AutoConfig.from_pretrained(Path(f'{shared.args.model_dir}/{model_name}'))
+        config = AutoConfig.from_pretrained(Path(f'{shared.args.model_dir}/{model_name}'), trust_remote_code=shared.args.trust_remote_code)
         # Not a "catch all", but fairly accurate
         if config.to_dict().get("is_encoder_decoder", False):
             return 'HF_seq2seq'
@@ -69,15 +69,13 @@ def load_model(model_name):
     t0 = time.time()
 
     shared.model_type = find_model_type(model_name)
+    trust_remote_code = shared.args.trust_remote_code
     if shared.model_type == 'chatglm':
         LoaderClass = AutoModel
-        trust_remote_code = shared.args.trust_remote_code
     elif shared.model_type == 'HF_seq2seq':
         LoaderClass = AutoModelForSeq2SeqLM
-        trust_remote_code = False
     else:
         LoaderClass = AutoModelForCausalLM
-        trust_remote_code = False
 
     # Load the model in simple 16-bit mode by default
     if not any([shared.args.cpu, shared.args.load_in_8bit, shared.args.wbits, shared.args.auto_devices, shared.args.disk, shared.args.gpu_memory is not None, shared.args.cpu_memory is not None, shared.args.deepspeed, shared.args.flexgen, shared.model_type in ['rwkv', 'llamacpp']]):


### PR DESCRIPTION
## Summary
I was having issues with some models not loading because `trust_remote_code` was `False`. Specifically with [bigcode/santacoder](https://huggingface.co/bigcode/santacoder). Which will get an error saying that `trust_remote_code` is false. Even when using the `--trust-remote-code` command-line parameter.

## In this PR
`modules/models.py` has been modified to always use the `--trust-remote-code` command-line parameter's existence as the value for the `trust_remote_code` argument for `from_pretrained()` in the AutoConfig and the LoaderClass.

## What does this fix?
This fixes the loading of models that didn't load even with `--trust-remote-code` set.