### PR TITLE
use pkg_resources to display the runtime version of llama-cpp-python

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ import os
 import requests
 import warnings
 import modules.logging_colors
+import pkg_resources
 
 os.environ['GRADIO_ANALYTICS_ENABLED'] = 'False'
 os.environ['BITSANDBYTES_NOWELCOME'] = '1'
@@ -376,6 +377,7 @@ def create_model_menus():
         with gr.Column():
             with gr.Box():
                 gr.Markdown('llama.cpp parameters')
+                gr.Markdown(f'llama-cpp-python version: {pkg_resources.get_distribution("llama-cpp-python").version}')
                 with gr.Row():
                     with gr.Column():
                         shared.gradio['threads'] = gr.Slider(label="threads", minimum=0, step=1, maximum=32, value=shared.args.threads)


### PR DESCRIPTION
small quality of life addition to the UI to display what version of llama-cpp-python is loaded at runtime. 

With the changes to quantization in llama.cpp I have some confusion regarding which models I need to run with which commit/release of text-generation-webui. Adding this gives me a quick reminder in the ui of what version I am on. 

I have only tested on linux. I would imagine it may fail on windows due to that package being installed directly from source instead of through pip. 