### PR TITLE
Fix hang in tokenizer for AutoGPTQ llama models.

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -114,7 +114,7 @@ def load_tokenizer(model_name, model):
     tokenizer = None
     if shared.model_type == 'gpt4chan' and Path(f"{shared.args.model_dir}/gpt-j-6B/").exists():
         tokenizer = AutoTokenizer.from_pretrained(Path(f"{shared.args.model_dir}/gpt-j-6B/"))
-    elif type(model) is transformers.LlamaForCausalLM:
+    elif type(model) is transformers.LlamaForCausalLM or "LlamaGPTQForCausalLM" in str(type(model)):
         # Try to load an universal LLaMA tokenizer
         if shared.model_type not in ['llava', 'oasst']:
             for p in [Path(f"{shared.args.model_dir}/llama-tokenizer/"), Path(f"{shared.args.model_dir}/oobabooga_llama-tokenizer/")]:


### PR DESCRIPTION
This affected me, not sure if it affects you. Loading hangs because it returns a different model type and then uses autotokenizer. Model loading for llama models goes to over 200s. I thought it was a AutoGPTQ bug but it is not.