### PR TITLE
8k size only for minotaur-15B

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -235,6 +235,7 @@ TheBloke_WizardLM-30B-GPTQ:
 .*minotaur:
   mode: 'instruct'
   instruction_template: 'Minotaur'
+.*minotaur-15b:
   truncation_length: 8192
   chat_prompt_size: 8192
   chat_prompt_size_max: 8192


### PR DESCRIPTION
Other minotaur have the same prompt format but only the 15B has 8k context, there is a minotoar landmark also, but perhaps it's better handling landmark more generally so I wont include it here.