### PR TITLE
Bump gradio from 3.31.0 to 3.34.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ datasets
 einops
 flexgen==0.1.7
 gradio_client==0.2.5
-gradio==3.33.1
+gradio==3.34.0
 markdown
 numpy
 pandas


### PR DESCRIPTION
Dependabot generated PR.

[Bump gradio from 3.31.0 to 3.34.0](https://github.com/oobabooga/text-generation-webui/commit/afacffb97295d40bdcf1bb449c9f314371655aa7) 

Bumps [gradio](https://github.com/gradio-app/gradio) from 3.31.0 to 3.34.0.
- [Release notes](https://github.com/gradio-app/gradio/releases)
- [Changelog](https://github.com/gradio-app/gradio/blob/main/CHANGELOG.md)
- [Commits](https://github.com/gradio-app/gradio/compare/v3.31.0...v3.34.0)