### PR TITLE
Fix issue with missing `wheel` install 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /build
 
 RUN python3 -m venv /build/venv
 RUN . /build/venv/bin/activate && \
-    pip3 install --upgrade pip setuptools && \
+    pip3 install --upgrade pip setuptools wheel && \
     pip3 install torch torchvision torchaudio && \
     pip3 install -r requirements.txt
 
@@ -39,7 +39,7 @@ RUN test -n "${WEBUI_VERSION}" && git reset --hard ${WEBUI_VERSION} || echo "Usi
 
 RUN virtualenv /app/venv
 RUN . /app/venv/bin/activate && \
-    pip3 install --upgrade pip setuptools && \
+    pip3 install --upgrade pip setuptools wheel && \
     pip3 install torch torchvision torchaudio
 
 COPY --from=builder /build /app/repositories/GPTQ-for-LLaMa


### PR DESCRIPTION
Running `docker build -f docker/Dockerfile` gives this error: 
Closes https://github.com/oobabooga/text-generation-webui/issues/2627

```
No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
usage: setup_cuda.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup_cuda.py --help [cmd1 cmd2 ...]
   or: setup_cuda.py --help-commands
   or: setup_cuda.py cmd --help

error: invalid command 'bdist_wheel'
Error: building at STEP "RUN . /build/venv/bin/activate &&     python3 setup_cuda.py bdist_wheel -d .": while running runtime: exit status 1

```


<img width="1430" alt="Screenshot 2023-06-16 at 12 01 16 PM" src="https://github.com/oobabooga/text-generation-webui/assets/4955119/3be9bc13-c6f3-477a-b7c6-7ffc248cfe9c">
