### PR TITLE
Fix superbooga get_documents_ids_distances return error when n_results = 0

### DIFF
--- a/extensions/superbooga/chromadb.py
+++ b/extensions/superbooga/chromadb.py
@@ -50,7 +50,7 @@ class ChromaCollector(Collecter):
     def get_documents_ids_distances(self, search_strings: list[str], n_results: int):
         n_results = min(len(self.ids), n_results)
         if n_results == 0:
-            return [], []
+            return [], [], []
 
         result = self.collection.query(query_texts=search_strings, n_results=n_results, include=['documents', 'distances'])
         documents = result['documents'][0]


### PR DESCRIPTION
Sorry missed something from the last PR

`ChromaCollector.get_documents_ids_distances()`, when n_results = 0, now returns 3 empty lists (for documents, ids, distances) instead of 2