### PR TITLE
Update Dockerfile to resolve superbooga requirement error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ LABEL maintainer="Your Name <your.email@example.com>"
 LABEL description="Docker image for GPTQ-for-LLaMa and Text Generation WebUI"
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y libportaudio2 libasound-dev git python3 python3-pip make g++ && \
+    apt-get install --no-install-recommends -y python3-dev libportaudio2 libasound-dev git python3 python3-pip make g++ && \
     rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install virtualenv


### PR DESCRIPTION
In my dockerfile, i added the extension for superbooga with the following lines after the other similar extension lines.

> COPY extensions/superbooga/requirements.txt /app/extensions/superbooga/requirements.txt
> RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/superbooga && pip3 install -r requirements.txt

This threw the following exception

> #0 9.790       /tmp/pip-build-env-fnkgxx14/overlay/lib/python3.10/site-packages/pybind11/include/pybind11/detail/../detail/common.h:266:10: fatal error: Python.h: No such file or directory
> #0 9.790         266 | #include <Python.h>

Adding python3-dev to the install list for the image resolved the error for me.