### PR TITLE
Small bug, when arbitrary loading character.json that doesn't exist

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -518,7 +518,12 @@ def load_character(character, name1, name2, instruct=False):
             if filepath.exists():
                 break
 
-        file_contents = open(filepath, 'r', encoding='utf-8').read()
+        try:
+            file_contents = open(filepath, 'r', encoding='utf-8').read()
+        except FileNotFoundError as e:
+            logger.error(f"Could not find character file for {character} in {folder} folder. Please check your spelling.")
+            return
+        
         data = json.loads(file_contents) if extension == "json" else yaml.safe_load(file_contents)
 
         # Finding the bot's name

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -513,17 +513,17 @@ def load_character(character, name1, name2, instruct=False):
     if character != 'None':
         folder = 'characters' if not instruct else 'characters/instruction-following'
         picture = generate_pfp_cache(character)
+        filepath = None
         for extension in ["yml", "yaml", "json"]:
             filepath = Path(f'{folder}/{character}.{extension}')
             if filepath.exists():
                 break
 
-        try:
-            file_contents = open(filepath, 'r', encoding='utf-8').read()
-        except FileNotFoundError:
+        if filepath is None:
             logger.error(f"Could not find character file for {character} in {folder} folder. Please check your spelling.")
-            return
-        
+            return name1, name2, picture, greeting, context, turn_template.replace("\n", r"\n")
+
+        file_contents = open(filepath, 'r', encoding='utf-8').read()
         data = json.loads(file_contents) if extension == "json" else yaml.safe_load(file_contents)
 
         # Finding the bot's name

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -520,7 +520,7 @@ def load_character(character, name1, name2, instruct=False):
 
         try:
             file_contents = open(filepath, 'r', encoding='utf-8').read()
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             logger.error(f"Could not find character file for {character} in {folder} folder. Please check your spelling.")
             return
         


### PR DESCRIPTION
When opening a character file that doesn't exist, we needed to add a try / except FileNotFoundError fixing #2482 