### PR TITLE
Fixed missing TFS and Top_A

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -229,6 +229,8 @@ class Handler(BaseHTTPRequestHandler):
                 'mirostat_eta': 0.1,
                 'ban_eos_token': False,
                 'skip_special_tokens': True,
+                'tfs': float(shared.settings.get('tfs', 1)),
+                'top_a': float(shared.settings.get('top_a', 0))
             }
 
             # fixup absolute 0.0's
@@ -580,6 +582,8 @@ class Handler(BaseHTTPRequestHandler):
                 'ban_eos_token': False,
                 'skip_special_tokens': True,
                 'custom_stopping_strings': [],
+                'tfs': float(shared.settings.get('tfs', 1)),
+                'top_a': float(shared.settings.get('top_a', 0))
             }
 
             if debug:


### PR DESCRIPTION
Was using the App with Airboros and couldn't get a response from the API, 

Fixed these errors for me:
```
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 42206)
Traceback (most recent call last):
  File "/usr/bin/conda/envs/textgen/lib/python3.10/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/bin/conda/envs/textgen/lib/python3.10/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/bin/conda/envs/textgen/lib/python3.10/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/bin/conda/envs/textgen/lib/python3.10/http/server.py", line 433, in handle
    self.handle_one_request()
  File "/usr/bin/conda/envs/textgen/lib/python3.10/http/server.py", line 421, in handle_one_request
    method()
  File "/home/atom/webchat/text-generation-webui/extensions/openai/script.py", line 405, in do_POST
    for a in generator:
  File "/home/atom/webchat/text-generation-webui/modules/text_generation.py", line 24, in generate_reply
    for result in _generate_reply(*args, **kwargs):
  File "/home/atom/webchat/text-generation-webui/modules/text_generation.py", line 191, in _generate_reply
    for reply in generate_func(question, original_question, seed, state, eos_token, stopping_strings, is_chat=is_chat):
  File "/home/atom/webchat/text-generation-webui/modules/text_generation.py", line 198, in generate_reply_HF
    generate_params[k] = state[k]
KeyError: 'top_a' 
```
```
Exception occurred during processing of request from ('127.0.0.1', 56136)
Traceback (most recent call last):
  File "/usr/bin/conda/envs/textgen/lib/python3.10/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/bin/conda/envs/textgen/lib/python3.10/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/bin/conda/envs/textgen/lib/python3.10/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/bin/conda/envs/textgen/lib/python3.10/http/server.py", line 433, in handle
    self.handle_one_request()
  File "/usr/bin/conda/envs/textgen/lib/python3.10/http/server.py", line 421, in handle_one_request
    method()
  File "/home/atom/webchat/text-generation-webui/extensions/openai/script.py", line 404, in do_POST
    for a in generator:
  File "/home/atom/webchat/text-generation-webui/modules/text_generation.py", line 24, in generate_reply
    for result in _generate_reply(*args, **kwargs):
  File "/home/atom/webchat/text-generation-webui/modules/text_generation.py", line 191, in _generate_reply
    for reply in generate_func(question, original_question, seed, state, eos_token, stopping_strings, is_chat=is_chat):
  File "/home/atom/webchat/text-generation-webui/modules/text_generation.py", line 198, in generate_reply_HF
    generate_params[k] = state[k]
KeyError: 'tfs'

```