### PR TITLE
Replace `stopping_criteria` logic for `generate_reply_HF`

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -260,10 +260,6 @@ def generate_reply_HF(question, original_question, seed, state, eos_token=None, 
         with generate_with_streaming(**generate_params) as generator:
             last_time = time.time()
             for output in generator:
-                # Check if the output contains the eos token
-                if output[-1] in eos_token_ids:
-                    reply = get_reply_from_output_ids(output[:-1], input_ids, original_question, state, is_chat=is_chat)
-                    break
 
                 cur_time = time.time()
                 time_threshold = (1/24) if state.get('stream', False) else 1
@@ -302,6 +298,10 @@ def generate_reply_HF(question, original_question, seed, state, eos_token=None, 
                     # none substring match, yield it
                     if not ends_with_substring:
                         yield tem_text
+
+                # Check if the output contains the eos token
+                if output[-1] in eos_token_ids:
+                    break
 
             # yield the last reply
             yield reply

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -256,12 +256,20 @@ def generate_reply_HF(question, original_question, seed, state, eos_token=None, 
         def generate_with_streaming(**kwargs):
             return Iteratorize(generate_with_callback, [], kwargs, callback=None)
 
+        reply = ''
         with generate_with_streaming(**generate_params) as generator:
+            last_time = time.time()
             for output in generator:
                 # Check if the output contains the eos token
                 if output[-1] in eos_token_ids:
                     reply = get_reply_from_output_ids(output[:-1], input_ids, original_question, state, is_chat=is_chat)
                     break
+
+                cur_time = time.time()
+                time_threshold = (1/24) if state.get('stream', False) else 1
+                if cur_time - last_time < time_threshold:
+                    continue
+                last_time = time.time()
 
                 reply = get_reply_from_output_ids(output, input_ids, original_question, state, is_chat=is_chat)
 


### PR DESCRIPTION
Expanded features from [here](https://github.com/oobabooga/text-generation-webui/pull/2766)
someone needs it for `exllama_HF`

Many people are confused about the `stopping_strings` and `custom_stopping_strings`.
It is achieved by intercepting tokens, not words or strings. So the effect is different from what people want.

So I replaced the logic of `stopping_criteria` with character matching.

1. In [`generate_reply_HF`](https://github.com/oobabooga/text-generation-webui/blob/d94ea31d54a646fd998732fe12370ecc1ffdfb2c/modules/text_generation.py#L193), now it generates 1 token per iteration regardless of whether it is output as a stream or not.
(In theory, it may cause a bit performance overhead, but so little that can ignore. Generally, it is same as before.)

2. As I said, now any string can be directly matched for interruption. It will not output anything in stopping strings.
<details>
<summary>Some screenshots of the test:</summary>

same seeds and different stopping strings outputs:
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/d666e062-d3af-44de-9e23-1ff72f809368)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/87b410e9-d517-45a1-a52a-59e0c2c10d8b)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/5c1ac105-2ab0-4d57-861a-4d533a250d2e)

</details>

3. It is possible to interrupt the generation in non-stream mode and immediately return the result.

### updated:
I tried multiple cases with or without exllama_HF loader and with or without stream (in single GPU, max context):

1.The VARM used is exactly the same, and in the same situation, the MiB numbers I measured are completely identical.

2.The GPU utilization dropped by around 1% (33b model)
my guess: String detection is handled by the CPU (in python), so at this time, the GPU will wait for a while. So theoretically, the performance will also decrease by 1% in this case.
A smaller models will cause the CPU to process at a faster frequency. Because the t/s is larger and requires processing each time.

Yes I confirmed that
there is a huge performance gap in the 7b model (like from 98% to 65% at gpu usage, and 61t/s to 44t/s at speed)

### updated:

<details>
<summary>I found that the main performance impact comes from get_reply_from_output_ids, I call it too many times</summary>

As the output gets longer, the more time it takes:

![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/69d89e85-b1f9-466a-aa2f-05c6fe8c9e0b)

This issue should also exist in the case of a stream in the main branch

</details>

~I'm trying to solve this performance issue~

### updated:

Enhanced performance

Non-stream mode will be close to the original (63.3t/s to 60.7t/s)

![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/2b4dd426-ae72-4554-b01c-5b5614bf752d)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/6b0b3608-d851-4d2e-9717-032d623de94a)

Stream mode will be **better** than the original (44.9t/s to 51.6t/s)

![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/da0f1a28-8f9c-4856-b078-55e5c440f938)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/a492be48-49a2-4cd5-8ec5-79af5bed443e)

Max content test:

Non-stream mode (44.5t/s to 41.5t/s)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/be94bfc6-becf-4679-9514-3db1618c4373)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/8f250bad-1da2-43ce-baae-3aab420afef8)

Stream mode (36.9/s to 38.3t/s)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/2f3906ff-878f-4ffd-8803-df365204e277)
![image](https://github.com/oobabooga/text-generation-webui/assets/15323975/02b73898-6ec1-4745-aa72-8c5f6fcafbbb)
