### PR TITLE
Fix superbooga error when querying empty DB (Issue #2160)

### DIFF
--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -42,11 +42,13 @@ class ChromaCollector(Collecter):
         self.ids = []
 
     def add(self, texts: list[str]):
+        if len(texts) == 0: return
         self.ids = [f"id{i}" for i in range(len(texts))]
         self.collection.add(documents=texts, ids=self.ids)
 
     def get_documents_and_ids(self, search_strings: list[str], n_results: int):
         n_results = min(len(self.ids), n_results)
+        if n_results == 0: return [], []
         result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents'])
         documents = result['documents'][0]
         ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
@@ -74,6 +76,7 @@ class ChromaCollector(Collecter):
 
     def clear(self):
         self.collection.delete(ids=self.ids)
+        self.ids = []
 
 
 class SentenceTransformerEmbedder(Embedder):

--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -42,13 +42,17 @@ class ChromaCollector(Collecter):
         self.ids = []
 
     def add(self, texts: list[str]):
-        if len(texts) == 0: return
+        if len(texts) == 0:
+            return
+
         self.ids = [f"id{i}" for i in range(len(texts))]
         self.collection.add(documents=texts, ids=self.ids)
 
     def get_documents_and_ids(self, search_strings: list[str], n_results: int):
         n_results = min(len(self.ids), n_results)
-        if n_results == 0: return [], []
+        if n_results == 0:
+            return [], []
+
         result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents'])
         documents = result['documents'][0]
         ids = list(map(lambda x: int(x[2:]), result['ids'][0]))
@@ -61,7 +65,7 @@ class ChromaCollector(Collecter):
 
     # Get ids by similarity
     def get_ids(self, search_strings: list[str], n_results: int) -> list[str]:
-        _ , ids = self.get_documents_and_ids(search_strings, n_results)
+        _, ids = self.get_documents_and_ids(search_strings, n_results)
         return ids
 
     # Get chunks by similarity and then sort by insertion order
@@ -71,7 +75,7 @@ class ChromaCollector(Collecter):
 
     # Get ids by similarity and then sort by insertion order
     def get_ids_sorted(self, search_strings: list[str], n_results: int) -> list[str]:
-        _ , ids = self.get_documents_and_ids(search_strings, n_results)
+        _, ids = self.get_documents_and_ids(search_strings, n_results)
         return sorted(ids)
 
     def clear(self):


### PR DESCRIPTION
# Current behavior
(Issue #2160) If the ChromaDB collection is queried (as in `ChromaCollector.get_documents_and_ids()`) before any documents have been added to it, it raises a `NoIndexException`.

# Fix
`ChromaCollector.get_documents_and_ids()` returns two empty lists without querying the DB if `n_results == 0`. Since `n_results` is set to 0 if `self.ids == 0`, this prevents the DB from being queried if it is empty.

# Additional changes
* `ChromaCollector.add()` returns immediately without adding to the DB if `len(texts) == 0`.
* `ChromaCollector.clear()` now clears its own `self.ids` attribute after clearing the DB itself, keeping consistency between `self.ids` and the actual contents of the DB.