### PR TITLE
LoRA Trainer: `train_only_after` option to control which part of your input to train on

### DIFF
--- a/modules/training.py
+++ b/modules/training.py
@@ -257,9 +257,9 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
             labels = None
 
         else:
-            ind = prompt.index(train_only_after)
+            ind = prompt.index(train_only_after) + len(train_only_after)
             before_tokens = encode(prompt[:ind])[:-1]
-            after_tokens = encode(prompt[ind + len(train_only_after):])[1:]
+            after_tokens = encode(prompt[ind:])[1:]
 
             full_length = len(after_tokens) + len(before_tokens)
             if full_length > cutoff_len:

--- a/modules/training.py
+++ b/modules/training.py
@@ -247,12 +247,12 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
     shared.tokenizer.padding_side = "left"
 
     def encode(text):
-        return shared.tokenizer.encode(text, truncation=True, max_length=cutoff_len + 1)
+        return shared.tokenizer.encode(text, truncation=True, max_length=cutoff_len)
 
     def tokenize(prompt):
 
         if train_only_after == '' or train_only_after not in prompt:
-            input_ids = encode(prompt)[:-1]
+            input_ids = encode(prompt)
             input_ids = [shared.tokenizer.pad_token_id] * (cutoff_len - len(input_ids)) + input_ids
             labels = [1] * len(input_ids)
 
@@ -264,8 +264,8 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
             full_length = len(after_tokens) + len(before_tokens)
             if full_length > cutoff_len:
                 after_tokens = after_tokens[:cutoff_len - len(before_tokens)]
-                full_length = cutoff_len
-            before_tokens = [shared.tokenizer.pad_token_id] * (cutoff_len - full_length) + before_tokens
+            else:
+                before_tokens = [shared.tokenizer.pad_token_id] * (cutoff_len - full_length) + before_tokens
 
             input_ids = before_tokens + after_tokens
             labels = [-100] * len(before_tokens) + [1] * len(after_tokens)

--- a/modules/training.py
+++ b/modules/training.py
@@ -1,5 +1,6 @@
 import json
 import math
+import random
 import sys
 import threading
 import time
@@ -339,13 +340,13 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
 
         logger.info("Loading JSON datasets...")
         data = load_dataset("json", data_files=clean_path('training/datasets', f'{dataset}.json'))
-        train_data = data['train'].map(generate_and_tokenize_prompt)
+        train_data = data['train'].map(generate_and_tokenize_prompt, new_fingerprint='%030x' % random.randrange(16**30))
 
         if eval_dataset == 'None':
             eval_data = None
         else:
             eval_data = load_dataset("json", data_files=clean_path('training/datasets', f'{eval_dataset}.json'))
-            eval_data = eval_data['train'].map(generate_and_tokenize_prompt)
+            eval_data = eval_data['train'].map(generate_and_tokenize_prompt, new_fingerprint='%030x' % random.randrange(16**30))
 
     # == Start prepping the model itself ==
     if not hasattr(shared.model, 'lm_head') or hasattr(shared.model.lm_head, 'weight'):

--- a/modules/training.py
+++ b/modules/training.py
@@ -259,7 +259,7 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
 
         else:
             ind = prompt.index(train_only_after) + len(train_only_after)
-            before_tokens = encode(prompt[:ind])[:-1]
+            before_tokens = encode(prompt[:ind])[1:]
             after_tokens = encode(prompt[ind:])[1:]
 
             full_length = len(after_tokens) + len(before_tokens)

--- a/modules/training.py
+++ b/modules/training.py
@@ -39,7 +39,7 @@ except:
 
 
 WANT_INTERRUPT = False
