### PR TITLE
Experimental jank multiGPU inference that's 2x faster than native somehow

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Optionally, you can use the following command-line flags:
 | `--wbits WBITS`           | Load a pre-quantized model with specified precision in bits. 2, 3, 4 and 8 are supported. |
 | `--model_type MODEL_TYPE` | Model type of pre-quantized model. Currently LLaMA, OPT, and GPT-J are supported. |
 | `--groupsize GROUPSIZE`   | Group size. |
-| `--pre_layer PRE_LAYER`   | The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models. |
+| `--pre_layer PRE_LAYER`   | The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models. Use a comma-separated list for multi-GPU, eg `30,60`. |
 | `--checkpoint CHECKPOINT` | The path to the quantized checkpoint file. If not specified, it will be automatically detected. |
 | `--monkey-patch`          | Apply the monkey patch for using LoRAs with quantized models.
 | `--quant_attn`         | (triton) Enable quant attention. |

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Optionally, you can use the following command-line flags:
 | `--wbits WBITS`           | Load a pre-quantized model with specified precision in bits. 2, 3, 4 and 8 are supported. |
 | `--model_type MODEL_TYPE` | Model type of pre-quantized model. Currently LLaMA, OPT, and GPT-J are supported. |
 | `--groupsize GROUPSIZE`   | Group size. |
-| `--pre_layer PRE_LAYER`   | The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models. Use a comma-separated list for multi-GPU, eg `30,60`. |
+| `--pre_layer PRE_LAYER [PRE_LAYER ...]`  | The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models. For multi-gpu, write the numbers separated by spaces, eg `--pre_layer 30 60`. |
 | `--checkpoint CHECKPOINT` | The path to the quantized checkpoint file. If not specified, it will be automatically detected. |
 | `--monkey-patch`          | Apply the monkey patch for using LoRAs with quantized models.
 | `--quant_attn`         | (triton) Enable quant attention. |

--- a/docs/GPTQ-models-(4-bit-mode).md
+++ b/docs/GPTQ-models-(4-bit-mode).md
@@ -107,6 +107,8 @@ This is the performance:
 Output generated in 123.79 seconds (1.61 tokens/s, 199 tokens)
 ```
 
+You can also use multiple GPUs with `pre_layer` if using the oobabooga fork of GPTQ, eg `--pre_layer 30,60` will load a LLaMA-30B model half onto your first GPU and half onto your second, or `--pre_layer 20,40` will load 20 layers onto GPU-0, 20 layers onto GPU-1, and 20 layers offloaded to CPU.
+
 ## Using LoRAs in 4-bit mode
 
 At the moment, this feature is not officially supported by the relevant libraries, but a patch exists and is supported by this web UI: https://github.com/johnsmith0031/alpaca_lora_4bit

--- a/docs/GPTQ-models-(4-bit-mode).md
+++ b/docs/GPTQ-models-(4-bit-mode).md
@@ -107,7 +107,7 @@ This is the performance:
 Output generated in 123.79 seconds (1.61 tokens/s, 199 tokens)
 ```
 
-You can also use multiple GPUs with `pre_layer` if using the oobabooga fork of GPTQ, eg `--pre_layer 30,60` will load a LLaMA-30B model half onto your first GPU and half onto your second, or `--pre_layer 20,40` will load 20 layers onto GPU-0, 20 layers onto GPU-1, and 20 layers offloaded to CPU.
+You can also use multiple GPUs with `pre_layer` if using the oobabooga fork of GPTQ, eg `--pre_layer 30 60` will load a LLaMA-30B model half onto your first GPU and half onto your second, or `--pre_layer 20 40` will load 20 layers onto GPU-0, 20 layers onto GPU-1, and 20 layers offloaded to CPU.
 
 ## Using LoRAs in 4-bit mode
 

--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -172,7 +172,11 @@ def load_quantized(model_name):
 
     # qwopqwop200's offload
     if model_type == 'llama' and shared.args.pre_layer:
-        model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize, shared.args.pre_layer)
+        if not ',' in shared.args.pre_layer:
+            pre_layer = int(shared.args.pre_layer)
+        else:
+            pre_layer = [int(x.strip()) for x in shared.args.pre_layer.split(',')]
+        model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize, pre_layer)
     else:
         threshold = False if model_type == 'gptj' else 128
         model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize, kernel_switch_threshold=threshold)

--- a/modules/GPTQ_loader.py
+++ b/modules/GPTQ_loader.py
@@ -172,10 +172,11 @@ def load_quantized(model_name):
 
     # qwopqwop200's offload
     if model_type == 'llama' and shared.args.pre_layer:
