### PR TITLE
Add a download progress bar to the web UI.

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -194,8 +194,8 @@ class ModelDownloader:
         r = self.s.get(url, stream=True, headers=headers, timeout=10)
         with open(output_path, mode) as f:
             total_size = int(r.headers.get('content-length', 0))
-            # Every 512Kb we report an update
-            block_size = 512*1024
+            # Every 4MB we report an update
+            block_size = 4*1024*1024
 
             with tqdm.tqdm(total=total_size, unit='iB', unit_scale=True, bar_format='{l_bar}{bar}| {n_fmt:6}/{total_fmt:6} {rate_fmt:6}') as t:
                 count = 0

--- a/download-model.py
+++ b/download-model.py
@@ -194,18 +194,25 @@ class ModelDownloader:
         r = self.s.get(url, stream=True, headers=headers, timeout=10)
         with open(output_path, mode) as f:
             total_size = int(r.headers.get('content-length', 0))
-            block_size = 1024
+            # Every 512Kb we report an update
+            block_size = 512*1024
+
             with tqdm.tqdm(total=total_size, unit='iB', unit_scale=True, bar_format='{l_bar}{bar}| {n_fmt:6}/{total_fmt:6} {rate_fmt:6}') as t:
+                count = 0
                 for data in r.iter_content(block_size):
                     t.update(len(data))
                     f.write(data)
+                    if self.progress_bar is not None:
+                        count += len(data)
+                        self.progress_bar(float(count)/float(total_size), f"Downloading {filename}")
 
 
     def start_download_threads(self, file_list, output_folder, start_from_scratch=False, threads=1):
         thread_map(lambda url: self.get_single_file(url, output_folder, start_from_scratch=start_from_scratch), file_list, max_workers=threads, disable=True)
 
 
-    def download_model_files(self, model, branch, links, sha256, output_folder, start_from_scratch=False, threads=1):
+    def download_model_files(self, model, branch, links, sha256, output_folder, progress_bar = None, start_from_scratch=False, threads=1):
+        self.progress_bar = progress_bar
         # Creating the folder and writing the metadata
         if not output_folder.exists():
             output_folder.mkdir(parents=True, exist_ok=True)

--- a/server.py
+++ b/server.py
@@ -211,6 +211,7 @@ def download_model_wrapper(repo_id, progress=gr.Progress()):
             downloader.download_model_files(model, branch, links, sha256, output_folder, progress_bar=progress, threads=1)
             yield ("Done!")
     except:
+        progress(1.0)
         yield traceback.format_exc()
 
 

--- a/server.py
+++ b/server.py
@@ -182,7 +182,7 @@ def count_tokens(text):
     return f'{tokens} tokens in the input.'
 
 
-def download_model_wrapper(repo_id):
+def download_model_wrapper(repo_id, progress=gr.Progress()):
     try:
         downloader_module = importlib.import_module("download-model")
         downloader = downloader_module.ModelDownloader()
@@ -191,6 +191,7 @@ def download_model_wrapper(repo_id):
         branch = repo_id_parts[1] if len(repo_id_parts) > 1 else "main"
         check = False
 
+        progress(0.0)
         yield ("Cleaning up the model/branch names")
         model, branch = downloader.sanitize_model_and_branch_names(model, branch)
 
@@ -201,11 +202,13 @@ def download_model_wrapper(repo_id):
         output_folder = downloader.get_output_folder(model, branch, is_lora)
 
         if check:
+            progress(0.5)
             yield ("Checking previously downloaded files")
             downloader.check_model_files(model, branch, links, sha256, output_folder)
+            progress(1.0)
         else:
             yield (f"Downloading files to {output_folder}")
-            downloader.download_model_files(model, branch, links, sha256, output_folder, threads=1)
+            downloader.download_model_files(model, branch, links, sha256, output_folder, progress_bar=progress, threads=1)
             yield ("Done!")
     except:
         yield traceback.format_exc()
@@ -450,7 +453,7 @@ def create_model_menus():
         save_model_settings, [shared.gradio[k] for k in ['model_menu', 'interface_state']], shared.gradio['model_status'], show_progress=False)
 
     shared.gradio['lora_menu_apply'].click(load_lora_wrapper, shared.gradio['lora_menu'], shared.gradio['model_status'], show_progress=False)
-    shared.gradio['download_model_button'].click(download_model_wrapper, shared.gradio['custom_model_menu'], shared.gradio['model_status'], show_progress=False)
+    shared.gradio['download_model_button'].click(download_model_wrapper, shared.gradio['custom_model_menu'], shared.gradio['model_status'], show_progress=True)
     shared.gradio['autoload_model'].change(lambda x: gr.update(visible=not x), shared.gradio['autoload_model'], load)
 
 


### PR DESCRIPTION
This places a download progress bar for each file on the model screen, so you can see how far along it's gotten.

It also should increase the amount of data between updates to the download rate display to every 512K (or when the file is done) from every 1K, so it's hopefully not as chatty. Since model downloads are on the order of 6-65GB download speeds are generally going to have to be able to handle 512K in sub-second intervals, so the visual update will still likely be fast.

The progress display overlays the Markdown block slightly.