### PR TITLE
Allow extensions to wrap `generate_reply`

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -12,7 +12,7 @@ import transformers
 import modules.shared as shared
 from modules.callbacks import (Iteratorize, Stream,
                                _SentinelTokenStoppingCriteria)
-from modules.extensions import apply_extensions
+from modules.extensions import apply_extensions, wrap_method
 from modules.html_generator import generate_4chan_html, generate_basic_html
 from modules.models import clear_torch_cache, local_rank
 
@@ -141,7 +141,7 @@ def set_manual_seed(seed):
 def stop_everything_event():
     shared.stop_everything = True
 
-
+@wrap_method
 def generate_reply(question, state, eos_token=None, stopping_strings=[]):
     state = apply_extensions('state', state)
     generate_func = apply_extensions('custom_generate_reply')


### PR DESCRIPTION
**What**

I added a `wrap_method` decorator to `modules/extensions.py`, which can be used to easily mark methods to be "wrappable" by extensions.

For now, I only marked `generate_reply`, which allows extensions to modify either the input or the full output of this method. However, in our own code, we also wrap `extensions.api.util.build_parameters` to add some extra data to requests.

**Why**

I'm using this app to host models within my team and we currently monkey-patch utilities into it, which obviously breaks with each update. The current extension methods don't fulfill our needs and I I also can't really upstream our changes, because they don't really belong in the core of this server.

If this is merged, I could also possibly share the extension we use to log all prompts+results into MLFlow

---

I'm not sure this PR fits the "philosopy" of how this app currently works, but it works quite well for us, to create simple extensions.