### PR TITLE
error when downloading a model for the first time

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -197,7 +197,7 @@ def start_download_threads(file_list, output_folder, start_from_scratch=False, t
 def download_model_files(model, branch, links, sha256, output_folder, start_from_scratch=False, threads=1):
     # Creating the folder and writing the metadata
     if not output_folder.exists():
-        output_folder.mkdir()
+        output_folder.mkdir(parents=True, exist_ok=True)
     with open(output_folder / 'huggingface-metadata.txt', 'w') as f:
         f.write(f'url: https://huggingface.co/{model}\n')
         f.write(f'branch: {branch}\n')


### PR DESCRIPTION
Fix this error when trying to download a model for the first time

```
% python ~/Downloads/download-model.py --threads=4  sambanovasystems/BLOOMChat-176B-v1
Traceback (most recent call last):
  File "/home/opyate/Downloads/download-model.py", line 277, in <module>
    download_model_files(model, branch, links, sha256, output_folder, threads=args.threads)
  File "/home/opyate/Downloads/download-model.py", line 200, in download_model_files
    output_folder.mkdir()
  File "/home/opyate/anaconda3/envs/py39/lib/python3.9/pathlib.py", line 1323, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: 'models/sambanovasystems_BLOOMChat-176B-v1'
```