### PR TITLE
Organize chat history/character import menu

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -598,7 +598,6 @@ def upload_character(json_file, img, tavern=False):
         f.write(json_file)
 
     if img is not None:
-        img = Image.open(io.BytesIO(img))
         img.save(Path(f'characters/{outfile_name}.png'))
 
     logger.info(f'New character saved to "characters/{outfile_name}.json".')
@@ -611,7 +610,7 @@ def upload_tavern_character(img, name1, name2):
     decoded_string = base64.b64decode(_img.info['chara'])
     _json = json.loads(decoded_string)
     _json = {"char_name": _json['name'], "char_persona": _json['description'], "char_greeting": _json["first_mes"], "example_dialogue": _json['mes_example'], "world_scenario": _json['scenario']}
-    return upload_character(json.dumps(_json), img, tavern=True)
+    return upload_character(json.dumps(_json), _img, tavern=True)
 
 
 def upload_your_profile_picture(img):

--- a/server.py
+++ b/server.py
@@ -577,12 +577,10 @@ def create_interface():
                     with gr.Tab('Chat history'):
                         with gr.Row():
                             with gr.Column():
-                                gr.Markdown('### Upload')
-                                shared.gradio['upload_chat_history'] = gr.File(type='binary', file_types=['.json', '.txt'])
+                                shared.gradio['upload_chat_history'] = gr.File(type='binary', file_types=['.json', '.txt'], label="Upload")
 
                             with gr.Column():
-                                gr.Markdown('### Download')
-                                shared.gradio['download'] = gr.File()
+                                shared.gradio['download'] = gr.File(label="Download")
                                 shared.gradio['download_button'] = gr.Button(value='Refresh')
 
                     with gr.Tab('Upload character'):

--- a/server.py
+++ b/server.py
@@ -583,22 +583,18 @@ def create_interface():
                             with gr.Column():
                                 gr.Markdown('### Download')
                                 shared.gradio['download'] = gr.File()
-                                shared.gradio['download_button'] = gr.Button(value='Click me')
+                                shared.gradio['download_button'] = gr.Button(value='Refresh')
 
                     with gr.Tab('Upload character'):
-                        gr.Markdown('### JSON format')
-                        with gr.Row():
-                            with gr.Column():
-                                gr.Markdown('1. Select the JSON file')
-                                shared.gradio['upload_json'] = gr.File(type='binary', file_types=['.json'])
+                        with gr.Tab('JSON'):
+                            with gr.Row():
+                                shared.gradio['upload_json'] = gr.File(type='binary', file_types=['.json'], label='JSON File')
+                                shared.gradio['upload_img_bot'] = gr.Image(type='pil', label='Profile Picture (optional)')
 
-                            with gr.Column():
-                                gr.Markdown('2. Select your character\'s profile picture (optional)')
-                                shared.gradio['upload_img_bot'] = gr.File(type='binary', file_types=['image'])
-
-                        shared.gradio['Upload character'] = gr.Button(value='Submit')
-                        gr.Markdown('### TavernAI PNG format')
-                        shared.gradio['upload_img_tavern'] = gr.File(type='binary', file_types=['image'])
+                            shared.gradio['Upload character'] = gr.Button(value='Submit', interactive=False)
+                        with gr.Tab('TavernAI'):
+                            shared.gradio['upload_img_tavern'] = gr.File(type='binary', file_types=['image'], label='TavernAI PNG File')
+                            shared.gradio['Upload tavern character'] = gr.Button(value='Submit', interactive=False)
 
             with gr.Tab("Parameters", elem_id="parameters"):
                 create_settings_menus(default_preset)
@@ -841,11 +837,16 @@ def create_interface():
 
             shared.gradio['download_button'].click(lambda x: chat.save_history(x, timestamp=True), shared.gradio['mode'], shared.gradio['download'])
             shared.gradio['Upload character'].click(chat.upload_character, [shared.gradio['upload_json'], shared.gradio['upload_img_bot']], [shared.gradio['character_menu']])
+            shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, [shared.gradio['Upload character']])
+            shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, [shared.gradio['Upload character']])
+
             shared.gradio['character_menu'].change(
                 partial(chat.load_character, instruct=False), [shared.gradio[k] for k in ['character_menu', 'name1', 'name2']], [shared.gradio[k] for k in ['name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy']]).then(
                 chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
 
-            shared.gradio['upload_img_tavern'].upload(chat.upload_tavern_character, [shared.gradio['upload_img_tavern'], shared.gradio['name1'], shared.gradio['name2']], [shared.gradio['character_menu']])
+            shared.gradio['Upload tavern character'].click(chat.upload_tavern_character, [shared.gradio['upload_img_tavern'], shared.gradio['name1'], shared.gradio['name2']], [shared.gradio['character_menu']])
+            shared.gradio['upload_img_tavern'].upload(lambda: gr.update(interactive=True), None, [shared.gradio['Upload tavern character']])
+            shared.gradio['upload_img_tavern'].clear(lambda: gr.update(interactive=False), None, [shared.gradio['Upload tavern character']])
             shared.gradio['your_picture'].change(
                 chat.upload_your_profile_picture, shared.gradio['your_picture'], None).then(
                 partial(chat.redraw_html, reset_cache=True), shared.reload_inputs, shared.gradio['display'])


### PR DESCRIPTION
- Moved the labels to the controls themselves.
- Changed profile picture to `gr.Image()`.
- Moved TavernAI to a separate tab.
- Added a Submit button to TavernAI tab. I was dropping files then clicking Submit, and wondering why there were errors. Until I looked at the code and realized that just dropping the file did it.
- Submit buttons are only clickable if the corresponding file is loaded.
- Changed "Click me" button to "Refresh".

![Untitled](https://github.com/oobabooga/text-generation-webui/assets/4073789/16094c1b-51b7-4292-8ba0-25c986bd3d63)
