### PR TITLE
Add an option to set low_cpu_mem_usage to False

### DIFF
--- a/convert-to-flexgen.py
+++ b/convert-to-flexgen.py
@@ -15,6 +15,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=54))
 parser.add_argument('MODEL', type=str, default=None, nargs='?', help="Path to the input model.")
+parser.add_argument('--no-low-cpu-mem-usage', action='store_true', help="Set low_cpu_mem_usage=False while loading a model. This could avoid some problem while loading some quantized models like ChatGLM-6B-int4.")
 args = parser.parse_args()
 
 
@@ -46,7 +47,7 @@ if __name__ == '__main__':
 
     print(f"Loading {model_name}...")
     # disable_torch_init()
-    model = AutoModelForCausalLM.from_pretrained(path, torch_dtype=torch.float16, low_cpu_mem_usage=True)
+    model = AutoModelForCausalLM.from_pretrained(path, torch_dtype=torch.float16, low_cpu_mem_usage=not args.no_low_cpu_mem_usage)
     # restore_torch_init()
 
     tokenizer = AutoTokenizer.from_pretrained(path)

--- a/convert-to-safetensors.py
+++ b/convert-to-safetensors.py
@@ -22,6 +22,7 @@ parser.add_argument('MODEL', type=str, default=None, nargs='?', help="Path to th
 parser.add_argument('--output', type=str, default=None, help='Path to the output folder (default: models/{model_name}_safetensors).')
 parser.add_argument("--max-shard-size", type=str, default="2GB", help="Maximum size of a shard in GB or MB (default: %(default)s).")
 parser.add_argument('--bf16', action='store_true', help='Load the model with bfloat16 precision. Requires NVIDIA Ampere GPU.')
+parser.add_argument('--no-low-cpu-mem-usage', action='store_true', help="Set low_cpu_mem_usage=False while loading a model. This could avoid some problem while loading some quantized models like ChatGLM-6B-int4.")
 args = parser.parse_args()
 
 if __name__ == '__main__':
@@ -29,7 +30,7 @@ if __name__ == '__main__':
     model_name = path.name
 
     print(f"Loading {model_name}...")
-    model = AutoModelForCausalLM.from_pretrained(path, low_cpu_mem_usage=True, torch_dtype=torch.bfloat16 if args.bf16 else torch.float16)
+    model = AutoModelForCausalLM.from_pretrained(path, low_cpu_mem_usage=not args.no_low_cpu_mem_usage, torch_dtype=torch.bfloat16 if args.bf16 else torch.float16)
     tokenizer = AutoTokenizer.from_pretrained(path)
 
     out_folder = args.output or Path(f"models/{model_name}_safetensors")

--- a/modules/models.py
+++ b/modules/models.py
@@ -124,7 +124,7 @@ def huggingface_loader(model_name):
 
     # Load the model in simple 16-bit mode by default
     if not any([shared.args.cpu, shared.args.load_in_8bit, shared.args.load_in_4bit, shared.args.auto_devices, shared.args.disk, shared.args.deepspeed, shared.args.gpu_memory is not None, shared.args.cpu_memory is not None]):
-        model = LoaderClass.from_pretrained(Path(f"{shared.args.model_dir}/{model_name}"), low_cpu_mem_usage=True, torch_dtype=torch.bfloat16 if shared.args.bf16 else torch.float16, trust_remote_code=shared.args.trust_remote_code)
+        model = LoaderClass.from_pretrained(Path(f"{shared.args.model_dir}/{model_name}"), low_cpu_mem_usage=not shared.args.no_low_cpu_mem_usage, torch_dtype=torch.bfloat16 if shared.args.bf16 else torch.float16, trust_remote_code=shared.args.trust_remote_code)
         if torch.has_mps:
             device = torch.device('mps')
             model = model.to(device)
@@ -141,7 +141,7 @@ def huggingface_loader(model_name):
     # Custom
     else:
         params = {
-            "low_cpu_mem_usage": True,
+            "low_cpu_mem_usage": not shared.args.no_low_cpu_mem_usage,
             "trust_remote_code": shared.args.trust_remote_code
         }
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -113,6 +113,7 @@ parser.add_argument('--no-cache', action='store_true', help='Set use_cache to Fa
 parser.add_argument('--xformers', action='store_true', help="Use xformer's memory efficient attention. This should increase your tokens/s.")
 parser.add_argument('--sdp-attention', action='store_true', help="Use torch 2.0's sdp attention.")
 parser.add_argument('--trust-remote-code', action='store_true', help="Set trust_remote_code=True while loading a model. Necessary for ChatGLM and Falcon.")
+parser.add_argument('--no-low-cpu-mem-usage', action='store_true', help="Set low_cpu_mem_usage=False while loading a model. This could avoid some problem while loading some quantized models like ChatGLM-6B-int4.")
 
 # Accelerate 4-bit
 parser.add_argument('--load-in-4bit', action='store_true', help='Load the model with 4-bit precision (using bitsandbytes).')


### PR DESCRIPTION
Some models cannot be loaded with `low_cpu_mem_usage` set to `True`. Let's add an option.

Use `--no-low-cpu-mem-usage` to set it `False`.