### PR TITLE
Add superbooga time weighted history retrieval

### DIFF
--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -76,7 +76,7 @@ class ChromaCollector(Collecter):
         return [x for _, x in sorted(zip(ids, documents))]
 
     # Multiply distance by factor within [min_time_weight, 1] where more recent is lower
-    def apply_time_weight_to_distances(self, ids: list[int], distances: list[float], min_time_weight: float = 1.0):
+    def apply_time_weight_to_distances(self, ids: list[int], distances: list[float], min_time_weight: float = 1.0) -> list[float]:
         if len(self.ids) <= 1: return distances.copy()
         return [distance * (_id / (len(self.ids)-1) * min_time_weight - _id / (len(self.ids)-1) + 1) for _id, distance in zip(ids, distances)]
 

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -45,16 +45,9 @@ class ChromaCollector(Collecter):
         self.ids = [f"id{i}" for i in range(len(texts))]
         self.collection.add(documents=texts, ids=self.ids)
 
-    def get_documents_and_ids(self, search_strings: list[str], n_results: int):
+    def get_documents_ids_distances(self, search_strings: list[str], n_results: int):
         n_results = min(len(self.ids), n_results)
         result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents'])
-        documents = result['documents'][0]
-        ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
-        return documents, ids
-
-    def get_documents_and_ids_and_distances(self, search_strings: list[str], n_results: int):
-        n_results = min(len(self.ids), n_results)
-        result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents', 'distances'])
         documents = result['documents'][0]
         ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
         distances = result['distances'][0]
@@ -62,38 +55,43 @@ class ChromaCollector(Collecter):
 
     # Get chunks by similarity
     def get(self, search_strings: list[str], n_results: int) -> list[str]:
-        documents, _ = self.get_documents_and_ids(search_strings, n_results)
+        documents, _, _ = self.get_documents_ids_distances(search_strings, n_results)
         return documents
 
     # Get ids by similarity
     def get_ids(self, search_strings: list[str], n_results: int) -> list[str]:
-        _ , ids = self.get_documents_and_ids(search_strings, n_results)
+        _, ids, _ = self.get_documents_ids_distances(search_strings, n_results)
         return ids
 
     # Get chunks by similarity and then sort by insertion order
     def get_sorted(self, search_strings: list[str], n_results: int) -> list[str]:
-        documents, ids = self.get_documents_and_ids(search_strings, n_results)
+        documents, ids, _ = self.get_documents_ids_distances(search_strings, n_results)
         return [x for _, x in sorted(zip(ids, documents))]
 
     # Multiply distance by factor within [min_time_weight, 1] where more recent is lower
     def apply_time_weight_to_distances(self, ids: list[int], distances: list[float], min_time_weight: float = 1.0) -> list[float]:
-        if len(self.ids) <= 1: return distances.copy()
-        return [distance * (_id / (len(self.ids)-1) * min_time_weight - _id / (len(self.ids)-1) + 1) for _id, distance in zip(ids, distances)]
+        if len(self.ids) <= 1:
+            return distances.copy()
+
+        return [distance * (_id / (len(self.ids) - 1) * min_time_weight - _id / (len(self.ids) - 1) + 1) for _id, distance in zip(ids, distances)]
 
     # Get ids by similarity and then sort by insertion order
     def get_ids_sorted(self, search_strings: list[str], n_results: int, n_initial: int = None, min_time_weight: float = 1.0) -> list[str]:
         do_time_weight = min_time_weight != 1
         if not (do_time_weight and n_initial):
             n_initial = n_results
+
         if n_initial < n_results:
             raise ValueError(f"n_initial {n_initial} should be >= n_results {n_results}")
-        _ , ids , distances = self.get_documents_and_ids_and_distances(search_strings, n_initial)
+
+        _, ids, distances = self.get_documents_ids_distances(search_strings, n_initial)
         if do_time_weight:
             distances_w = self.apply_time_weight_to_distances(ids, distances, min_time_weight=min_time_weight)
             results = zip(ids, distances, distances_w)
