### PR TITLE
FIX `silero_tts` activation/deactivation

### DIFF
--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -62,22 +62,22 @@ def remove_surrounded_chars(string):
 
 
 def state_modifier(state):
+    if not params['activate']:
+        return state
+
     state['stream'] = False
     return state
 
 
 def input_modifier(string):
-    """
-    This function is applied to your text inputs before
-    they are fed into the model.
-    """
+    if not params['activate']:
+        return string
 
     shared.processing_message = "*Is recording a voice message...*"
     return string
 
 
 def history_modifier(history):
-
     # Remove autoplay from the last reply
     if len(history['internal']) > 0:
         history['visible'][-1] = [
@@ -89,10 +89,6 @@ def history_modifier(history):
 
 
 def output_modifier(string):
-    """
-    This function is applied to the model outputs.
-    """
-
     global params, wav_idx
 
     if not params['activate']:

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -84,11 +84,6 @@ def input_modifier(string):
     if not params['activate']:
         return string
 
-    """
-    This function is applied to your text inputs before
-    they are fed into the model.
-    """
-
     shared.processing_message = "*Is recording a voice message...*"
     return string
 
@@ -105,12 +100,7 @@ def history_modifier(history):
 
 
 def output_modifier(string):
-    """
-    This function is applied to the model outputs.
-    """
-
     global model, current_params, streaming_state
-
     for i in params:
         if params[i] != current_params[i]:
             model = load_model()

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -73,11 +73,17 @@ def toggle_text_in_history():
 
 
 def state_modifier(state):
+    if not params['activate']:
+        return state
+
     state['stream'] = False
     return state
 
 
 def input_modifier(string):
+    if not params['activate']:
+        return string
+
     """
     This function is applied to your text inputs before
     they are fed into the model.
@@ -88,7 +94,6 @@ def input_modifier(string):
 
 
 def history_modifier(history):
-
     # Remove autoplay from the last reply
     if len(history['internal']) > 0:
         history['visible'][-1] = [


### PR DESCRIPTION
## Current behavior

When we deactivate the `silero_tts` extension unchecking the "_Activate TTS_" checkbox, it still prevents the _stream_ and still modifies the input with "_*Is recording a voice message...*_".

## Proposed solution

Add guard clauses based on `params['activate']` in the beginning of both `state_modifier` and `input_modifier` function.