### PR TITLE
docker compose working with wsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv/
 *.bak
 *.ipynb
 *.log
+**/.env
 
 settings.json
 notification.mp3

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -2,7 +2,7 @@
 Dockerfile
 /characters
 /loras
-/models
+# /models
 /presets
 /prompts
 /softprompts

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,15 +1,22 @@
 # by default the Dockerfile specifies these versions: 3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX
 # however for me to work i had to specify the exact version for my card ( 2060 ) it was 7.5
 # https://developer.nvidia.com/cuda-gpus you can find the version for your card here
-TORCH_CUDA_ARCH_LIST=7.5
+TORCH_CUDA_ARCH_LIST=8.6
 
-# these commands worked for me with roughly 4.5GB of vram
-CLI_ARGS=--model llama-7b-4bit --wbits 4 --listen --auto-devices
+# the version used to install QUANT REPO from
+QUANT_MODEL_URL=https://github.com/oobabooga/GPTQ-for-LLaMa
+QUANT_SHA=53a2aeac935b7eef0e1451eb7b465fea4f318e7a
+QUANT_BRANCH=cuda
 
-# the following examples have been tested with the files linked in docs/README_docker.md:
-# example running 13b with 4bit/128 groupsize        : CLI_ARGS=--model llama-13b-4bit-128g --wbits 4 --listen --groupsize 128 --pre_layer 25
-# example with loading api extension and public share: CLI_ARGS=--model llama-7b-4bit --wbits 4 --listen --auto-devices --no-stream --extensions api --share
-# example running 7b with 8bit groupsize             : CLI_ARGS=--model llama-7b --load-in-8bit --listen --auto-devices
+# the version used to install text-generation-webui from
+WEBUI_URL=https://github.com/oobabooga/text-generation-webui.git
+WEBUI_SHA=b817f686d4f36c5a78152c966582ee79cb108b95
+WEBUI_BRANCH=load-in-4bit
+
+# ALPACA 4 BIT LORA VERSION
+LORA_4BIT_URL=https://github.com/johnsmith0031/alpaca_lora_4bit.git
+LORA_4BIT_SHA=2f704b93c961bf202937b10aac9322b092afdce0
+LORA_4BIT_BRANCH=main
 
 # the port the webui binds to on the host
 HOST_PORT=7860
@@ -25,6 +32,3 @@ CONTAINER_API_PORT=5000
 HOST_API_STREAM_PORT=5005
 # the port the api stream endpoint binds to inside the container
 CONTAINER_API_STREAM_PORT=5005
-
-# the version used to install text-generation-webui from
-WEBUI_VERSION=HEAD

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,68 +1,65 @@
+# DEV
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as builder
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git vim build-essential python3-dev python3-venv && \
+    apt-get install --no-install-recommends -y git ninja-build build-essential python3-dev python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/oobabooga/GPTQ-for-LLaMa /build
+ARG QUANT_MODEL_URL QUANT_BRANCH QUANT_SHA
+RUN git clone ${QUANT_MODEL_URL} /build
 
 WORKDIR /build
 
-RUN python3 -m venv /build/venv
-RUN . /build/venv/bin/activate && \
-    pip3 install --upgrade pip setuptools && \
-    pip3 install torch torchvision torchaudio && \
-    pip3 install -r requirements.txt
+RUN git checkout ${QUANT_BRANCH}
+RUN git reset --hard ${QUANT_SHA}
+RUN --mount=type=cache,target=/root/.cache/pip pip install torch
+RUN pip install -r requirements.txt
 
-# https://developer.nvidia.com/cuda-gpus
-# for a rtx 2060: ARG TORCH_CUDA_ARCH_LIST="7.5"
-ARG TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
-RUN . /build/venv/bin/activate && \
-    python3 setup_cuda.py bdist_wheel -d .
 
+ARG TORCH_CUDA_ARCH_LIST
+RUN python3 setup_cuda.py bdist_wheel -d .
+
+# RUNTIME
 FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
