### PR TITLE
fix tokenizer for `exllama` and `llamacpp`

### DIFF
--- a/modules/exllama.py
+++ b/modules/exllama.py
@@ -1,4 +1,5 @@
 import sys
+import numpy as np
 from pathlib import Path
 
 from modules import shared
@@ -50,7 +51,7 @@ class ExllamaModel:
         result.cache = cache
         result.tokenizer = tokenizer
         result.generator = generator
-        return result, result
+        return result, tokenizer
 
     def generate_with_streaming(self, prompt, state):
         self.generator.settings.temperature = state['temperature']
@@ -89,4 +90,11 @@ class ExllamaModel:
         return output
 
     def encode(self, string, **kwargs):
-        return self.tokenizer.encode(string)
+        input_ids = self.tokenizer.encode(str(string))
+        input_ids = np.array(input_ids.tolist())
+        return input_ids
+
+    def decode(self, tokens):
+        if type(tokens[0]) is np.ndarray:
+            tokens = tokens[0]
+            return self.tokenizer.decode(tokens)


### PR DESCRIPTION
yesterday, I found this problem: https://github.com/oobabooga/text-generation-webui/pull/2757#issuecomment-1599171125

so, I try to fix it
then found that [`decode` in `text_generation.py`](https://github.com/oobabooga/text-generation-webui/blob/89fb6f9236849a66920e20716240343edc0f3d9d/modules/text_generation.py#L75) is not available both `exllama` and `llamacpp`

the reason is:
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/4efa6293-05f6-40b2-90bb-c287c9db8a25)
`shared.model` and `shared.tokenizer` is the same thing
and model doesn't has a `decode` function

- [x] fix `from_pretrained` outputs the correct tokenizer
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/48c4a83b-9b93-47b6-9ce0-1e9cfebc0811)
- [x] Make all `exllama.py`, `llamacpp_model.py` and `text_generation.py`'s encode output the same type ( same as `llamacpp` before )
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/78f46180-e071-47b9-834b-bcaf039c6c39)

- [x]  Make all `exllama.py`, `llamacpp_model.py` and `text_generation.py`'s decode output is string ( same as before )

Considering that the `encode` is mostly used only to count the number of tokens, this PR basically does not change any logic
Implemented the decode part of the function

