### PR TITLE
Add api port options

### DIFF
--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -2,10 +2,6 @@ import extensions.api.blocking_api as blocking_api
 import extensions.api.streaming_api as streaming_api
 from modules import shared
 
-BLOCKING_PORT = 5000
-STREAMING_PORT = 5005
-
-
 def setup():
-    blocking_api.start_server(BLOCKING_PORT, share=shared.args.public_api)
-    streaming_api.start_server(STREAMING_PORT, share=shared.args.public_api)
+    blocking_api.start_server(shared.args.api_blocking_port, share=shared.args.public_api)
+    streaming_api.start_server(shared.args.api_streaming_port, share=shared.args.public_api)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -158,6 +158,8 @@ parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authent
 
 # API
 parser.add_argument('--api', action='store_true', help='Enable the API extension.')
+parser.add_argument('--api-blocking-port', type=int, default=5000, help='The listening port for the blocking API.')
+parser.add_argument('--api-streaming-port', type=int,  default=5005, help='The listening port for the streaming API.')
 parser.add_argument('--public-api', action='store_true', help='Create a public URL for the API using Cloudfare.')
 
 # Multimodal


### PR DESCRIPTION
I found it useful to be able to set a custom port for the API (instead of the default 5000 and 5005 for the blocking and streaming APIs respectively).
I simply added two argument parser options (one for blocking API port and one for streaming API port) and used this argument in the right place (script.py)