### PR TITLE
update llama-cpp-python to v0.1.53 for ggml v3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ tqdm
 git+https://github.com/huggingface/peft@4fd374e80d670781c0d82c96ce94d1215ff23306
 transformers==4.29.1
 bitsandbytes==0.38.1; platform_system != "Windows"
-llama-cpp-python==0.1.51; platform_system != "Windows"
-https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.51/llama_cpp_python-0.1.51-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+llama-cpp-python==0.1.53; platform_system != "Windows"
+https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.53/llama_cpp_python-0.1.53-cp310-cp310-win_amd64.whl; platform_system == "Windows"


### PR DESCRIPTION
Let's update llama-cpp-python to support the latest llama.cpp and ggml v3, v0.1.53 is working well for me on Linux with v3 models. This fixes #2245.