### PR TITLE
Clarify how to start server.py with multimodal API support

### DIFF
--- a/extensions/multimodal/README.md
+++ b/extensions/multimodal/README.md
@@ -57,7 +57,10 @@ This extension uses the following parameters (from `settings.json`):
 
 ## Usage through API
 
-You can run the multimodal inference through API, by inputting the images to prompt. Images are embedded like so: `f'<img src="data:image/jpeg;base64,{img_str}">'`, where `img_str` is base-64 jpeg data. Note that you will need to launch `server.py` with the arguments `--api --extensions multimodal`. Python example:
+You can run the multimodal inference through API, by inputting the images to prompt. Images are embedded like so: `f'<img src="data:image/jpeg;base64,{img_str}">'`, where `img_str` is base-64 jpeg data. Note that you will need to launch `server.py` with the arguments `--api --extensions multimodal`. 
+
+Python example:
+
 ```Python
 import base64
 import requests

--- a/extensions/multimodal/README.md
+++ b/extensions/multimodal/README.md
@@ -57,7 +57,7 @@ This extension uses the following parameters (from `settings.json`):
 
 ## Usage through API
 
-You can run the multimodal inference through API, by inputting the images to prompt. Images are embedded like so: `f'<img src="data:image/jpeg;base64,{img_str}">'`, where `img_str` is base-64 jpeg data. Python example:
+You can run the multimodal inference through API, by inputting the images to prompt. Images are embedded like so: `f'<img src="data:image/jpeg;base64,{img_str}">'`, where `img_str` is base-64 jpeg data. Note that you will need to launch `server.py` with the arguments `--api --extensions multimodal`. Python example:
 ```Python
 import base64
 import requests


### PR DESCRIPTION
At the moment it seems I need to pass both `--api` and `--extensions multimodal` to get multimodal support working using the API (this isn't necessary for `--chat` mode). This PR updates the docs to state that.