### PR TITLE
Update llama.cpp-models.md for macOS

### DIFF
--- a/docs/llama.cpp-models.md
+++ b/docs/llama.cpp-models.md
@@ -35,6 +35,13 @@ set FORCE_CMAKE=1
 pip install llama-cpp-python --no-cache-dir
 ```
 
+#### macOS
+
+```
+pip uninstall -y llama-cpp-python
+CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir
+```
+
 Here you can find the different compilation options for OpenBLAS / cuBLAS / CLBlast: https://pypi.org/project/llama-cpp-python/
 
 ## Performance


### PR DESCRIPTION
I added commands for building llama-cpp-python with metal GPU acceleration for macOS.

I tested it with python 3.10 + pytorch 2.0.1 on macOS 13.4 on MacBook Pro 14" M1 Max. It works!