### PR TITLE
FIX `get_model_specific_settings` which currently is updated only on program start

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -214,18 +214,23 @@ def is_chat():
 # Loading model-specific settings
 with Path(f'{args.model_dir}/config.yaml') as p:
     if p.exists():
-        model_config = yaml.safe_load(open(p, 'r').read())
+        default_model_config = yaml.safe_load(open(p, 'r').read())
     else:
-        model_config = {}
+        default_model_config = {}
+
+default_model_config = OrderedDict(default_model_config)
 
 # Applying user-defined model settings
-with Path(f'{args.model_dir}/config-user.yaml') as p:
-    if p.exists():
-        user_config = yaml.safe_load(open(p, 'r').read())
-        for k in user_config:
-            if k in model_config:
-                model_config[k].update(user_config[k])
-            else:
-                model_config[k] = user_config[k]
+def model_config():
+    model_config = default_model_config.copy()
 
-model_config = OrderedDict(model_config)
+    with Path(f'{args.model_dir}/config-user.yaml') as p:
+        if p.exists():
+            user_config = yaml.safe_load(open(p, 'r').read())
+            for k in user_config:
+                if k in model_config:
+                    model_config[k].update(user_config[k])
+                else:
+                    model_config[k] = user_config[k]
+
+        return OrderedDict(model_config)

--- a/server.py
+++ b/server.py
@@ -252,7 +252,7 @@ def update_model_parameters(state, initial=False):
 
 
 def get_model_specific_settings(model):
-    settings = shared.model_config
+    settings = shared.model_config()
     model_settings = {}
 
     for pat in settings:
@@ -984,7 +984,7 @@ if __name__ == "__main__":
             shared.settings[item] = new_settings[item]
 
     # Set default model settings based on settings.json
-    shared.model_config['.*'] = {
+    shared.default_model_config['.*'] = {
         'wbits': 'None',
         'model_type': 'None',
         'groupsize': 'None',
@@ -994,7 +994,7 @@ if __name__ == "__main__":
         'custom_stopping_strings': shared.settings['custom_stopping_strings'],
     }
 
-    shared.model_config.move_to_end('.*', last=False)  # Move to the beginning
+    shared.default_model_config.move_to_end('.*', last=False)  # Move to the beginning
 
     # Default extensions
     extensions_module.available_extensions = utils.get_available_extensions()


### PR DESCRIPTION
## Current behavior

The "Save settings for this model" save settings properly, but when we come back to the model, they are properly loaded **only after the app being restarted**.

## Fix

`get_model_specific_settings` currently relies on `shared.model_config`, which is computed just once on the program start.

The new behavior still loads `config.yaml` (which should be static indeed) on program start, but loads now dynamically the `config-user.yaml`.