### PR TITLE
When model is loaded/unloaded/reloaded the LORA names are no longer valid

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -329,6 +329,7 @@ def clear_torch_cache():
 
 def unload_model():
     shared.model = shared.tokenizer = None
+    shared.lora_names = []
     clear_torch_cache()
 
 

--- a/server.py
+++ b/server.py
@@ -362,17 +362,21 @@ def create_model_menus():
     load.click(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
         update_model_parameters, shared.gradio['interface_state'], None).then(
-        partial(load_model_wrapper, autoload=True), shared.gradio['model_menu'], shared.gradio['model_status'], show_progress=False)
+        partial(load_model_wrapper, autoload=True), shared.gradio['model_menu'], shared.gradio['model_status'], show_progress=False).then(
+        lambda: shared.lora_names, None,shared.gradio['lora_menu'])
 
     unload.click(
         unload_model, None, None).then(
-        lambda: "Model unloaded", None, shared.gradio['model_status'])
+        lambda: "Model unloaded", None, shared.gradio['model_status']).then(
+        lambda: shared.lora_names, None,shared.gradio['lora_menu'])
+
 
     reload.click(
         unload_model, None, None).then(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
         update_model_parameters, shared.gradio['interface_state'], None).then(
-        partial(load_model_wrapper, autoload=True), shared.gradio['model_menu'], shared.gradio['model_status'], show_progress=False)
+        partial(load_model_wrapper, autoload=True), shared.gradio['model_menu'], shared.gradio['model_status'], show_progress=False).then(
+        lambda: shared.lora_names, None,shared.gradio['lora_menu'])
 
     save_settings.click(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(


### PR DESCRIPTION
This will reset lora list and clear the LORA box after model load/reload/unload
In each case the LORA was already destroyed, but the box still showed LORA names and lora_names still had list of (invalid) loras that would mess up next time you use add_lora_to_model (because it thinks some loras were already loaded, even though the model is not yet PEFT, but a casualllama or whatever else you loaded in meantime

1. clear lora list on unload_model
2. reloading LORA after model load/unload/reload