### PR TITLE
Sending peft back to original (issue with kwargs in PeftConfig) and lora.py changes

### DIFF
--- a/modules/LoRA.py
+++ b/modules/LoRA.py
@@ -77,7 +77,7 @@ def add_lora_to_model(lora_names):
                 elif shared.args.load_in_8bit:
                     params['device_map'] = {'': 0}
 
-            shared.model = PeftModel.from_pretrained(shared.model, Path(f"{shared.args.lora_dir}/{lora_names[0]}"), **params)
+            shared.model = PeftModel.from_pretrained(shared.model, Path(f"{shared.args.lora_dir}/{lora_names[0]}"),adapter_name=lora_names[0], **params)
 
             for lora in lora_names[1:]:
                 shared.model.load_adapter(Path(f"{shared.args.lora_dir}/{lora}"), lora)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sentencepiece
 tqdm
 scipy
 transformers==4.30.0
-git+https://github.com/huggingface/peft@e45529b149c7f91ec1d4d82a5a152ef56c56cb94
+git+https://github.com/huggingface/peft@3714aa2fff158fdfa637b2b65952580801d890b2
 bitsandbytes==0.39.0; platform_system != "Windows"
 https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.39.0-py3-none-any.whl; platform_system == "Windows"
 llama-cpp-python==0.1.62; platform_system != "Windows"


### PR DESCRIPTION
see peft_model.py line 169, # load the config, the new repo passes kwargs to PeftConfig that will break ooba
PeftConfig doesn't want 'dtype' and 'device_map'
1. check if newer peft fixes it
2. the main should stay on old peft untill this is fixed otherwise loading LORA doesn't work