-PARAMETERS = ["lora_name", "always_override", "save_steps", "micro_batch_size", "batch_size", "epochs", "learning_rate", "lr_scheduler_type", "lora_rank", "lora_alpha", "lora_dropout", "cutoff_len", "dataset", "eval_dataset", "format", "eval_steps", "raw_text_file", "overlap_len", "newline_favor_len", "higher_rank_limit", "warmup_steps", "optimizer", "hard_cut_string"]
+PARAMETERS = ["lora_name", "always_override", "save_steps", "micro_batch_size", "batch_size", "epochs", "learning_rate", "lr_scheduler_type", "lora_rank", "lora_alpha", "lora_dropout", "cutoff_len", "dataset", "eval_dataset", "format", "eval_steps", "raw_text_file", "overlap_len", "newline_favor_len", "higher_rank_limit", "warmup_steps", "optimizer", "hard_cut_string", "train_only_after"]
 
 
 def create_train_interface():
@@ -96,6 +96,7 @@ def create_train_interface():
             lora_dropout = gr.Slider(label='LoRA Dropout', minimum=0.0, maximum=1.0, step=0.025, value=0.05, info='Percentage probability for dropout of LoRA layers. This can help reduce overfitting. Most users should leave at default.')
             warmup_steps = gr.Number(label='Warmup Steps', value=100, info='For this many steps at the start, the learning rate will be lower than normal. This helps the trainer prepare the model and precompute statistics to improve the quality of training after the start.')
             optimizer = gr.Dropdown(label='Optimizer', value='adamw_torch', choices=['adamw_hf', 'adamw_torch', 'adamw_torch_fused', 'adamw_torch_xla', 'adamw_apex_fused', 'adafactor', 'adamw_bnb_8bit', 'adamw_anyprecision', 'sgd', 'adagrad'], info='Different optimizer implementation options, for advanced users. Effects of different options are not well documented yet.')
+            train_only_after = gr.Textbox(label='Train Only After', value='', info='Only consider text *after* this string in any given chunk for training. For Alpaca datasets, use "### Response:" to only train the response and ignore the input.')
 
             with gr.Row():
                 higher_rank_limit = gr.Checkbox(label='Enable higher ranks', value=False, info='If checked, changes Rank/Alpha slider above to go much higher. This will not work without a datacenter-class GPU.')
@@ -127,7 +128,7 @@ def create_train_interface():
         save_comments = gr.Button('Save comments')
 
     # Training events
-    all_params = [lora_name, always_override, save_steps, micro_batch_size, batch_size, epochs, learning_rate, lr_scheduler_type, lora_rank, lora_alpha, lora_dropout, cutoff_len, dataset, eval_dataset, format, eval_steps, raw_text_file, overlap_len, newline_favor_len, higher_rank_limit, warmup_steps, optimizer, hard_cut_string]
+    all_params = [lora_name, always_override, save_steps, micro_batch_size, batch_size, epochs, learning_rate, lr_scheduler_type, lora_rank, lora_alpha, lora_dropout, cutoff_len, dataset, eval_dataset, format, eval_steps, raw_text_file, overlap_len, newline_favor_len, higher_rank_limit, warmup_steps, optimizer, hard_cut_string, train_only_after]
     copy_from.change(do_copy_params, [copy_from] + all_params, all_params)
     start_button.click(do_train, all_params, output)
     stop_button.click(do_interrupt, None, None, queue=False)
@@ -190,7 +191,7 @@ def clean_path(base_path: str, path: str):
     return f'{Path(base_path).absolute()}/{path}'
 
 
-def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch_size: int, batch_size: int, epochs: int, learning_rate: str, lr_scheduler_type: str, lora_rank: int, lora_alpha: int, lora_dropout: float, cutoff_len: int, dataset: str, eval_dataset: str, format: str, eval_steps: int, raw_text_file: str, overlap_len: int, newline_favor_len: int, higher_rank_limit: bool, warmup_steps: int, optimizer: str, hard_cut_string: str):
+def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch_size: int, batch_size: int, epochs: int, learning_rate: str, lr_scheduler_type: str, lora_rank: int, lora_alpha: int, lora_dropout: float, cutoff_len: int, dataset: str, eval_dataset: str, format: str, eval_steps: int, raw_text_file: str, overlap_len: int, newline_favor_len: int, higher_rank_limit: bool, warmup_steps: int, optimizer: str, hard_cut_string: str, train_only_after: str):
 
     if shared.args.monkey_patch:
         from monkeypatch.peft_tuners_lora_monkey_patch import \
