### PR TITLE
Lora Trainer improvements, part 6 - slightly better raw text inputs

### DIFF
--- a/docs/Training-LoRAs.md
+++ b/docs/Training-LoRAs.md
@@ -75,6 +75,13 @@ So for example if a dataset has `"instruction": "answer my question"`, then the 
 
 If you have different sets of key inputs, you can make your own format file to match it. This format-file is designed to be as simple as possible to enable easy editing to match your needs.
 
+## Raw Text File Settings
+
+When using raw text files as your dataset, the text is automatically split into chunks based on your `Cutoff Length` you get a few basic options to configure them.
+- `Overlap Length` is how much to overlap chunks by. Overlapping chunks helps prevent the model from learning strange mid-sentence cuts, and instead learn continual sentences that flow from earlier text.
+- `Prefer Newline Cut Length` sets a maximum distance in characters to shift the chunk cut towards newlines. Doing this helps prevent lines from starting or ending mid-sentence, preventing the model from learning to cut off sentences randomly.
+- `Hard Cut String` sets a string that indicates there must be a hard cut without overlap. This defaults to `\n\n\n`, meaning 3 newlines. No trained chunk will ever contain this string. This allows you to insert unrelated sections of text in the same text file, but still ensure the model won't be taught to randomly change the subject.
+
 ## Parameters
 
 The basic purpose and function of each parameter is documented on-page in the WebUI, so read through them in the UI to understand your options.

--- a/modules/training.py
+++ b/modules/training.py
@@ -258,7 +258,13 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
 
         tokens = shared.tokenizer.encode(raw_text)
         del raw_text  # Note: could be a gig for a large dataset, so delete redundant data as we go to be safe on RAM
-        tokens = list(split_chunks(tokens, cutoff_len - overlap_len))
+
+        step = cutoff_len - overlap_len
+        if step <= 0:
+            yield f"Error: overlap_len ({overlap_len}) cannot be greater than or equal to cutoff_len ({cutoff_len})"
+            return
+
+        tokens = list(split_chunks(tokens, step))
         for i in range(1, len(tokens)):
             tokens[i] = tokens[i - 1][-overlap_len:] + tokens[i]
 

--- a/modules/training.py
+++ b/modules/training.py
@@ -36,8 +36,8 @@ except:
         "GPTNeoXForCausalLM": "gpt_neox"
     }
 
-WANT_INTERRUPT = False
 
+WANT_INTERRUPT = False
 PARAMETERS = ["lora_name", "always_override", "save_steps", "micro_batch_size", "batch_size", "epochs", "learning_rate", "lr_scheduler_type", "lora_rank", "lora_alpha", "lora_dropout", "cutoff_len", "dataset", "eval_dataset", "format", "eval_steps", "raw_text_file", "overlap_len", "newline_favor_len", "higher_rank_limit", "warmup_steps", "optimizer", "hard_cut_string"]
 
 
@@ -179,7 +179,7 @@ def change_rank_limit(use_higher_ranks: bool):
 
 
 def clean_path(base_path: str, path: str):
-    """"Strips unusual symbols and forcibly builds a path as relative to the intended directory."""
+    """Strips unusual symbols and forcibly builds a path as relative to the intended directory."""
     # TODO: Probably could do with a security audit to guarantee there's no ways this can be bypassed to target an unwanted path.
     # Or swap it to a strict whitelist of [a-zA-Z_0-9]
     path = path.replace('\\', '/').replace('..', '_')
@@ -264,7 +264,6 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
                 continue
 
             tokens = shared.tokenizer.encode(text_part)
-
             step = cutoff_len - overlap_len
             if step <= 0:
                 yield f"Error: overlap_len ({overlap_len}) cannot be greater than or equal to cutoff_len ({cutoff_len})"
@@ -273,7 +272,7 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
             tokens = list(split_chunks(tokens, step))
             for i in range(1, len(tokens)):
                 tokens[i] = tokens[i - 1][-overlap_len:] + tokens[i]
-            
+
             out_tokens.extend(tokens)
             del tokens
 


### PR DESCRIPTION
- Added an error check for if overlap/cutoff lengths don't make sense, that gives a clear error message (as a user on Discord was confused about it)
- Added `Hard Cut String`, a way to prevent unwanted overlaps.
This enables you to have text files like...
```
User: Question
Assistant: Answer


User: Question2
Assistant: Answer2
```
And it works just like a formatted json dataset wherein it properly cuts each chunk apart, but instead of messy json data you just split em with newlines. I made it generic enough that you can repurpose it to other split strings, other numbers of newlines, etc. easily within the UI.
Similarly useful if the raw text input is a series of different documents / quotes / whatever, separated by some consistent space block.
Prior to this change, models trained with this type of input would tend to learn that it's okay to suddenly and randomly change the subject (as, well, that's what the data did! And now, with this, your data doesn't, so theoretically your bot doesn't either).
I was originally going to use `ast` logic like `custom_stopping_strings` does but tbh I don't think it's worth the bother? You're unlikely to have multiple separator strings that need python-syntax input, so I just specialcased newlines and made it otherwise just a string.
- Also, added short bit of documentation about raw text file settings in the docs.
- ~~I was planning to test and implement the fix <https://github.com/oobabooga/text-generation-webui/discussions/1586> but I can't actually currently replicate the bug anymore ... and I do not not why. I also don't know why I was ever able to replicate the bug in the first place, as it's a strange bug that shouldn't happen. I might've updated packages at some point and that's why it's fine now? Not sure.~~ Confirmed as fixed by upstream
- I also wanted to look into multigpu training (per my jank housefire of a multigpu setup https://github.com/oobabooga/text-generation-webui/pull/2100 ) but, uh, frankly `torchrun` is an absolute nightmare, and pytorch internal splitting... exists, but is awful. And building my own multigpu logic as in that PR would be way more complicated, as it involves HF Transformers internals. So I'm not sure on how to do that, but it's a whole separate massive project.