### PR TITLE
Add stream API port to docker compose

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -21,5 +21,10 @@ HOST_API_PORT=5000
 # the port the api binds to inside the container
 CONTAINER_API_PORT=5000
 
+# the port the api stream endpoint binds to on the host
+HOST_API_STREAM_PORT=5005
+# the port the api stream endpoint binds to inside the container
+CONTAINER_API_STREAM_PORT=5005
+
 # the version used to install text-generation-webui from
 WEBUI_VERSION=HEAD

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - "${HOST_PORT}:${CONTAINER_PORT}"
       - "${HOST_API_PORT}:${CONTAINER_API_PORT}"
+      - "${HOST_API_STREAM_PORT}:${CONTAINER_API_STREAM_PORT}"
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
Very minor change. Connection to stream api endpoint would be refused because of missing ports in `docker-compose.yaml`.