### PR TITLE
revert inserting extra space in get_reply_from_output_ids(). Fixes #1791

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -109,11 +109,6 @@ def get_reply_from_output_ids(output_ids, input_ids, original_question, state, i
     else:
         new_tokens = len(output_ids) - len(input_ids[0])
         reply = decode(output_ids[-new_tokens:], state['skip_special_tokens'])
-
-        if type(shared.tokenizer) is transformers.LlamaTokenizer:
-            if len(original_question) > 0 and original_question[-1] not in [' ', '\n']:
-                reply = ' ' + reply
-
         if not is_chat:
             reply = original_question + apply_extensions('output', reply)
 


### PR DESCRIPTION
I don't really understand why this is here, but it breaks a variety of formatted text outputs like python code, continuations, etc. So remove it.