-LABEL maintainer="Your Name <your.email@example.com>"
-LABEL description="Docker image for GPTQ-for-LLaMa and Text Generation WebUI"
-
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y libportaudio2 libasound-dev git python3 python3-pip make g++ && \
+    apt-get install --no-install-recommends -y libportaudio2 libasound-dev git python3-dev python3-pip make g++ ninja-build cuda-compiler-11-8 && \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip pip3 install virtualenv
 RUN mkdir /app
 
 WORKDIR /app
 
-ARG WEBUI_VERSION
-RUN test -n "${WEBUI_VERSION}" && git reset --hard ${WEBUI_VERSION} || echo "Using provided webui source"
+RUN --mount=type=cache,target=/root/.cache/pip pip install torch torchvision torchaudio
 
-RUN virtualenv /app/venv
-RUN . /app/venv/bin/activate && \
-    pip3 install --upgrade pip setuptools && \
-    pip3 install torch torchvision torchaudio
+
+# WebUI
+ARG WEBUI_URL WEBUI_BRANCH WEBUI_SHA
+RUN --mount=type=cache,target=/root/.cache/pip <<EOF
+git config --global http.postBuffer 1048576000
+git clone ${WEBUI_URL} /app
+git checkout ${WEBUI_BRANCH}
+git reset --hard ${WEBUI_SHA}
+cd /app/extensions/api && pip install -r requirements.txt
+cd /app/extensions/elevenlabs_tts && pip install -r requirements.txt
+cd /app/extensions/google_translate && pip install -r requirements.txt
+cd /app/extensions/silero_tts && pip install -r requirements.txt
+cd /app/extensions/whisper_stt && pip install -r requirements.txt
+cd /app && pip install -r requirements.txt
+EOF
 
 COPY --from=builder /build /app/repositories/GPTQ-for-LLaMa
