### PR TITLE
Fix - .DS_Store files should be ignored in the models and loras lists

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -15,9 +15,9 @@ def natural_keys(text):
 
 def get_available_models():
     if shared.args.flexgen:
-        return sorted([re.sub('-np$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if item.name.endswith('-np')], key=natural_keys)
+        return sorted([re.sub('-np$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if item.name.endswith('-np') and not item.name.startswith('.DS_Store')], key=natural_keys)
     else:
-        return sorted([re.sub('.pth$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json', '.yaml'))], key=natural_keys)
+        return sorted([re.sub('.pth$', '', item.name) for item in list(Path(f'{shared.args.model_dir}/').glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.DS_Store'))], key=natural_keys)
 
 
 def get_available_presets():
@@ -54,7 +54,7 @@ def get_available_softprompts():
 
 
 def get_available_loras():
-    return sorted([item.name for item in list(Path(shared.args.lora_dir).glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json'))], key=natural_keys)
+    return sorted([item.name for item in list(Path(shared.args.lora_dir).glob('*')) if not item.name.endswith(('.txt', '-np', '.pt', '.json', '.DS_Store'))], key=natural_keys)
 
 
 def get_datasets(path: str, ext: str):


### PR DESCRIPTION
For some reason on macOS, `.DS_Store` files are shown in the models and loras lists.  
The reason is the wildcard in the `.glob('*')` method.

<img width="288" alt="ds-models" src="https://user-images.githubusercontent.com/1554207/236837904-9dad01d3-be6b-41c0-bd12-897bb1f2b5fa.png"> <img width="289" alt="ds-loras" src="https://user-images.githubusercontent.com/1554207/236837920-f2fba8b7-fa84-4e51-b5d7-9c0806dc5949.png">

This PR add conditions to ignore them. There's probably a better way to to that globally?
Code tested on my Mac and it works.