### PR TITLE
fix: elevenlabs removed the need for the api key for refreshing voices

### DIFF
--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -19,7 +19,7 @@ wav_idx = 0
 
 def refresh_voices():
     global params
-    your_voices = elevenlabs.voices(api_key=params['api_key'])
+    your_voices = elevenlabs.voices()
     voice_names = [voice.name for voice in your_voices]
     return voice_names
 


### PR DESCRIPTION
As per [this commit](https://github.com/elevenlabs/elevenlabs-python/commit/ba8b1775354db2f6d865c35c38816c19f2a50258)
The `refresh_voices()` function now no longer takes the `api_key` parameter for security reasons. This was causing the error "TypeError: voices() got an unexpected keyword argument 'api_key'"