### PR TITLE
Fix broken version of peft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ rwkv==0.7.3
 safetensors==0.3.1
 sentencepiece
 tqdm
-git+https://github.com/huggingface/peft
+git+https://github.com/huggingface/peft@4fd374e80d670781c0d82c96ce94d1215ff23306
 transformers==4.29.1
 bitsandbytes==0.38.1; platform_system != "Windows"
 llama-cpp-python==0.1.51; platform_system != "Windows"


### PR DESCRIPTION
Peft updated to support an unreleased, closed beta version of bitsandbytes. Naturally, they also broke support for the current version of bitsandbytes.

See: #2228