### PR TITLE
Update gradio dependency, to fix KeyError issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate==0.18.0
 colorama
 datasets
 flexgen==0.1.7
-gradio==3.25.0
+gradio==3.28.3
 markdown
 numpy
 pandas


### PR DESCRIPTION
Fixes https://github.com/oobabooga/text-generation-webui/issues/1825 for me. I'm on Ubuntu 20, and installing onto a clean micromamba environment - reinstalled from scratch using this, and it seems to work.

More testing probably needed :)