### PR TITLE
Add Api `/api/v1/encode` and `/api/v1/decode`

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -1,4 +1,6 @@
 import json
+import torch
+
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 
@@ -9,7 +11,7 @@ from modules.LoRA import add_lora_to_model
 from modules.models import load_model, unload_model
 from modules.models_settings import (get_model_settings_from_yamls,
                                      update_model_parameters)
-from modules.text_generation import (encode, generate_reply,
+from modules.text_generation import (encode, decode, generate_reply,
                                      stop_everything_event)
 from modules.utils import get_available_models
 
@@ -181,6 +183,108 @@ class Handler(BaseHTTPRequestHandler):
             })
 
             self.wfile.write(response.encode('utf-8'))
+
+        elif self.path == '/api/v1/encode':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+
+            prompt = body['prompt']
+            add_special_tokens = body.get('add_special_tokens', True)
+            add_bos_token = body.get('add_bos_token', True)
+            truncation_length = body.get('truncation_length')
+
+            tokens = encode(prompt, add_special_tokens, add_bos_token, truncation_length)[0]
+            # tensor to list
+            token_ids = [t.item() for t in tokens]
+
+            # Using encode directly for each token would cause spaces to be lost
+            # and non-english characters could be encoded as multiple tokens
+            token_texts = []
+            tokens = torch.tensor([])
+            new_ids = []
+            length = 0
+            for t in token_ids:
+                new_tokens = torch.tensor([t])
+                tokens = torch.cat((tokens, new_tokens))
+                new_ids.extend([t])
+                decoded_text = decode(tokens, not add_special_tokens)
+                # Take the new part from the end of decoded_text as the text of the new_tokens
+                new_text_length = len(decoded_text) - length
+                new_text = decoded_text[-new_text_length:]
+
+                # chr(0xfffd) is a partial unicode character
+                if chr(0xfffd) in new_text:
+                    continue
+
+                length = len(decoded_text)
+                token_texts.append({
+                    'text': new_text,
+                    'ids': new_ids
+                })
+                new_ids = []
+
+            if len(new_ids) > 0:
+                token_texts.append({
+                    'text': new_text,
+                    'ids': new_ids
+                })
+
+            response = json.dumps({
+                'token_ids': token_ids,
+                'token_texts': token_texts,
+                'tokens_count': len(token_ids)
+            })
+
+            self.wfile.write(response.encode('utf-8'))
+
+        elif self.path == '/api/v1/decode':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+
+            token_ids = body['token_ids']
+            skip_special_tokens = body.get('skip_special_tokens', True)
+
+            # Using encode directly for each token would cause spaces to be lost
+            # and non-english characters could be encoded as multiple tokens
+            token_texts = []
+            tokens = torch.tensor([])
+            new_ids = []
+            length = 0
+            for t in token_ids:
+                new_tokens = torch.tensor([t])
+                tokens = torch.cat((tokens, new_tokens))
+                new_ids.extend([t])
+                decoded_text = decode(tokens, skip_special_tokens)
+                # Take the new part from the end of decoded_text as the text of the new_tokens
+                new_text_length = len(decoded_text) - length
+                new_text = decoded_text[-new_text_length:]
+
+                # chr(0xfffd) is a partial unicode character
+                if chr(0xfffd) in new_text:
+                    continue
+
+                length = len(decoded_text)
+                token_texts.append({
+                    'text': new_text,
+                    'ids': new_ids
+                })
+                new_ids = []
+
+            if len(new_ids) > 0:
+                token_texts.append({
+                    'text': new_text,
+                    'ids': new_ids
+                })
+
+            response = json.dumps({
+                'decoded_text': decoded_text,
+                'token_texts': token_texts
+            })
+
+            self.wfile.write(response.encode('utf-8'))
+
         else:
             self.send_error(404)
 


### PR DESCRIPTION
Add Api `/api/v1/encode` and `/api/v1/decode`

Enhancement needs from #2473 

I split it into two APIs, `/api/v1/encode` and `/api/v1/decode`
and add `add_special_tokens` and `add_bos_token` for consistency with generation
it can handle non-english (Multiple tokens for one character) and emoji now

`/api/v1/encode` request:
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/9ef497d1-2e85-4fc0-95bd-f6ad4f79c861)
`/api/v1/encode` response:
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/2946fba2-2589-47d3-8221-38de6e1b4d29)

`/api/v1/encode` basically does what `/api/v1/token-count` does, and I've made a token count field
( I don't think it's suitable for me to delete `/api/v1/token-count`, even though they do the same thing )

I also made `/api/v1/decode` can decode from tokens

if the tokens are incomplete, it will still show the garbled text instead of just deleting it
it can be filtered out very simply from response data
And when the generation continues, the model will prefer to complete the emoji
[ 243, 162, 149, 164 ] for 💡
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/b3fb4cff-15e9-4861-8edb-68a96391350a)


![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/ea26af76-e17a-4e20-b30b-9a690dd882fe)
This will make it easier for the frontend to colour tokens like this :)


---
I'm sorry I did a PR of the main branch before, I didn't know how to redevelop the new branch so I deleted that repository and created a new one