@@ -245,11 +246,35 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
     shared.tokenizer.pad_token_id = 0
     shared.tokenizer.padding_side = "left"
 
+    def encode(text):
+        return shared.tokenizer.encode(text, truncation=True, max_length=cutoff_len + 1)
+
     def tokenize(prompt):
-        result = shared.tokenizer(prompt, truncation=True, max_length=cutoff_len + 1, padding="max_length")
+
+        if train_only_after == '' or train_only_after not in prompt:
+            input_ids = encode(prompt)[:-1]
+            input_ids = [shared.tokenizer.pad_token_id] * (cutoff_len - len(input_ids)) + input_ids
+            labels = None
+
+        else:
+            ind = prompt.index(train_only_after)
+            before_tokens = encode(prompt[:ind])[:-1]
+            after_tokens = encode(prompt[ind + len(train_only_after):])[1:]
+
+            full_length = len(after_tokens) + len(before_tokens)
+            if full_length > cutoff_len:
+                after_tokens = after_tokens[:cutoff_len - len(before_tokens)]
+                full_length = cutoff_len
+            before_tokens = [shared.tokenizer.pad_token_id] * (cutoff_len - full_length) + before_tokens
+
+            input_ids = before_tokens + after_tokens
+            labels = [-100] * len(before_tokens) + [1] * len(after_tokens)
+
+        input_ids = torch.tensor(input_ids)
         return {
-            "input_ids": result["input_ids"][:-1],
-            "attention_mask": result["attention_mask"][:-1],
+            "input_ids": input_ids,
+            "labels": labels,
+            "attention_mask": input_ids.ne(shared.tokenizer.pad_token_id),
         }
 
     # == Prep the dataset, format, etc ==

--- a/modules/training.py
+++ b/modules/training.py
@@ -254,7 +254,7 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
         if train_only_after == '' or train_only_after not in prompt:
             input_ids = encode(prompt)[:-1]
             input_ids = [shared.tokenizer.pad_token_id] * (cutoff_len - len(input_ids)) + input_ids
-            labels = None
+            labels = [1] * len(input_ids)
 
         else:
             ind = prompt.index(train_only_after) + len(train_only_after)


### PR DESCRIPTION
tldr: adds new option `train_only_after` under Advanced that you can fill in a string and it will ignore text before that part and only count text after it for training.

Relevant backend `labels` with its magic value `-1` is documented @ https://huggingface.co/transformers/v3.1.0/custom_datasets.html

Labels seems to have other abilities that might be worth looking into? Not sure.

This feature was shown to be in use in the original Stanford Alpaca https://github.com/tatsu-lab/stanford_alpaca/blob/main/train.py#L123 but to my knowledge hasn't been ported to other trainers (eg the original alpaca-lora that was the starting point for this code, way back when, in the ancient times). Not sure if that means it's not that useful, or just nobody's really noticed it's missing before now.

So for training on an Alpaca formatted dataset, you can set this to `### Response:` 

Operates in string space because token space is cursed for some theoretically valid matchers (ie anything that lacks spaces).

The code is a bit longer than I'd like it to be, because operating in string space means replicating the padding code (as otherwise it would double-pad), but not too bad.

I tested and verified that training with/without the setting works as normal, and that the splitter does exactly what it's meant to, and that the labels are being received and processed by the HF Trainer.
I have not tested the effect on quality of training results with vs without.

---

Also, additional fixes:

- Fixed last tokens being stripped. Not sure if this was happening before or as a byproduct of the encoder call change, but either way, it definitely doesn't wrongly strip now!
- HF datasets are cursedbad. See prior issue <https://github.com/oobabooga/text-generation-webui/discussions/1586> but also new issue - they give errors when loading from cache when new labels data is present it seems. ... also after disabling that, it loads so much faster. Wow. Ow.