### PR TITLE
Add fixed Flash attention code

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Optionally, you can use the following command-line flags:
 | `--no-cache`                                | Set `use_cache` to False while generating text. This reduces the VRAM usage a bit with a performance cost. |
 | `--xformers`                                | Use xformer's memory efficient attention. This should increase your tokens/s. |
 | `--sdp-attention`                           | Use torch 2.0's sdp attention. |
+| `--flash-attention`                         | Use HazyResearch's Flash Attention. This drastically reduces the VRAM cost |
 | `--trust-remote-code`                       | Set trust_remote_code=True while loading a model. Necessary for ChatGLM and Falcon. |
 
 #### Accelerate 4-bit

--- a/modules/llama_attn_hijack.py
+++ b/modules/llama_attn_hijack.py
@@ -23,6 +23,9 @@ def hijack_llama_attention():
     elif shared.args.sdp_attention:
         transformers.models.llama.modeling_llama.LlamaAttention.forward = sdp_attention_forward
         logger.info("Replaced attention with sdp_attention")
+    elif shared.args.flash_attention:
+        transformers.models.llama.modeling_llama.LlamaAttention.forward = flash_attention_forward
+        logger.info("Replaced attention with flash_attention")
 
 
 def xformers_forward(
@@ -169,3 +172,168 @@ def sdp_attention_forward(
     attn_output = self.o_proj(attn_output)
 
     return attn_output, attn_weights, past_key_value
+
+# Implementation graciously copied from https://github.com/LAION-AI/Open-Assistant/blob/main/model/model_training/models/patching_llama.py
+# and ported to work with HuggingFace Transformers
+def compute_flash_attention(q, k, v, attention_mask=None, head_mask=None):
+    from flash_attn.flash_attn_interface import flash_attn_unpadded_qkvpacked_func
+    
+    # q, k, v: [bs, seq_len, num_attention_heads, attn_head_size]
+    # attention_mask (float): [bs, seq_len]
+    batch_size, max_len = q.size(0), q.size(1)
+
+    qkv = torch.stack([q, k, v], dim=2).to(
+        torch.float16
+    )  # need to truncate in case input is fp32
+    cu_seqlens, max_seqlen = None, None
+
+    if attention_mask is None:
+        return flash_attn_unpadded_qkvpacked_func(
+            qkv,
+            dropout_p=0.0,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            causal=True,
+        )
+    else:
+        # Limitation: non-contiguous attention mask will not be handled correctly
+        # model will be able to pay attention between the first and last non-masked token, i.e. left- and right-side padding is supported.
+        csums = (attention_mask >= 0).cumsum(dim=1)
+        ends = csums.argmax(dim=1) + 1
+        starts = ends - csums.max(dim=1).values
+        seqlens = ends - starts
+
+        qkv = torch.cat([qkv[i, starts[i] : ends[i]] for i in range(batch_size)], dim=0)
+        zero = torch.zeros_like(
+            seqlens[:1]
+        )  # torch.tensor([0]) with correct dtype and device
+        cu_seqlens = torch.cat([zero, seqlens.cumsum(dim=0)], dim=0).to(torch.int32)
+        max_seqlen = seqlens.max().item()
+
+        out = flash_attn_unpadded_qkvpacked_func(
+            qkv,
+            dropout_p=0.0,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            causal=True,
+        )
+        # out: [num_unmasked_tokens, num_attention_heads, attn_head_size]
+
+        seqs = [out[start:end] for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])]
+        # stack and pad sequences together
+        padded_seqs = [
+            nn.functional.pad(
+                seqs[i],
+                (0, 0) * (seqs[i].dim() - 1) + (starts[i], max_len - ends[i]),
+                value=0.0,
+            )
+            for i in range(batch_size)
+        ]
+        out = torch.stack(padded_seqs)
+        return out
+
+
+def flash_attention_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states = (
+        self.q_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    key_states = (
+        self.k_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    value_states = (
+        self.v_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    (
+        query_states,
+        key_states,
+    ) = transformers.models.llama.modeling_llama.apply_rotary_pos_emb(
+        query_states, key_states, cos, sin, position_ids
+    )
+    # [bsz, nh, t, hd]
+
+    if past_key_value is not None:
+        # reuse k, v, self_attention
+        key_states = torch.cat([past_key_value[0], key_states], dim=2)
+        value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+    past_key_value = (key_states, value_states) if use_cache else None
+
+    # We only apply sdp attention if we don't need to output the whole attention matrix
+    if not output_attentions and (query_states.shape == key_states.shape):
+        if attention_mask is not None:
+            attention_mask = attention_mask[:, 0, -1]
+
+        out_dtype = value_states.dtype
+        q, k, v = (
+            query_states.transpose(1, 2),
+            key_states.transpose(1, 2),
+            value_states.transpose(1, 2),
+        )
+        attn_output = compute_flash_attention(q, k, v, attention_mask)
+        attn_output = attn_output.transpose(1, 2).to(out_dtype)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+    else:
+        attn_weights = torch.matmul(
+            query_states, key_states.transpose(2, 3)
+        ) / math.sqrt(self.head_dim)
+
+        if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention weights should be of size {(bsz * self.num_heads, q_len, kv_seq_len)}, but is"
+                f" {attn_weights.size()}"
+            )
+
+        if attention_mask is not None:
+            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                )
+            attn_weights = attn_weights + attention_mask
+            attn_weights = torch.max(
+                attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min)
+            )
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(
+            attn_weights, dim=-1, dtype=torch.float32
+        ).to(query_states.dtype)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+    attn_output = attn_output.transpose(1, 2)
+    attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+
+    attn_output = self.o_proj(attn_output)
+
+    return attn_output, None, past_key_value