-        if not ',' in shared.args.pre_layer:
-            pre_layer = int(shared.args.pre_layer)
+        if len(shared.args.pre_layer) == 1:
+            pre_layer = shared.args.pre_layer[0]
         else:
-            pre_layer = [int(x.strip()) for x in shared.args.pre_layer.split(',')]
+            pre_layer = shared.args.pre_layer
+
         model = load_quant(str(path_to_model), str(pt_path), shared.args.wbits, shared.args.groupsize, pre_layer)
     else:
         threshold = False if model_type == 'gptj' else 128

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -130,7 +130,7 @@ parser.add_argument('--n-gpu-layers', type=int, default=0, help='Number of layer
 parser.add_argument('--wbits', type=int, default=0, help='Load a pre-quantized model with specified precision in bits. 2, 3, 4 and 8 are supported.')
 parser.add_argument('--model_type', type=str, help='Model type of pre-quantized model. Currently LLaMA, OPT, and GPT-J are supported.')
 parser.add_argument('--groupsize', type=int, default=-1, help='Group size.')
-parser.add_argument('--pre_layer', type=int, default=0, help='The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models.')
+parser.add_argument('--pre_layer', type=str, default='', help='The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models.')
 parser.add_argument('--checkpoint', type=str, help='The path to the quantized checkpoint file. If not specified, it will be automatically detected.')
 parser.add_argument('--monkey-patch', action='store_true', help='Apply the monkey patch for using LoRAs with quantized models.')
 parser.add_argument('--quant_attn', action='store_true', help='(triton) Enable quant attention.')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -130,7 +130,7 @@ parser.add_argument('--n-gpu-layers', type=int, default=0, help='Number of layer
 parser.add_argument('--wbits', type=int, default=0, help='Load a pre-quantized model with specified precision in bits. 2, 3, 4 and 8 are supported.')
 parser.add_argument('--model_type', type=str, help='Model type of pre-quantized model. Currently LLaMA, OPT, and GPT-J are supported.')
 parser.add_argument('--groupsize', type=int, default=-1, help='Group size.')
-parser.add_argument('--pre_layer', type=str, default='', help='The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models.')
+parser.add_argument('--pre_layer', type=int, nargs="+", help='The number of layers to allocate to the GPU. Setting this parameter enables CPU offloading for 4-bit models. For multi-gpu, write the numbers separated by spaces, eg --pre_layer 30 60.')
 parser.add_argument('--checkpoint', type=str, help='The path to the quantized checkpoint file. If not specified, it will be automatically detected.')
 parser.add_argument('--monkey-patch', action='store_true', help='Apply the monkey patch for using LoRAs with quantized models.')
 parser.add_argument('--quant_attn', action='store_true', help='(triton) Enable quant attention.')


### PR DESCRIPTION
Hello it's 4 am and I've committed attempted housefire

![image](https://github.com/oobabooga/text-generation-webui/assets/4000772/01e688c7-60c8-4625-a2d9-197ad2301836)

----

Anyway so this PR updates `pre_layer` to support a comma-separated list of integer layer IDs, such that if you use a `,` it enables new _multiGPU support_ in GPTQ. And by 'in GPTQ' I mean in the PR for GPTQ: https://github.com/oobabooga/GPTQ-for-LLaMa/pull/1

I've done my best to keep it all backwards-compatible, ie if you're using any fork of GPTQ that isn't my PR, `pre_layer` should still work as intended. Also if you use `pre_layer` without a `,` in it it will still use the old behavior.

It seems like due to <https://huggingface.co/docs/optimum/bettertransformer/overview> possibly? Native multi-GPU exists and half-works, but when loading LLaMA-30B-4Bit-gr128, native gets me 8 token/sec and this glorious 4 am creation gets me 19 token/sec. So, 2x perf on multi-GPU inference. I'm sure someone somewhere needs that!

It's not maxing out usage of the GPU at all, it splits load evenly. I'd bet a careful implementation of beam search could be made such that each GPU runs at full (ie GPU0 runs Beam 2 while GPU1 is finishing Beam 1). But that's future problems.

Here's how fast it runs for me using 1x 3090 and 1x 3080 TI with `pre_layer 50,60`

![multigpulol](https://github.com/oobabooga/text-generation-webui/assets/4000772/1caf9952-6723-424f-9b4f-6051a1fc7b98)

And here's what nvtop has to say about it:

![Screenshot from 2023-05-16 03-29-40](https://github.com/oobabooga/text-generation-webui/assets/4000772/ba662684-d50d-4d1c-af1e-b6177846f63a)

using `30,60` splits much more evenly but runs slightly slower (17 token/sec).

---

Note: https://github.com/oobabooga/GPTQ-for-LLaMa/pull/1 must be pulled alongside this for it to work.

(ps I won't blame you if you call me insane and close these PRs, this is a mess)
