### PR TITLE
Add error message when GPTQ-for-LLaMa import fails

### DIFF
--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -12,13 +12,12 @@ from transformers import AutoConfig, AutoModelForCausalLM
 import modules.shared as shared
 
 sys.path.insert(0, str(Path("repositories/GPTQ-for-LLaMa")))
+
 try:
     import llama_inference_offload
 except ImportError:
-    import logging
     logging.error('Failed to load GPTQ-for-LLaMa')
     logging.error('See https://github.com/oobabooga/text-generation-webui/blob/main/docs/GPTQ-models-(4-bit-mode).md')
-    import sys
     sys.exit(-1)
 
 try:

--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -12,7 +12,14 @@ from transformers import AutoConfig, AutoModelForCausalLM
 import modules.shared as shared
 
 sys.path.insert(0, str(Path("repositories/GPTQ-for-LLaMa")))
-import llama_inference_offload
+try:
+    import llama_inference_offload
+except ImportError:
+    import logging
+    logging.error('Failed to load GPTQ-for-LLaMa')
+    logging.error('See https://github.com/oobabooga/text-generation-webui/blob/main/docs/GPTQ-models-(4-bit-mode).md')
+    import sys
+    sys.exit(-1)
 
 try:
     from modelutils import find_layers


### PR DESCRIPTION
I'm of the opinion that users should *not* have to Google random error messages for 30 minutes when a program crashes, so I decided to do something constructive and add helpful instructions for when loading a GPTQ model fails.

EDIT: FWIW, a super helpful improvement would be to check in GPTQ-for-LLaMa as a git submodule; that way `git submodule update --init` would automatically download the external dependency without having to follow an extra documentation page in the first place.