### PR TITLE
[extensions/openai] clip extra leading space

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -520,6 +520,10 @@ class Handler(BaseHTTPRequestHandler):
             for a in generator:
                 answer = a
 
+            # some reply's have an extra leading space to fit the instruction template, just clip it off from the reply.
+            if edit_task[-1] != '\n' and answer and answer[0] == ' ':
+                answer = answer[1:]
+
             completion_token_count = len(encode(answer)[0])
 
             resp = {


### PR DESCRIPTION
with rstrip in the template expansion now, we can safely clip an extra space if it's returned for some models.