### PR TITLE
Fix the API example for missing stream key error

### DIFF
--- a/api-example.py
+++ b/api-example.py
@@ -28,6 +28,7 @@ def run(prompt):
         'add_bos_token': True,
         'truncation_length': 2048,
         'ban_eos_token': False,
+        'stream': False,
         'skip_special_tokens': True,
         'stopping_strings': []
     }


### PR DESCRIPTION
Missing stream value in request parameters will cause an exception in text_generation.py.

```bash
text-generation-webui/modules/text_generation.py", line 245, in generate_reply_HF
    if not state['stream']:
KeyError: 'stream'
```