-            results = sorted(results, key = lambda x: x[2])[:n_results]
-            results = sorted(results, key = lambda x: x[0])
+            results = sorted(results, key=lambda x: x[2])[:n_results]
+            results = sorted(results, key=lambda x: x[0])
             ids = [x[0] for x in results]
+
         return sorted(ids)
 
     def clear(self):

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -78,7 +78,7 @@ class ChromaCollector(Collecter):
         if len(self.ids) <= 1:
             return distances.copy()
 
-        return [distance * (_id / (len(self.ids) - 1) * min_time_weight - _id / (len(self.ids) - 1) + 1) for _id, distance in zip(ids, distances)]
+        return [distance * (1 - _id / (len(self.ids) - 1) * (1 - min_time_weight)) for _id, distance in zip(ids, distances)]
 
     # Get ids by similarity and then sort by insertion order
     def get_ids_sorted(self, search_strings: list[str], n_results: int, n_initial: int = None, min_time_weight: float = 1.0) -> list[str]:

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -52,6 +52,14 @@ class ChromaCollector(Collecter):
         ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
         return documents, ids
 
+    def get_documents_and_ids_and_distances(self, search_strings: list[str], n_results: int):
+        n_results = min(len(self.ids), n_results)
+        result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents', 'distances'])
+        documents = result['documents'][0]
+        ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
+        distances = result['distances'][0]
+        return documents, ids, distances
+
     # Get chunks by similarity
     def get(self, search_strings: list[str], n_results: int) -> list[str]:
         documents, _ = self.get_documents_and_ids(search_strings, n_results)
@@ -67,9 +75,25 @@ class ChromaCollector(Collecter):
         documents, ids = self.get_documents_and_ids(search_strings, n_results)
         return [x for _, x in sorted(zip(ids, documents))]
 
+    # Multiply distance by factor within [min_time_weight, 1] where more recent is lower
+    def apply_time_weight_to_distances(self, ids: list[int], distances: list[float], min_time_weight: float = 1.0):
+        if len(self.ids) <= 1: return distances.copy()
+        return [distance * (_id / (len(self.ids)-1) * min_time_weight - _id / (len(self.ids)-1) + 1) for _id, distance in zip(ids, distances)]
+
     # Get ids by similarity and then sort by insertion order
-    def get_ids_sorted(self, search_strings: list[str], n_results: int) -> list[str]:
-        _ , ids = self.get_documents_and_ids(search_strings, n_results)
+    def get_ids_sorted(self, search_strings: list[str], n_results: int, n_initial: int = None, min_time_weight: float = 1.0) -> list[str]:
+        do_time_weight = min_time_weight != 1
+        if not (do_time_weight and n_initial):
+            n_initial = n_results
+        if n_initial < n_results:
+            raise ValueError(f"n_initial {n_initial} should be >= n_results {n_results}")
+        _ , ids , distances = self.get_documents_and_ids_and_distances(search_strings, n_initial)
+        if do_time_weight:
+            distances_w = self.apply_time_weight_to_distances(ids, distances, min_time_weight=min_time_weight)
+            results = zip(ids, distances, distances_w)
+            results = sorted(results, key = lambda x: x[2])[:n_results]
+            results = sorted(results, key = lambda x: x[0])
+            ids = [x[0] for x in results]
         return sorted(ids)
 
     def clear(self):

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -83,8 +83,10 @@ class ChromaCollector(Collecter):
     # Get ids by similarity and then sort by insertion order
     def get_ids_sorted(self, search_strings: list[str], n_results: int, n_initial: int = None, time_weight: float = 1.0) -> list[str]:
         do_time_weight = time_weight > 0
-        if not (do_time_weight and n_initial):
+        if not (do_time_weight and n_initial is not None):
             n_initial = n_results
