### PR TITLE
fix: elevenlabs cloned voices do not show up in webui after entering API key

### DIFF
--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -17,6 +17,12 @@ voices = None
 wav_idx = 0
 
 
+def update_api_key(key):
+    params['api_key'] = key
+    if key is not None:
+        elevenlabs.set_api_key(key)
+
+
 def refresh_voices():
     global params
     your_voices = elevenlabs.voices()
@@ -167,7 +173,7 @@ def ui():
     # Event functions to update the parameters in the backend
     activate.change(lambda x: params.update({'activate': x}), activate, None)
     voice.change(lambda x: params.update({'selected_voice': x}), voice, None)
-    api_key.change(lambda x: [params.update({'api_key': x}), elevenlabs.set_api_key(x)], api_key, None)
+    api_key.change(update_api_key, api_key, None)
     # connect.click(check_valid_api, [], connection_status)
     refresh.click(refresh_voices_dd, [], voice)
     # Event functions to update the parameters in the backend

--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -167,7 +167,7 @@ def ui():
     # Event functions to update the parameters in the backend
     activate.change(lambda x: params.update({'activate': x}), activate, None)
     voice.change(lambda x: params.update({'selected_voice': x}), voice, None)
-    api_key.change(lambda x: params.update({'api_key': x}), api_key, None)
+    api_key.change(lambda x: [params.update({'api_key': x}), elevenlabs.set_api_key(x)], api_key, None)
     # connect.click(check_valid_api, [], connection_status)
     refresh.click(refresh_voices_dd, [], voice)
     # Event functions to update the parameters in the backend


### PR DESCRIPTION
The elevenlabs api key is not sent when refreshing voices. Therefore, only the default voices are shown. This fix adds a call to the elevenlabs api library to set the API key when changed, so that it is pushed to Elevenlabs when refreshing voices.