--- a/modules/models.py
+++ b/modules/models.py
@@ -105,7 +105,7 @@ def load_model(model_name):
             tokenizer = load_tokenizer(model_name, model)
 
     # Hijack attention with xformers
-    if any((shared.args.xformers, shared.args.sdp_attention)):
+    if any((shared.args.xformers, shared.args.sdp_attention, shared.args.flash_attention)):
         llama_attn_hijack.hijack_llama_attention()
 
     logger.info(f"Loaded the model in {(time.time()-t0):.2f} seconds.\n")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -110,6 +110,7 @@ parser.add_argument('--bf16', action='store_true', help='Load the model with bfl
 parser.add_argument('--no-cache', action='store_true', help='Set use_cache to False while generating text. This reduces the VRAM usage a bit at a performance cost.')
 parser.add_argument('--xformers', action='store_true', help="Use xformer's memory efficient attention. This should increase your tokens/s.")
 parser.add_argument('--sdp-attention', action='store_true', help="Use torch 2.0's sdp attention.")
+parser.add_argument('--flash-attention', action='store_true', help="Use HazyResearch's Flash Attention. This drastically reduces VRAM cost")
 parser.add_argument('--trust-remote-code', action='store_true', help="Set trust_remote_code=True while loading a model. Necessary for ChatGLM and Falcon.")
 
 # Accelerate 4-bit


### PR DESCRIPTION
This PR fixes the flash attention implementation that is currently in the repo and adds the `--flash-attention` flag to activate it.
To use it, install flash attention:
```
pip install ninja
pip install flash-attn
```
If that doesn't work (it should only take < 20 minutes), you need to compile from source with ninja:
```
pip install ninja
git clone https://github.com/HazyResearch/flash-attention.git
cd flash-attention
python setup.py install
```
If downstream users confirm it is working for them, I will add the pip install to the requirements.txt

With the fixed implementation, flash attention works as expected:

RTX 3090 (24 GB VRAM)
tsumeone SuperCOT 30B 128 groupsize CUDA:
```
Max new tokens: 1
3001 tokens
w/ flash attention: OOM

2614 tokens:
w/ flash attention: 23.7 GB
```

llama 13B with an 8 Rank LoRA applied:
```
Max new tokens: 1
3001 tokens
w flash attention: 12.7 GB
w/o flash attention: 15.3 GB

4002 tokens
w flash attention: ~14 GB
w/o flash attention: 17.7 GB
```

In fact, I can get 6300 tokens on 13B.

The current implementation in the repo uses PyTorch's scaled_dot_product to perform the attention call. This method falls back to standard attention when flash attention or memory efficient attention is not available -- so what's wrong? PyTorch's implementation is somewhat old, and at the time, flash attention did not support attention masking in the forward pass, so trying to run it with the attention mask fails and falls back to normal attention. Since that time, HazyResearch has already updated their flash attention to work for Causal language modeling, so we can just use it directly from the source. Maybe in the future PyTorch will fix their version. 

Also, all credit for the code goes to LAION who already implemented it for LLaMa:
https://github.com/LAION-AI/Open-Assistant/blob/main/model/model_training/models/patching_llama.py

I merely took the code there and adapted it to work without the rest of their scaffolding.

**NOTE:
This PR works, but it is not ready to be merged since flash attention requires either `pip install flash-attn` or compilation from the source by cloning HazyResearch's repo and following the source compiling instructions. I already had it compiled on my machine, so until it is confirmed that downstream users can compile on their machine or the pip install works for them (Personally it froze for me which is why I had to compile from source with ninja), I would not recommend pushing this through just yet.**

But once it is pushed I think everyone should use Flash Attention by default -- it exists for a reason, there is no catch!
