### PR TITLE
Beginning of multi-user support

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -5,9 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from modules.text_generation import GenerationQueue
-
-queue = GenerationQueue()
+queue = None
 model = None
 tokenizer = None
 model_name = "None"

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 import yaml
 
+from modules.text_generation import GenerationQueue
+
+queue = GenerationQueue()
 model = None
 tokenizer = None
 model_name = "None"

--- a/server.py
+++ b/server.py
@@ -49,7 +49,7 @@ from modules.extensions import apply_extensions
 from modules.html_generator import chat_html_wrapper
 from modules.LoRA import add_lora_to_model
 from modules.models import load_model, load_soft_prompt, unload_model
-from modules.text_generation import generate_reply_wrapper, get_encoded_length, stop_everything_event
+from modules.text_generation import generate_reply_wrapper, get_encoded_length, stop_everything_event, GenerationQueue
 
 
 def load_model_wrapper(selected_model, autoload=False):
@@ -1047,6 +1047,7 @@ if __name__ == "__main__":
             'instruction_template': shared.settings['instruction_template']
         })
 
+    shared.queue = GenerationQueue()
     # Launch the web UI
     create_interface()
     while True:


### PR DESCRIPTION
This PR makes it so the app doesn't crash on concurrent requests. It does so by forwarding generate_reply tasks to a queue with a service worker, which is initialized before creating the interface. The function generate_reply is rewritten to be a simple wrapper around the queue, ensuring backwards compatibility. The old blocking function is renamed as _generate_reply, which is called by the worker when a task is placed in the queue.

Behavior before PR:
Concurrent text generation requests via API, UI, extensions, etc. would crash the program entirely.

Behavior after PR:
Concurrent text generation requests are placed in a queue and executed in the order they came in.

Note that this doesn't separate session states or chat histories, so that's still an issue for multiple people trying to access through the native UI. 

One final important note is that I haven't _rigorously_ tested this. I have tested the functionality it promises - concurrent requests are in fact queued - but I'm not entirely sure if running the tasks in a single worker introduces a bottleneck on the CPU. Ideally we want multiple cores as far as I know (?), and I'm not sure if the threading library utilized here will automatically support that since _generate_reply is called in the worker. Something to look into. I get full speed, but I run GPTQ models on GPU so not sure if that's indicative, or if this is even a problem.