### PR TITLE
Update README.md to account for BnB Windows wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Optionally, you can use the following command-line flags:
 
 #### Accelerate 4-bit
 
-⚠️ Not supported on Windows at the moment.
+⚠️ Requires minimum compute of 7.0 on Windows at the moment.
 
 | Flag                                        | Description |
 |---------------------------------------------|-------------|


### PR DESCRIPTION
Windows is now supported, but only for GPUs with compute capability of at least 7.0.
This means Volta+ as well as GTX 16 series cards which have compute 7.5