### PR TITLE
Add api endpoint to initiate stop

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -4,7 +4,7 @@ from threading import Thread
 
 from extensions.api.util import build_parameters, try_start_cloudflared
 from modules import shared
-from modules.text_generation import encode, generate_reply
+from modules.text_generation import encode, generate_reply, stop_everything_event
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -14,6 +14,15 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             response = json.dumps({
                 'result': shared.model_name
+            })
+
+            self.wfile.write(response.encode('utf-8'))
+        elif self.path == '/api/v1/stop':
+            stop_everything_event()
+            self.send_response(200)
+            self.end_headers()
+            response = json.dumps({
+                'status': 'stopping'
             })
 
             self.wfile.write(response.encode('utf-8'))


### PR DESCRIPTION
Simple change to make it possible to generation via an API route.
I made it a get method rather than a post so that you don't have send a payload or change the existing parsing on post requests.