### PR TITLE
Update docker-compose.yml to reflect the move to the "docker" folder

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,10 @@
 version: "3.3"
 services:
   text-generation-webui:
+    image: oobabooga/text-generation-webui
     build:
-      context: .
+      context: ../
+      dockerfile: docker/Dockerfile
       args:
         # specify which cuda version your card supports: https://developer.nvidia.com/cuda-gpus
         TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}
@@ -15,14 +17,14 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - ./characters:/app/characters
-      - ./extensions:/app/extensions
-      - ./loras:/app/loras
-      - ./models:/app/models
-      - ./presets:/app/presets
-      - ./prompts:/app/prompts
-      - ./softprompts:/app/softprompts
-      - ./training:/app/training
+      - ../characters:/app/characters
+      - ../extensions:/app/extensions
+      - ../loras:/app/loras
+      - ../models:/app/models
+      - ../presets:/app/presets
+      - ../prompts:/app/prompts
+      - ../softprompts:/app/softprompts
+      - ../training:/app/training
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
The docker related files appear to have started at the root of the repository and then were moved to the "docker" folder. However the docker compose file doesn't appear to have been updated to reflect this. 

I noticed the stablediffusion PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7946 has a similar docker structure to this and applied similar changes. This ended up working on my local copy and I am able to run "docker compose build" to generate the "oobabooga/text-generation-webui" image for my use in Portainer.