### PR TITLE
Update bitsandbytes to 0.39.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ tqdm
 scipy
 transformers==4.30.2
 git+https://github.com/huggingface/peft@03eb378eb914fbee709ff7c86ba5b1d033b89524
-bitsandbytes==0.39.0; platform_system != "Windows"
-https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.39.0-py3-none-any.whl; platform_system == "Windows"
+bitsandbytes==0.39.1; platform_system != "Windows"
+https://github.com/jllllll/bitsandbytes-windows-webui/releases/download/wheels/bitsandbytes-0.39.1-py3-none-win_amd64.whl; platform_system == "Windows"
 llama-cpp-python==0.1.64; platform_system != "Windows"
 https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.64/llama_cpp_python-0.1.64-cp310-cp310-win_amd64.whl; platform_system == "Windows"
 https://github.com/PanQiWei/AutoGPTQ/releases/download/v0.2.2/auto_gptq-0.2.2+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"


### PR DESCRIPTION
This update of bitsandbytes allows for older GPUs to use `load-in-4bit`.

I have not included changes to documentation in this PR as I am not sure of the extent of the compatibility, but I know Pascal works.

From bitsandbytes changelog:
```
Bug fixes:

    Fixed a bug where 8-bit models consumed twice the memory as expected after serialization

Deprecated:

    Kepler binaries (GTX 700s and Tesla K40/K80) are not longer provided via pip and need to be compiled from source.
    Kepler support might be fully removed in the future.
```