### PR TITLE
Fixes Falcon error 'Expected query, key, and value to have the same dtype'.

### DIFF
--- a/modules/falcon_fixer.py
+++ b/modules/falcon_fixer.py
@@ -1,0 +1,29 @@
+from modules.logging_colors import logger
+
+
+def patch_falcon_rotary_embedding(model):
+    """The `modelling_RW.py` provided with some of the Falcon models has a bug in its rotary embedding code where it doesn't respect the incoming datatypes. This causes a crash such as `RuntimeError: Expected query, key, and value to have the same dtype, but got query.dtype: float key.dtype: float and value.dtype: c10::Half instead.` when using a custom dtype.
+
+    Our fix is to monkeypatch `RotaryEmbedding.forward` to wrap the original implementation to cast the result back to the incoming dtype. This will have no effect if the original implementation is correct (since we'd convert from the same dtype to the same dtype which is a no-op.)
+    """
+
+    if model.__class__.__name__ != 'RWForCausalLM':
+        return model
+
+    # Since the code is downloaded dynamically, it's easiest to find the RotaryEmbedding module by name.
+    for name, child in model.named_modules():
+        if child.__class__.__name__ != 'RotaryEmbedding':
+            continue
+
+        logger.info(f"Found Falcon RotaryEmbedding. Patching...")
+        original_forward = child.__class__.forward
+
+        def falcon_rotary_forward_wrapper(self, q, k):
+            out_q, out_k = original_forward(self, q, k)
+            return out_q.to(q.dtype), out_k.to(k.dtype)
+
+        child.__class__.forward = falcon_rotary_forward_wrapper
+        # Since we're patching the class (not the instance), all instances will be patched.
+        break
+
+    return model

--- a/modules/models.py
+++ b/modules/models.py
@@ -15,7 +15,7 @@ from transformers import (AutoConfig, AutoModel, AutoModelForCausalLM,
                           BitsAndBytesConfig, LlamaTokenizer)
 
 import modules.shared as shared
-from modules import llama_attn_hijack, sampler_hijack
+from modules import llama_attn_hijack, sampler_hijack, falcon_fixer
 from modules.logging_colors import logger
 
 transformers.logging.set_verbosity_error()
@@ -108,7 +108,9 @@ def load_model(model_name):
     if any((shared.args.xformers, shared.args.sdp_attention)):
         llama_attn_hijack.hijack_llama_attention()
 
-    logger.info(f"Loaded the model in {(time.time()-t0):.2f} seconds.\n")
+    model = falcon_fixer.patch_falcon_rotary_embedding(model)
+
+    logger.info(f"Loaded the model in {(time.time() - t0):.2f} seconds.\n")
     return model, tokenizer
 
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -108,7 +108,8 @@ def load_model(model_name):
     if any((shared.args.xformers, shared.args.sdp_attention)):
         llama_attn_hijack.hijack_llama_attention()
 
-    model = falcon_fixer.patch_falcon_rotary_embedding(model)
+    if model.__class__.__name__ == 'RWForCausalLM':
+        model = falcon_fixer.patch_falcon_rotary_embedding(model)
 
     logger.info(f"Loaded the model in {(time.time() - t0):.2f} seconds.\n")
     return model, tokenizer


### PR DESCRIPTION
The custom code distributed with the Falcon models breaks if you change the dtype used by the model, for example by using `load_in_4bit`. (Strangely, it's not true for all the models on HuggingFace, some are OK.)

This PR hotfixes the problem without affecting versions that already have it right. If later a fixed version of the Falcon model is landed in Transformers, it might still be useful to keep this auto-fix around for a while since the models that already are on HF Hub today will continue to have the problem.

Fixes #2437.