### PR TITLE
Add a `/api/v1/stop-stream` API that allows the user to interrupt the generation

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -5,7 +5,7 @@ from threading import Thread
 from extensions.api.util import build_parameters, try_start_cloudflared
 from modules import shared
 from modules.chat import generate_chat_reply
-from modules.text_generation import encode, generate_reply
+from modules.text_generation import encode, generate_reply, stop_everything_event
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -74,6 +74,19 @@ class Handler(BaseHTTPRequestHandler):
                 'results': [{
                     'history': answer
                 }]
+            })
+
+            self.wfile.write(response.encode('utf-8'))
+
+        elif self.path == '/api/v1/stop':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+
+            stop_everything_event()
+
+            response = json.dumps({
+                'results': 'success'
             })
 
             self.wfile.write(response.encode('utf-8'))

--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -78,7 +78,7 @@ class Handler(BaseHTTPRequestHandler):
 
             self.wfile.write(response.encode('utf-8'))
 
-        elif self.path == '/api/v1/stop':
+        elif self.path == '/api/v1/stop-stream':
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
             self.end_headers()


### PR DESCRIPTION
I implemented this feature using the `stop_everything_event` method

It is only available for the stream APIs. So I renamed the API to `stop-stream` to avoid confusion.