### PR TITLE
Possible for the ZeroDivisionError when downloading a model

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -149,7 +149,7 @@ class ModelDownloader:
                     for data in r.iter_content(block_size):
                         t.update(len(data))
                         f.write(data)
-                        if self.progress_bar is not None:
+                        if total_size != 0 and self.progress_bar is not None:
                             count += len(data)
                             self.progress_bar(float(count) / float(total_size), f"Downloading {filename}")
 


### PR DESCRIPTION
Possible fix for #2796. It doesn't throw the error at least and the model loads fine. The progress bar is a bit glitched when it encounters a zero though. 