### PR TITLE
Add 'scipy' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ requests
 safetensors==0.3.1
 sentencepiece
 tqdm
+scipy
 git+https://github.com/huggingface/peft@3714aa2fff158fdfa637b2b65952580801d890b2
 git+https://github.com/huggingface/transformers@e45e756d22206ca8fa9fb057c8c3d8fa79bf81c6
 git+https://github.com/huggingface/accelerate@0226f750257b3bf2cadc4f189f9eef0c764a0467


### PR DESCRIPTION
Unlisted dependency of bitsandbytes
Fixes https://github.com/oobabooga/text-generation-webui/issues/2335

I also updated the Windows wheel to include scipy as an install dependency. That will at least prevent this from happening with Windows users.