### PR TITLE
Support of the `--gradio-auth` flag (like `--gradio-auth-path` but without the need of a file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Optionally, you can use the following command-line flags:
 | `--listen-port LISTEN_PORT`           | The listening port that the server will use. |
 | `--share`                             | Create a public URL. This is useful for running the web UI on Google Colab or similar. |
 | `--auto-launch`                       | Open the web UI in the default browser upon launch. |
+| `--gradio-auth USER:PWD`              | set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3" |
 | `--gradio-auth-path GRADIO_AUTH_PATH` | Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3" |
 
 #### API

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -163,6 +163,7 @@ parser.add_argument('--listen-host', type=str, help='The hostname that the serve
 parser.add_argument('--listen-port', type=int, help='The listening port that the server will use.')
 parser.add_argument('--share', action='store_true', help='Create a public URL. This is useful for running the web UI on Google Colab or similar.')
 parser.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
+parser.add_argument("--gradio-auth", type=str, help='set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
 parser.add_argument("--gradio-auth-path", type=str, help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"', default=None)
 
 # API

--- a/server.py
+++ b/server.py
@@ -529,11 +529,14 @@ def create_interface():
 
     # Authentication variables
     auth = None
+    gradio_auth_creds = []
+    if shared.args.gradio_auth:
+        gradio_auth_creds += [x.strip() for x in shared.args.gradio_auth.strip('"').replace('\n', '').split(',') if x.strip()]
     if shared.args.gradio_auth_path is not None:
-        gradio_auth_creds = []
         with open(shared.args.gradio_auth_path, 'r', encoding="utf8") as file:
             for line in file.readlines():
                 gradio_auth_creds += [x.strip() for x in line.split(',') if x.strip()]
+    if gradio_auth_creds:
         auth = [tuple(cred.split(':')) for cred in gradio_auth_creds]
 
     # Importing the extension files and executing their setup() functions


### PR DESCRIPTION
## Context

To set up _gradio authentication_, we currently need to set a flag AND to create a file (`--gradio-auth-path GRADIO_AUTH_PATH`).

We could easily have a _flag-only_ solution like with [AUTOMATIC1111/stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui).

## Proposed solution

Be able to set up _gradio authentication_ by simply passing a `--gradio-auth username:password` flag to the _server.py_ script (e.g. via the `CMD_FLAGS` constant).