### PR TITLE
Update llama-cpp-python from 0.1.45 to 0.1.50

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ tqdm
 git+https://github.com/huggingface/peft
 transformers==4.28.1
 bitsandbytes==0.38.1; platform_system != "Windows"
-llama-cpp-python==0.1.45; platform_system != "Windows"
-https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.45/llama_cpp_python-0.1.45-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+llama-cpp-python==0.1.50; platform_system != "Windows"
+hhttps://github.com/abetlen/llama-cpp-python/releases/download/v0.1.50/llama_cpp_python-0.1.50-cp310-cp310-win_amd64.whl; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ git+https://github.com/huggingface/peft
 transformers==4.28.1
 bitsandbytes==0.38.1; platform_system != "Windows"
 llama-cpp-python==0.1.50; platform_system != "Windows"
-hhttps://github.com/abetlen/llama-cpp-python/releases/download/v0.1.50/llama_cpp_python-0.1.50-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.50/llama_cpp_python-0.1.50-cp310-cp310-win_amd64.whl; platform_system == "Windows"


### PR DESCRIPTION
The ggml format was updated again so newly created models might require a newer llama.cpp version.

This should fix the following open issues:

- https://github.com/oobabooga/text-generation-webui/issues/2020
- https://github.com/oobabooga/text-generation-webui/issues/2046
- https://github.com/oobabooga/text-generation-webui/issues/2000