### PR TITLE
Add a `dark_theme` settings

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -33,6 +33,7 @@ reload_inputs = []  # Parameters for reloading the chat interface
 need_restart = False
 
 settings = {
+    'dark_theme': False,
     'autoload_model': True,
     'max_new_tokens': 200,
     'max_new_tokens_min': 1,

--- a/server.py
+++ b/server.py
@@ -954,6 +954,8 @@ def create_interface():
             shared.gradio['count_tokens'].click(count_tokens, shared.gradio['textbox'], shared.gradio['status'], show_progress=False)
 
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
+        if shared.settings['dark_theme']:
+            shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => document.getElementsByTagName('body')[0].classList.add('dark')")
         shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, [shared.gradio[k] for k in ui.list_interface_input_elements(chat=shared.is_chat())], show_progress=False)
         # Extensions tabs
         extensions_module.create_extensions_tabs()

--- a/server.py
+++ b/server.py
@@ -956,7 +956,9 @@ def create_interface():
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
         if shared.settings['dark_theme']:
             shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => document.getElementsByTagName('body')[0].classList.add('dark')")
+
         shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, [shared.gradio[k] for k in ui.list_interface_input_elements(chat=shared.is_chat())], show_progress=False)
+
         # Extensions tabs
         extensions_module.create_extensions_tabs()
 

--- a/settings-template.json
+++ b/settings-template.json
@@ -19,6 +19,7 @@
     "truncation_length_min": 0,
     "truncation_length_max": 8192,
     "mode": "chat",
+    "dark_theme": false,
     "chat_style": "cai-chat",
     "instruction_template": "None",
     "chat-instruct_command": "Continue the chat dialogue below. Write a single reply for the character \"<|character|>\".\n\n<|prompt|>",

--- a/settings-template.json
+++ b/settings-template.json
@@ -1,4 +1,5 @@
 {
+    "dark_theme": false,
     "autoload_model": true,
     "max_new_tokens": 200,
     "max_new_tokens_min": 1,
@@ -19,7 +20,6 @@
     "truncation_length_min": 0,
     "truncation_length_max": 8192,
     "mode": "chat",
-    "dark_theme": false,
     "chat_style": "cai-chat",
     "instruction_template": "None",
     "chat-instruct_command": "Continue the chat dialogue below. Write a single reply for the character \"<|character|>\".\n\n<|prompt|>",


### PR DESCRIPTION
## Context

Currently, we can e.g. make the _autoload_ mode persistent through `settings.json` (which is great 🙏), but not the UI theme.
Bring this preference through a `__theme=dark` URL parameter is not convenient. The WebUI should be able to remember by itself our preference regarding the UI theme.

## Proposed solution

Here I propose to follow how the WebUI currently handles settings (such as how the _autoload_ mode for models are currently loaded).