### PR TITLE
Add context_instruct parameter to API

### DIFF
--- a/extensions/api/util.py
+++ b/extensions/api/util.py
@@ -62,7 +62,7 @@ def build_parameters(body, chat=False):
             'greeting': greeting,
             'name1_instruct': name1_instruct,
             'name2_instruct': name2_instruct,
-            'context_instruct': context_instruct,
+            'context_instruct': body.get('context_instruct',  context_instruct),
             'turn_template': turn_template,
             'chat-instruct_command': str(body.get('chat-instruct_command', shared.settings['chat-instruct_command'])),
         })


### PR DESCRIPTION
I found it useful to be able to override the context text from the API. The context text is basically the equivalent of OpenAI's system message which makes sense to be able to control through the API.