### PR TITLE
Fix trust_remote_code in wrong location

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -160,12 +160,14 @@ def load_model(model_name):
 
     # Custom
     else:
-        params = {"low_cpu_mem_usage": True}
+        params = {
+          "low_cpu_mem_usage": True,
+          "trust_remote_code": trust_remote_code
+        }
+        
         if not any((shared.args.cpu, torch.cuda.is_available(), torch.has_mps)):
             logging.warning("torch.cuda.is_available() returned False. This means that no GPU has been detected. Falling back to CPU mode.")
             shared.args.cpu = True
-
-        params["trust_remote_code"] = trust_remote_code
 
         if shared.args.cpu:
             params["torch_dtype"] = torch.float32
@@ -286,6 +288,7 @@ def load_soft_prompt(name):
                         logging.info(f"{field}: {', '.join(j[field])}")
                     else:
                         logging.info(f"{field}: {j[field]}")
+                        
             logging.info()
             tensor = np.load('tensor.npy')
             Path('tensor.npy').unlink()

--- a/modules/models.py
+++ b/modules/models.py
@@ -165,11 +165,12 @@ def load_model(model_name):
             logging.warning("torch.cuda.is_available() returned False. This means that no GPU has been detected. Falling back to CPU mode.")
             shared.args.cpu = True
 
+        params["trust_remote_code"] = trust_remote_code
+
         if shared.args.cpu:
             params["torch_dtype"] = torch.float32
         else:
             params["device_map"] = 'auto'
-            params["trust_remote_code"] = trust_remote_code
             if shared.args.load_in_8bit and any((shared.args.auto_devices, shared.args.gpu_memory)):
                 params['quantization_config'] = BitsAndBytesConfig(load_in_8bit=True, llm_int8_enable_fp32_cpu_offload=True)
             elif shared.args.load_in_8bit:


### PR DESCRIPTION
Running models that need "trust_remote_code" will fail when running in --cpu (CPU-only) mode, because this check is in the wrong location.

This simple change fixes the issue of loading MPT models in CPU-only mode, for example.

See https://github.com/oobabooga/text-generation-webui/issues/1828#issuecomment-1539165119