+        elif n_initial == -1:
+            n_initial = len(self.ids)
 
         if n_initial < n_results:
             raise ValueError(f"n_initial {n_initial} should be >= n_results {n_results}")

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -52,7 +52,7 @@ class ChromaCollector(Collecter):
         if n_results == 0:
             return [], []
 
-        result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents'])
+        result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents', 'distances'])
         documents = result['documents'][0]
         ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
         distances = result['distances'][0]

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -73,16 +73,16 @@ class ChromaCollector(Collecter):
         documents, ids, _ = self.get_documents_ids_distances(search_strings, n_results)
         return [x for _, x in sorted(zip(ids, documents))]
 
-    # Multiply distance by factor within [min_time_weight, 1] where more recent is lower
-    def apply_time_weight_to_distances(self, ids: list[int], distances: list[float], min_time_weight: float = 1.0) -> list[float]:
+    # Multiply distance by factor within [0, time_weight] where more recent is lower
+    def apply_time_weight_to_distances(self, ids: list[int], distances: list[float], time_weight: float = 1.0) -> list[float]:
         if len(self.ids) <= 1:
             return distances.copy()
 
-        return [distance * (1 - _id / (len(self.ids) - 1) * (1 - min_time_weight)) for _id, distance in zip(ids, distances)]
+        return [distance * (1 - _id / (len(self.ids) - 1) * time_weight) for _id, distance in zip(ids, distances)]
 
     # Get ids by similarity and then sort by insertion order
-    def get_ids_sorted(self, search_strings: list[str], n_results: int, n_initial: int = None, min_time_weight: float = 1.0) -> list[str]:
-        do_time_weight = min_time_weight != 1
+    def get_ids_sorted(self, search_strings: list[str], n_results: int, n_initial: int = None, time_weight: float = 1.0) -> list[str]:
+        do_time_weight = time_weight > 0
         if not (do_time_weight and n_initial):
             n_initial = n_results
 
@@ -91,7 +91,7 @@ class ChromaCollector(Collecter):
 
         _, ids, distances = self.get_documents_ids_distances(search_strings, n_initial)
         if do_time_weight:
-            distances_w = self.apply_time_weight_to_distances(ids, distances, min_time_weight=min_time_weight)
+            distances_w = self.apply_time_weight_to_distances(ids, distances, time_weight=time_weight)
             results = zip(ids, distances, distances_w)
             results = sorted(results, key=lambda x: x[2])[:n_results]
             results = sorted(results, key=lambda x: x[0])

--- a/extensions/superbooga/script.py
+++ b/extensions/superbooga/script.py
@@ -242,7 +242,7 @@ def ui():
                 chunk_count = gr.Number(value=params['chunk_count'], label='Chunk count', info='The number of closest-matching chunks to include in the prompt.')
                 gr.Markdown('Time weighting (optional, used in to make recently added chunks more likely to appear)')
                 time_weight = gr.Slider(0, 1, value=params['time_weight'], label='Time weight', info='Defines the strength of the time weighting. 0 = no time weighting.')
-                chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count. Only used if time_weight != 1.')
+                chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count. Only used if time_weight > 0.')
 
                 update_settings = gr.Button('Apply changes')
 

