### PR TITLE
fix: reverse-proxied URI should end with 'chat', not 'generate'

### DIFF
--- a/api-examples/api-example-chat.py
+++ b/api-examples/api-example-chat.py
@@ -7,7 +7,7 @@ HOST = 'localhost:5000'
 URI = f'http://{HOST}/api/v1/chat'
 
 # For reverse-proxied streaming, the remote will likely host with ssl - https://
-# URI = 'https://your-uri-here.trycloudflare.com/api/v1/generate'
+# URI = 'https://your-uri-here.trycloudflare.com/api/v1/chat'
 
 
 def run(user_input, history):


### PR DESCRIPTION
Self-explanatory title. I just ran into this on my machine. Not a big thing but some people (like me) might get a little thrown by it.