### PR TITLE
Vicuna instruction templates space removal, huge quality improvement

### DIFF
--- a/characters/instruction-following/StableVicuna.yaml
+++ b/characters/instruction-following/StableVicuna.yaml
@@ -1,4 +1,4 @@
 user: "### Human:"
 bot: "### Assistant:"
-turn_template: "<|user|> <|user-message|>\n<|bot|> <|bot-message|>\n\n"
+turn_template: "<|user|> <|user-message|>\n<|bot|><|bot-message|>\n\n"
 context: "### Assistant: I am StableVicuna, a large language model created by CarperAI. I am here to chat!\n\n"

--- a/characters/instruction-following/Vicuna-v0.yaml
+++ b/characters/instruction-following/Vicuna-v0.yaml
@@ -1,4 +1,4 @@
 user: "### Human:"
 bot: "### Assistant:"
-turn_template: "<|user|> <|user-message|>\n<|bot|> <|bot-message|>\n"
+turn_template: "<|user|> <|user-message|>\n<|bot|><|bot-message|>\n"
 context: "A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions.\n\n"

--- a/characters/instruction-following/Vicuna-v1.1.yaml
+++ b/characters/instruction-following/Vicuna-v1.1.yaml
@@ -1,4 +1,4 @@
 user: "USER:"
 bot: "ASSISTANT:"
-turn_template: "<|user|> <|user-message|>\n<|bot|> <|bot-message|></s>\n"
+turn_template: "<|user|> <|user-message|>\n<|bot|><|bot-message|></s>\n"
 context: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n\n"

--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -520,6 +520,10 @@ class Handler(BaseHTTPRequestHandler):
             for a in generator:
                 answer = a
 
+            # hack to eat an extra leading space
+            if instruction_template[-1] not in [' ', '\n'] and answer[0] == ' ':
+                answer = answer[1:]
+
             completion_token_count = len(encode(answer)[0])
 
             resp = {


### PR DESCRIPTION
@oobabooga 
I'm seeing massive quality improvements after removing the space after the <|bot|> entry in the 3 vicuna instruction templates - it's now Koala like in format and performance. The bot always leads with the space itself.

Additionally, in the openai/edits I remove the extra leading space when using templates with no leading space.

With this change I'm getting 'perfect' output now from Vicuna's using the openai.Edit() interface. As well as correct, no extra space, outputs from the normal completion interfaces - since your changes.

Working great!

For reference, compare the Koala and Vicuna templates here:
https://github.com/lm-sys/FastChat/blob/main/fastchat/conversation.py

I tested against:
TheBloke_wizard-vicuna-13B-GPTQ
TheBloke_stable-vicuna-13B-GPTQ
TheBloke_vicuna-13B-1.1-GPTQ-4bit-128g