### PR TITLE
Fix `custom_generate_chat_prompt`

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -78,6 +78,7 @@ def _apply_custom_generate_chat_prompt(text, state, **kwargs):
     custom_generate_chat_prompt = None
     for extension, _ in iterator():
         if hasattr(extension, 'custom_generate_chat_prompt'):
+            custom_generate_chat_prompt = extension.custom_generate_chat_prompt
             return custom_generate_chat_prompt(text, state, **kwargs)
 
     return None

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -75,11 +75,9 @@ def _apply_input_hijack(text, visible_text):
 
 # custom_generate_chat_prompt handling - currently only the first one will work
 def _apply_custom_generate_chat_prompt(text, state, **kwargs):
-    custom_generate_chat_prompt = None
     for extension, _ in iterator():
         if hasattr(extension, 'custom_generate_chat_prompt'):
-            custom_generate_chat_prompt = extension.custom_generate_chat_prompt
-            return custom_generate_chat_prompt(text, state, **kwargs)
+            return extension.custom_generate_chat_prompt(text, state, **kwargs)
 
     return None
 


### PR DESCRIPTION
Fix to allow `custom_generate_chat_prompt` to be loaded from extensions again rather than throwing a TypeError.