-RUN . /app/venv/bin/activate && \
-    pip3 install /app/repositories/GPTQ-for-LLaMa/*.whl
+RUN --mount=type=cache,target=/root/.cache/pip pip install /app/repositories/GPTQ-for-LLaMa/*.whl
 
-COPY extensions/api/requirements.txt /app/extensions/api/requirements.txt
-COPY extensions/elevenlabs_tts/requirements.txt /app/extensions/elevenlabs_tts/requirements.txt
-COPY extensions/google_translate/requirements.txt /app/extensions/google_translate/requirements.txt
-COPY extensions/silero_tts/requirements.txt /app/extensions/silero_tts/requirements.txt
-COPY extensions/whisper_stt/requirements.txt /app/extensions/whisper_stt/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/api && pip3 install -r requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/elevenlabs_tts && pip3 install -r requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/google_translate && pip3 install -r requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/silero_tts && pip3 install -r requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/whisper_stt && pip3 install -r requirements.txt
+# Get Default Model from ./models
+COPY ./models /app/models
 
-COPY requirements.txt /app/requirements.txt
-RUN . /app/venv/bin/activate && \
-    pip3 install -r requirements.txt
+COPY ./docker/entrypoint.sh /app/docker/entrypoint.sh
+RUN chmod +x /app/docker/entrypoint.sh
 
-RUN cp /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda118.so /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so
+# RUN cp /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda118.so /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so
 
-COPY . /app/
-ENV CLI_ARGS=""
-CMD . /app/venv/bin/activate && python3 server.py ${CLI_ARGS}
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+RUN test -e /usr/local/cuda/bin/nvcc
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,58 @@
+# Docker Instructions
+
+Works on WSL2 with CUDA. Tested on TheBloke/wizardLM-7B-GPTQ in 4bit lora. Because I do not want to break my machine running this I am using containers. I had to go branch and SHA hunting for something that worked.
+
+## Setup
+
+1. Move start_docker.sh and stop_docker.sh to /text-generation-webui
+2. Copy .env.example into .env and edit the values within
+3. Download a model on your local machine to save time:
+
+  ```python
+  pip install requests tqdm
+  python download-model.py TheBloke/wizardLM-7B-GPTQ
+  ```
+
+4. Update your CLI ARGS in entrypoint.sh. Make note of the folder downloaded in models. Mine is TheBloke_wizardLM-7B-GPTQ what worked for me was:
+
+  ```sh
+  python3 server.py --model TheBloke_wizardLM-7B-GPTQ --wbits 4 --listen --auto-devices --groupsize 128 --pre_layer 30 --model_type LLaMA --monkey-patch --notebook --verbose --extensions api
+  ```
+
+4. To start container execute:
+
+  ```sh
+  sh start_docker.sh
+  ```
+
+5. To kill container (because container does not wanna die gracefully)
+
+  ```sh
+  sh stop_docker.sh
+  ```
+
+## Changelog
+
+5/25/23: Added shell script to execute Docker and put config args in entrypoint. added pip install git+<https://github.com/johnsmith0031/alpaca_lora_4bit@winglian-setup_pip> just in case it works for anyone. Added installation files for WSL with their sources.
+
+## Works On
+
+RTX 3060
+WIN 11
+WSL 2
+Docker v23.0.5
+Docker Compose version v2.17.3
+
+## Contributing
+
+[EHGP](https://github.com/ehgp)
+
+## Disclaimer
+
+Not responsible if your GPU bricks or WSL takes your GPU hostage.
+
+## Sources
+
+Docker <https://gist.github.com/r7l/99d4c880d5dc9bfa57a8a988eae78696>
+CUDA on WSL <https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl>
+NVIDIA container runtime <https://github.com/nvidia/nvidia-container-runtime#docker-engine-setup>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,15 @@ services:
       args:
         # specify which cuda version your card supports: https://developer.nvidia.com/cuda-gpus
         TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}
-        WEBUI_VERSION: ${WEBUI_VERSION}
+        QUANT_MODEL_URL: ${QUANT_MODEL_URL}
+        QUANT_SHA: ${QUANT_SHA}
+        QUANT_BRANCH: ${QUANT_BRANCH}
+        WEBUI_URL: ${WEBUI_URL}
+        WEBUI_SHA: ${WEBUI_SHA}
+        WEBUI_BRANCH: ${WEBUI_BRANCH}
+        LORA_4BIT_URL: ${LORA_4BIT_URL}
+        LORA_4BIT_BRANCH: ${LORA_4BIT_BRANCH}
+        LORA_4BIT_SHA: ${LORA_4BIT_SHA}
     env_file: .env
     ports:
       - "${HOST_PORT}:${CONTAINER_PORT}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+mkdir /app/repositories/alpaca_lora_4bit
+git config --global http.postBuffer 1048576000
+git clone ${LORA_4BIT_URL} /app/repositories/alpaca_lora_4bit
+cd /app/repositories/alpaca_lora_4bit || exit
+git checkout ${LORA_4BIT_BRANCH}
+git reset --hard ${LORA_4BIT_SHA}
+echo "git+https://github.com/sterlind/GPTQ-for-LLaMa.git@lora_4bit" >> requirements.txt
+pip install -r requirements.txt
+pip install scipy
+cd /app || exit
+
+exec "$@"
+
+# pip install git+https://github.com/johnsmith0031/alpaca_lora_4bit@winglian-setup_pip
+
+python3 server.py --model TheBloke_wizardLM-7B-GPTQ --wbits 4 --listen --auto-devices --groupsize 128 --pre_layer 30 --model_type LLaMA --monkey-patch --notebook --verbose --extensions api
+
+# the following examples have been tested with the files linked in docs/README_docker.md:
+# example running 13b with 4bit/128 groupsize        : CLI_ARGS=--model llama-13b-4bit-128g --wbits 4 --listen --groupsize 128 --pre_layer 25
+# example with loading api extension and public share: CLI_ARGS=--model llama-7b-4bit --wbits 4 --listen --auto-devices --no-stream --extensions api --share
+# example running 7b with 8bit groupsize             : CLI_ARGS=--model llama-7b --load-in-8bit --listen --auto-devices

--- a/docker/install_cuda_wsl.sh
+++ b/docker/install_cuda_wsl.sh
@@ -1,0 +1,28 @@
+# RUN INSIDE WSL https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl
+
+sudo apt-key del 7fa2af80 && \
+wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin && \
+sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
+wget https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda-repo-wsl-ubuntu-12-1-local_12.1.1-1_amd64.deb && \
+sudo dpkg -i cuda-repo-wsl-ubuntu-12-1-local_12.1.1-1_amd64.deb && \
+sudo cp /var/cuda-repo-wsl-ubuntu-12-1-local/cuda-*-keyring.gpg /usr/share/keyrings/ && \
+sudo apt-get update && \
+sudo apt-get -y install cuda && \
+curl -s -L https://nvidia.github.io/nvidia-container-runtime/gpgkey | \
+sudo apt-key add -
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/nvidia-container-runtime/$distribution/nvidia-container-runtime.list | \
+sudo tee /etc/apt/sources.list.d/nvidia-container-runtime.list && \
+sudo apt-get update && \
+sudo apt-get -y install nvidia-container-runtime
+
+# THEN UPDATE YOUR DAEMON.JSON https://github.com/nvidia/nvidia-container-runtime#docker-engine-setup
+#
+#   "default-runtime": "nvidia",
+#   "runtimes": {
+#     "nvidia": {
+#       "path": "/usr/bin/nvidia-container-runtime",
+#       "runtimeArgs": []
+#     }
+#   }
+#

--- a/docker/start_docker.sh
+++ b/docker/start_docker.sh
@@ -1,0 +1,5 @@
+(test -f ./Dockerfile && rm ./Dockerfile); \
+(test -f ./.env && rm ./.env); \
+(test -f ./.dockerignore && rm ./.dockerignore); \
+(test -f ./docker-compose.yml && rm ./docker-compose.yml); \
+ln -s docker/{Dockerfile,docker-compose.yml,.dockerignore,.env} . && docker compose up

--- a/docker/stop_docker.sh
+++ b/docker/stop_docker.sh
@@ -1,0 +1,1 @@
+docker compose kill -s SIGINT && rm ./Dockerfile ./.env ./.dockerignore ./docker-compose.yml && docker system prune --volumes -a -f


### PR DESCRIPTION
# Docker Instructions

Works on WSL2 with CUDA. Tested on TheBloke/wizardLM-7B-GPTQ in 4bit lora. Because I do not want to break my machine running this I am using containers. I had to go branch and SHA hunting for something that worked.

## Setup

1. Move start_docker.sh and stop_docker.sh to /text-generation-webui
2. Copy .env.example into .env and edit the values within
3. Download a model on your local machine to save time:

  ```python
  pip install requests tqdm
  python download-model.py TheBloke/wizardLM-7B-GPTQ
  ```

4. Update your CLI ARGS in entrypoint.sh. Make note of the folder downloaded in models. Mine is TheBloke_wizardLM-7B-GPTQ what worked for me was:

  ```sh
  python3 server.py --model TheBloke_wizardLM-7B-GPTQ --wbits 4 --listen --auto-devices --groupsize 128 --pre_layer 30 --model_type LLaMA --monkey-patch --notebook --verbose --extensions api
  ```

4. To start container execute:

  ```sh
  sh start_docker.sh
  ```

5. To kill container (because container does not wanna die gracefully)

  ```sh
  sh stop_docker.sh
  ```

## Changelog

5/25/23: Added shell script to execute Docker and put config args in entrypoint. added pip install git+<https://github.com/johnsmith0031/alpaca_lora_4bit@winglian-setup_pip> just in case it works for anyone. Added installation files for WSL with their sources.

## Works On

RTX 3060
WIN 11
WSL 2
Docker v23.0.5
Docker Compose version v2.17.3

## Contributing

[EHGP](https://github.com/ehgp)

## Disclaimer

Not responsible if your GPU bricks or WSL takes your GPU hostage.

## Sources

Docker <https://gist.github.com/r7l/99d4c880d5dc9bfa57a8a988eae78696>
CUDA on WSL <https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl>
NVIDIA container runtime <https://github.com/nvidia/nvidia-container-runtime#docker-engine-setup>