--- a/extensions/superbooga/script.py
+++ b/extensions/superbooga/script.py
@@ -22,9 +22,6 @@ params = {
 
 collector = make_collector()
 chat_collector = make_collector()
-chunk_count = 5
-chunk_count_initial = 10
-min_time_weight = 1.0
 
 
 def feed_data_into_collector(corpus, chunk_len, chunk_sep):
@@ -86,17 +83,12 @@ def feed_url_into_collector(urls, chunk_len, chunk_sep, strong_cleanup, threads)
         yield i
 
 
-def apply_settings(_chunk_count, _chunk_count_initial, _min_time_weight):
-    global chunk_count, chunk_count_initial, min_time_weight
-    chunk_count = int(_chunk_count)
-    chunk_count_initial = int(_chunk_count_initial)
-    min_time_weight = _min_time_weight
-    settings_to_display = {
-        'chunk_count': chunk_count,
-        'chunk_count_initial': chunk_count_initial,
-        'min_time_weight': min_time_weight,
-    }
-
+def apply_settings(chunk_count, chunk_count_initial, min_time_weight):
+    global params
+    params['chunk_count'] = int(chunk_count)
+    params['chunk_count_initial'] = int(chunk_count_initial)
+    params['min_time_weight'] = min_time_weight
+    settings_to_display = {k: params[k] for k in params if k in ['chunk_count', 'chunk_count_initial', 'min_time_weight']}
     yield f"The following settings are now active: {str(settings_to_display)}"
 
 
@@ -104,7 +96,7 @@ def custom_generate_chat_prompt(user_input, state, **kwargs):
     global chat_collector
 
     if state['mode'] == 'instruct':
-        results = collector.get_sorted(user_input, n_results=chunk_count)
+        results = collector.get_sorted(user_input, n_results=params['chunk_count'])
         additional_context = '\nYour reply should be based on the context below:\n\n' + '\n'.join(results)
         user_input += additional_context
     else:
@@ -115,7 +107,7 @@ def custom_generate_chat_prompt(user_input, state, **kwargs):
             output += f"{state['name2']}: {shared.history['internal'][id_][1]}\n"
             return output
 
-        if len(shared.history['internal']) > chunk_count and user_input != '':
+        if len(shared.history['internal']) > params['chunk_count'] and user_input != '':
             chunks = []
             hist_size = len(shared.history['internal'])
             for i in range(hist_size-1):
@@ -124,7 +116,7 @@ def custom_generate_chat_prompt(user_input, state, **kwargs):
             add_chunks_to_collector(chunks, chat_collector)
             query = '\n'.join(shared.history['internal'][-1] + [user_input])
             try:
-                best_ids = chat_collector.get_ids_sorted(query, n_results=chunk_count, n_initial=chunk_count_initial, min_time_weight=min_time_weight)
+                best_ids = chat_collector.get_ids_sorted(query, n_results=params['chunk_count'], n_initial=params['chunk_count_initial'], min_time_weight=params['min_time_weight'])
                 additional_context = '\n'
                 for id_ in best_ids:
                     if shared.history['internal'][id_][0] != '<|BEGIN-VISIBLE-CHAT|>':
@@ -155,7 +147,7 @@ def input_modifier(string):
         user_input = match.group(1).strip()
 
         # Get the most similar chunks
-        results = collector.get_sorted(user_input, n_results=chunk_count)
+        results = collector.get_sorted(user_input, n_results=params['chunk_count'])
 
         # Make the injection
         string = string.replace('<|injection-point|>', '\n'.join(results))
@@ -244,8 +236,11 @@ def ui():
 
             with gr.Tab("Generation settings"):
                 chunk_count = gr.Number(value=params['chunk_count'], label='Chunk count', info='The number of closest-matching chunks to include in the prompt.')
-                chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count.')
-                min_time_weight = gr.Number(value=params['min_time_weight'], label='Minimum time weight', info='Time weight will range from this value to 1, with more recent chunks receiving lower weight (higher priority). Set to 1 to disable time weight.')
+                gr.Markdown('Time weighting (optional, used in chat mode to make recent messages more likely to appear)')
+                with gr.Row():
+                    min_time_weight = gr.Number(value=params['min_time_weight'], label='Minimum time weight', info='Time weight will range from this value to 1, with more recent chunks receiving lower weight (higher priority). Set to 1 to disable time weight.')
+                    chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count. Only used if min_time_weight != 1.')
+
                 update_settings = gr.Button('Apply changes')
 
             chunk_len = gr.Number(value=params['chunk_length'], label='Chunk length', info='In characters, not tokens. This value is used when you click on "Load data".')

--- a/extensions/superbooga/script.py
+++ b/extensions/superbooga/script.py
@@ -240,7 +240,7 @@ def ui():
 
             with gr.Tab("Generation settings"):
                 chunk_count = gr.Number(value=params['chunk_count'], label='Chunk count', info='The number of closest-matching chunks to include in the prompt.')
-                gr.Markdown('Time weighting (optional, used in chat mode to make recent messages more likely to appear)')
+                gr.Markdown('Time weighting (optional, used in to make recently added chunks more likely to appear)')
                 with gr.Row():
                     min_time_weight = gr.Number(value=params['min_time_weight'], label='Minimum time weight', info='Time weight will range from this value to 1, with more recent chunks receiving lower weight (higher priority). Set to 1 to disable time weight.')
                     chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count. Only used if min_time_weight != 1.')

--- a/extensions/superbooga/script.py
+++ b/extensions/superbooga/script.py
@@ -242,7 +242,7 @@ def ui():
                 chunk_count = gr.Number(value=params['chunk_count'], label='Chunk count', info='The number of closest-matching chunks to include in the prompt.')
                 gr.Markdown('Time weighting (optional, used in to make recently added chunks more likely to appear)')
                 time_weight = gr.Slider(0, 1, value=params['time_weight'], label='Time weight', info='Defines the strength of the time weighting. 0 = no time weighting.')
-                chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count. Only used if time_weight > 0.')
+                chunk_count_initial = gr.Number(value=params['chunk_count_initial'], label='Initial chunk count', info='The number of closest-matching chunks retrieved for time weight reordering in chat mode. This should be >= chunk count. -1 = All chunks are retrieved. Only used if time_weight > 0.')
 
                 update_settings = gr.Button('Apply changes')
 


### PR DESCRIPTION
# Problem
During a long chat session, information about the characters and their environment may be described or change more than once. For example:
```
Assistant: I am wearing a red shirt.
...a few messages later...
Assistant: I am wearing a blue shirt.
```
If the user were to later query `What color is your shirt?`, the first message `...red shirt`, which is now outdated, may be retrieved as context instead of the second `...blue shirt`.

# Solution
This PR adds an option to apply time weighting to distance values. This might help break ties between similar history input/reply pairs by prioritizing more recent ones.

The time weight is linear within [`min_time_weight`, 1] where more recent history pairs are given smaller time weight values (to decrease the distance). Time weighting is disabled when `min_time_weight` = 1.

# Procedure
1. Retrieve top `n_initial` (where `n_initial` >= `n_results`) most similar documents from vector store.
2. Apply time weights to these documents' distances.
3. Sort the documents in ascending order by time-weighted distance.
4. Truncate the list of documents. Keep only the first `n_results` documents.
5. Sort the list again in ascending order by id.
6. Return the list of ids.

# Limitations
Suggestions for these, if any, are appreciated.
1. There might be better weighting schemes than this that I'm not aware of.

2. Ideally, we would do the time weighting on **all** distances, not just the subset retrieved by hnswlib/chromadb. Referring back to the example above, if the character changes clothes 500 times throughout your chat, but your `n_initial` = 50, that subset of 50 could still be anything from that 500 regardless of recency. I can only think of two ways to deal with this:
* Retrieve everything from the vector store (equivalent to `n_initial` = vector store size) and do all the calculations in Python. This won't scale well, but probably fine for small amounts of data.
* Fork hnswlib and insert the time weighting there. More complicated because hnswlib's custom distance functions accept the vectors only, and not ids, which we would need to calculate the time weights.

  As far as existing approaches, [Langchain's time weighted retriever](https://github.com/hwchase17/langchain/blob/master/langchain/retrievers/time_weighted_retriever.py#L23) just uses an initial k = 100 by default and does weighting on that subset.