### PR TITLE
Download optimizations

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -207,18 +207,14 @@ class ModelDownloader:
 
     def download_model_files(self, model, branch, links, sha256, output_folder, start_from_scratch=False, threads=1):
         # Creating the folder and writing the metadata
-        if not output_folder.exists():
-            output_folder.mkdir(parents=True, exist_ok=True)
-        with open(output_folder / 'huggingface-metadata.txt', 'w') as f:
-            f.write(f'url: https://huggingface.co/{model}\n')
-            f.write(f'branch: {branch}\n')
-            f.write(f'download date: {str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))}\n')
-            sha256_str = ''
-            for i in range(len(sha256)):
-                sha256_str += f'    {sha256[i][1]} {sha256[i][0]}\n'
-            if sha256_str != '':
-                f.write(f'sha256sum:\n{sha256_str}')
-
+        output_folder.mkdir(parents=True, exist_ok=True)
+        sha256_str ='\n'.join([f'    {item[1]} {item[0]}' for item in sha256])
+        metadata = f'url: https://huggingface.co/{model}\nbranch: {branch}\ndownload date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n'
+        if sha256_str:
+            metadata += f'sha256sum:\n{sha256_str}'
+        metadata += '\n'
+        (output_folder / 'huggingface-metadata.txt').write_text(metadata)
+        
         # Downloading the files
         print(f"Downloading the model to {output_folder}")
         self.start_download_threads(links, output_folder, start_from_scratch=start_from_scratch, threads=threads)

--- a/download-model.py
+++ b/download-model.py
@@ -208,7 +208,9 @@ class ModelDownloader:
     def download_model_files(self, model, branch, links, sha256, output_folder, start_from_scratch=False, threads=1):
         # Creating the folder and writing the metadata
         output_folder.mkdir(parents=True, exist_ok=True)
-        metadata = f'url: https://huggingface.co/{model}\nbranch: {branch}\ndownload date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n'
+        metadata = f'url: https://huggingface.co/{model}\n' \
+                    'branch: {branch}\n' \
+                    'download date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n'
         sha256_str ='\n'.join([f'    {item[1]} {item[0]}' for item in sha256])
         if sha256_str:
             metadata += f'sha256sum:\n{sha256_str}'

--- a/download-model.py
+++ b/download-model.py
@@ -208,8 +208,8 @@ class ModelDownloader:
     def download_model_files(self, model, branch, links, sha256, output_folder, start_from_scratch=False, threads=1):
         # Creating the folder and writing the metadata
         output_folder.mkdir(parents=True, exist_ok=True)
-        sha256_str ='\n'.join([f'    {item[1]} {item[0]}' for item in sha256])
         metadata = f'url: https://huggingface.co/{model}\nbranch: {branch}\ndownload date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n'
+        sha256_str ='\n'.join([f'    {item[1]} {item[0]}' for item in sha256])
         if sha256_str:
             metadata += f'sha256sum:\n{sha256_str}'
         metadata += '\n'

--- a/download-model.py
+++ b/download-model.py
@@ -77,7 +77,6 @@ class ModelDownloader:
         if os.getenv('HF_USER') is not None and os.getenv('HF_PASS') is not None:
             self.s.auth = (os.getenv('HF_USER'), os.getenv('HF_PASS'))
 
-
     def sanitize_model_and_branch_names(self, model, branch):
         if model[-1] == '/':
             model = model[:-1]
@@ -91,7 +90,6 @@ class ModelDownloader:
                     "Invalid branch name. Only alphanumeric characters, period, underscore and dash are allowed.")
 
         return model, branch
-
 
     def get_download_links_from_huggingface(self, model, branch, text_only=False):
         base = "https://huggingface.co"
@@ -163,7 +161,6 @@ class ModelDownloader:
 
         return links, sha256, is_lora
 
-
     def get_output_folder(self, model, branch, is_lora, base_folder=None):
         if base_folder is None:
             base_folder = 'models' if not is_lora else 'loras'
@@ -173,7 +170,6 @@ class ModelDownloader:
             output_folder += f'_{branch}'
         output_folder = Path(base_folder) / output_folder
         return output_folder
-
 
     def get_single_file(self, url, output_folder, start_from_scratch=False):
         filename = Path(url.rsplit('/', 1)[1])
@@ -189,47 +185,44 @@ class ModelDownloader:
             # Otherwise, resume the download from where it left off
             headers = {'Range': f'bytes={output_path.stat().st_size}-'}
             mode = 'ab'
-        
+
         with self.s.get(url, stream=True, headers=headers, timeout=20) as r:
-            r.raise_for_status() #Do not continue the download if the request was unsuccessful
+            r.raise_for_status()  # Do not continue the download if the request was unsuccessful
             total_size = int(r.headers.get('content-length', 0))
-            block_size = 1024 * 1024 #1MB
+            block_size = 1024 * 1024  # 1MB
             with open(output_path, mode) as f:
-                with tqdm.tqdm(total=total_size, 
-                               unit='iB', 
-                               unit_scale=True, 
+                with tqdm.tqdm(total=total_size,
+                               unit='iB',
+                               unit_scale=True,
                                bar_format='{l_bar}{bar}| {n_fmt:6}/{total_fmt:6} {rate_fmt:6}'
-                ) as t:
+                               ) as t:
                     count = 0
                     for data in r.iter_content(block_size):
                         t.update(len(data))
                         f.write(data)
                         if self.progress_bar is not None:
                             count += len(data)
-                            self.progress_bar(float(count)/float(total_size), f"Downloading {filename}")
-
+                            self.progress_bar(float(count) / float(total_size), f"Downloading {filename}")
 
     def start_download_threads(self, file_list, output_folder, start_from_scratch=False, threads=1):
         thread_map(lambda url: self.get_single_file(url, output_folder, start_from_scratch=start_from_scratch), file_list, max_workers=threads, disable=True)
 
-
-    def download_model_files(self, model, branch, links, sha256, output_folder, progress_bar = None, start_from_scratch=False, threads=1):
+    def download_model_files(self, model, branch, links, sha256, output_folder, progress_bar=None, start_from_scratch=False, threads=1):
         self.progress_bar = progress_bar
         # Creating the folder and writing the metadata
         output_folder.mkdir(parents=True, exist_ok=True)
         metadata = f'url: https://huggingface.co/{model}\n' \
-                    'branch: {branch}\n' \
-                    'download date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n'
-        sha256_str ='\n'.join([f'    {item[1]} {item[0]}' for item in sha256])
+                   f'branch: {branch}\n' \
+                   f'download date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n'
+        sha256_str = '\n'.join([f'    {item[1]} {item[0]}' for item in sha256])
         if sha256_str:
             metadata += f'sha256sum:\n{sha256_str}'
         metadata += '\n'
         (output_folder / 'huggingface-metadata.txt').write_text(metadata)
-        
+
         # Downloading the files
         print(f"Downloading the model to {output_folder}")
         self.start_download_threads(links, output_folder, start_from_scratch=start_from_scratch, threads=threads)
-
 
     def check_model_files(self, model, branch, links, sha256, output_folder):
         # Validate the checksums


### PR DESCRIPTION
No need to check if output_folder exists when mkdir(exists_ok=True) will not throw an error even if output_folder exists.
Built the file metadata as a single string for one .write() call.
Made sha256_str with .join() instead of a for loop.

This change has been tested to produce results identical to the previous code.
