### PR TITLE
Update docker repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ docker compose up --build
 ```
 
 * You need to have docker compose v2.17 or higher installed. See [this guide](https://github.com/oobabooga/text-generation-webui/blob/main/docs/Docker.md) for instructions.
-* For additional docker files, check out [this repository](https://github.com/Atinoda/text-generation-webui/blob/docker-wrapper/docs/Docker.md#dedicated-docker-repository).
+* For additional docker files, check out [this repository](https://github.com/Atinoda/text-generation-webui-docker).
 
 ### Updating the requirements
 


### PR DESCRIPTION
Hi oobabooga, thanks for checking out and linking to my docker companion repo. This PR is a quick update to the link in README.me so that it points directly to the repo, rather than to the docs. Hope that you're happy enough with that, I think it'll make it easier for people to find it. I plan to get pre-built images on Docker hub this weekend, and that should accelerate uptake because users won't need to build the deployment to get it running!

PS. nice work on getting 4-bit transformers rolled out so quickly