### PR TITLE
Fixes a bug in download-model.py. Checks if a model has actually been specified.

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -217,6 +217,10 @@ if __name__ == '__main__':
     branch = args.branch
     model = args.MODEL
 
+    if model is None:
+        print("Error: Please specify the model you'd like to download (e.g. 'python download-model.py facebook/opt-1.3b').")
+        sys.exit()
+
     downloader = ModelDownloader()
     # Cleaning up the model/branch names
     try:


### PR DESCRIPTION
It appears commit 5dfe0be removed the model parameter validation [`Ln 273`](https://github.com/oobabooga/text-generation-webui/commit/5dfe0bec06297e510c95f7cd950362425c57b76f#diff-dcc9d9f1b01ac4bc43a94686d1fb8c0bf764fd0af862adaed54e6ec8628d2f77L273), that checks if a model name was specified with the command itself. Typically it'd normally open the model selection menu, however that menu has since been removed.

I assume removing the model menu was on purpose? This PR checks if the user has specified a model, returning this error if none was provided.
```
Error: Please specify the model you'd like to download (e.g. 'python download-model.py facebook/opt-1.3b'.
```

*Alternatively, I personally quite liked having the menu. I'd prefer having a prompt with the "Type the name of your desired Hugging Face model" like before, but without all the other preset models. I think it'd also be more user (or beginner) friendly.*