### PR TITLE
Fix printing, take two.

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -111,4 +111,16 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
         display: flex;
         flex-direction: column-reverse;
     }
+    
+    .message {
+        break-inside: avoid;
+    }
+    
+    .gradio-container {
+        overflow: visible;
+    }
+    
+    .tab-nav {
+        display: none !important;
+    }
 }

--- a/css/chat.css
+++ b/css/chat.css
@@ -93,3 +93,22 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
 .message-body :not(pre) > code {
     white-space: normal !important;
 }
+
+@media print {
+    body {
+        visibility: hidden;
+    }
+
+    .chat {
+        visibility: visible;
+        position: absolute;
+        left: 0;
+        top: 0;
+        max-width: none;
+        max-height: none;
+        width: 100%;
+        height: fit-content;
+        display: flex;
+        flex-direction: column-reverse;
+    }
+}


### PR DESCRIPTION
It wasn't printing longer chats correctly because a parent still had `overflow: hidden;` set.

I also fixed mid-message page breaks as [suggested](https://github.com/oobabooga/text-generation-webui/pull/2793#issuecomment-1600951892), and removed the gap at the top (the tabs were in the way).