### PR TITLE
Windows commands to install llama-cpp-python changed

### DIFF
--- a/docs/llama.cpp-models.md
+++ b/docs/llama.cpp-models.md
@@ -30,8 +30,8 @@ CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python --no-c
 
 ```
 pip uninstall -y llama-cpp-python
-set CMAKE_ARGS="-DLLAMA_CUBLAS=on"
-set FORCE_CMAKE=1
+set "CMAKE_ARGS=-DLLAMA_OPENBLAS=on"
+set "FORCE_CMAKE=1"
 pip install llama-cpp-python --no-cache-dir
 ```
 


### PR DESCRIPTION
The commands as they are did not work in my Windows Anaconda prompt (compilation failed), then with changes suggested in https://github.com/oobabooga/text-generation-webui/issues/1534#issuecomment-1557287144 it worked.