### PR TITLE
Use a random seed, instead of the fixed seed 0

### DIFF
--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -23,7 +23,7 @@ class LlamaCppModel:
         params = {
             'model_path': str(path),
             'n_ctx': 2048,
-            'seed': 0,
+            'seed': -1,
             'n_threads': shared.args.threads or None,
             'n_batch': shared.args.n_batch,
             'use_mmap': not shared.args.no_mmap,


### PR DESCRIPTION
I recently started using this repo and downloaded https://huggingface.co/MetaIX/Alpaca-30B-Int4 as my model. Quickly noticed that the model always gives the same output for a given input. Turns out, llama models are always run with 0 as seed, instead of -1 for random.