### PR TITLE
Add trust_remote_code support for AutoGPTQ

### DIFF
--- a/modules/AutoGPTQ_loader.py
+++ b/modules/AutoGPTQ_loader.py
@@ -35,6 +35,7 @@ def load_quantized(model_name):
         'device': "cuda:0" if not shared.args.cpu else "cpu",
         'use_triton': shared.args.triton,
         'use_safetensors': use_safetensors,
+        'trust_remote_code': shared.args.trust_remote_code,
         'max_memory': get_max_memory_dict()
     }
 


### PR DESCRIPTION
A one line fix to pass through `trust_remote_code` to AutoGPTQ, which is required for loading some of the newer models such as Falcon