### PR TITLE
Add max context size and Compression factor for positional embeddings for exllama/exllama_hf

### DIFF
--- a/modules/exllama.py
+++ b/modules/exllama.py
@@ -51,7 +51,7 @@ class ExllamaModel:
             config.gpu_peer_fix = True
 
         if shared.args.max_ctx_length:
-            config.max_seq_len = int(shared.args.ctx_length)
+            config.max_seq_len = int(shared.args.max_ctx_length)
 
         if shared.args.compress_pos_emb:
             config.compress_pos_emb = int(shared.args.compress_pos_emb)

--- a/modules/exllama.py
+++ b/modules/exllama.py
@@ -50,6 +50,12 @@ class ExllamaModel:
             config.set_auto_map(shared.args.gpu_split)
             config.gpu_peer_fix = True
 
+        if shared.args.max_ctx_length:
+            config.max_seq_len = int(shared.args.ctx_length)
+
+        if shared.args.compress_pos_emb:
+            config.compress_pos_emb = int(shared.args.compress_pos_emb)
+
         model = ExLlama(config)
         tokenizer = ExLlamaTokenizer(str(tokenizer_model_path))
         cache = ExLlamaCache(model)

--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -96,6 +96,12 @@ class ExllamaHF(PreTrainedModel):
             config.set_auto_map(shared.args.gpu_split)
             config.gpu_peer_fix = True
 
+        if shared.args.max_ctx_length:
+            config.max_seq_len = int(shared.args.ctx_length)
+
+        if shared.args.compress_pos_emb:
+            config.compress_pos_emb = int(shared.args.compress_pos_emb)
+
         # This slowes down a bit but align better with autogptq generation.
         # TODO: Should give user choice to tune the exllama config
         # config.fused_attn = False

--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -97,7 +97,7 @@ class ExllamaHF(PreTrainedModel):
             config.gpu_peer_fix = True
 
         if shared.args.max_ctx_length:
-            config.max_seq_len = int(shared.args.ctx_length)
+            config.max_seq_len = int(shared.args.max_ctx_length)
 
         if shared.args.compress_pos_emb:
             config.compress_pos_emb = int(shared.args.compress_pos_emb)

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -56,10 +56,14 @@ loaders_and_params = {
     'ExLlama' : [
         'gpu_split',
         'exllama_info',
+        'max_ctx_length',
+        'compress_pos_emb',
     ],
     'ExLlama_HF' : [
         'gpu_split',
         'exllama_HF_info',
+        'max_ctx_length',
+        'compress_pos_emb',  
     ]
 }
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -30,7 +30,7 @@ theme = gr.themes.Default(
 
 
 def list_model_elements():
-    elements = ['loader', 'cpu_memory', 'auto_devices', 'disk', 'cpu', 'bf16', 'load_in_8bit', 'trust_remote_code', 'load_in_4bit', 'compute_dtype', 'quant_type', 'use_double_quant', 'wbits', 'groupsize', 'model_type', 'pre_layer', 'triton', 'desc_act', 'no_inject_fused_attention', 'no_inject_fused_mlp', 'no_use_cuda_fp16', 'threads', 'n_batch', 'no_mmap', 'mlock', 'n_gpu_layers', 'n_ctx', 'llama_cpp_seed', 'gpu_split', 'ctx_length', 'compress_pos_emb']
+    elements = ['loader', 'cpu_memory', 'auto_devices', 'disk', 'cpu', 'bf16', 'load_in_8bit', 'trust_remote_code', 'load_in_4bit', 'compute_dtype', 'quant_type', 'use_double_quant', 'wbits', 'groupsize', 'model_type', 'pre_layer', 'triton', 'desc_act', 'no_inject_fused_attention', 'no_inject_fused_mlp', 'no_use_cuda_fp16', 'threads', 'n_batch', 'no_mmap', 'mlock', 'n_gpu_layers', 'n_ctx', 'llama_cpp_seed', 'gpu_split', 'max_ctx_length', 'compress_pos_emb']
     for i in range(torch.cuda.device_count()):
         elements.append(f'gpu_memory_{i}')
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -30,7 +30,7 @@ theme = gr.themes.Default(
 
 
 def list_model_elements():
-    elements = ['loader', 'cpu_memory', 'auto_devices', 'disk', 'cpu', 'bf16', 'load_in_8bit', 'trust_remote_code', 'load_in_4bit', 'compute_dtype', 'quant_type', 'use_double_quant', 'wbits', 'groupsize', 'model_type', 'pre_layer', 'triton', 'desc_act', 'no_inject_fused_attention', 'no_inject_fused_mlp', 'no_use_cuda_fp16', 'threads', 'n_batch', 'no_mmap', 'mlock', 'n_gpu_layers', 'n_ctx', 'llama_cpp_seed', 'gpu_split']
+    elements = ['loader', 'cpu_memory', 'auto_devices', 'disk', 'cpu', 'bf16', 'load_in_8bit', 'trust_remote_code', 'load_in_4bit', 'compute_dtype', 'quant_type', 'use_double_quant', 'wbits', 'groupsize', 'model_type', 'pre_layer', 'triton', 'desc_act', 'no_inject_fused_attention', 'no_inject_fused_mlp', 'no_use_cuda_fp16', 'threads', 'n_batch', 'no_mmap', 'mlock', 'n_gpu_layers', 'n_ctx', 'llama_cpp_seed', 'gpu_split', 'ctx_length', 'compress_pos_emb']
     for i in range(torch.cuda.device_count()):
         elements.append(f'gpu_memory_{i}')
 

--- a/server.py
+++ b/server.py
@@ -223,6 +223,8 @@ def create_model_menus():
                         shared.gradio['pre_layer'] = gr.Slider(label="pre_layer", minimum=0, maximum=100, value=shared.args.pre_layer[0] if shared.args.pre_layer is not None else 0)
                         shared.gradio['autogptq_info'] = gr.Markdown('On some systems, AutoGPTQ can be 2x slower than GPTQ-for-LLaMa. You can manually select the GPTQ-for-LLaMa loader above.')
                         shared.gradio['gpu_split'] = gr.Textbox(label='gpu-split', info='Comma-separated list of VRAM (in GB) to use per GPU. Example: 20,7,7')
+                        shared.gradio['max_ctx_length'] = gr.Textbox(label='max_ctx_length', info='Max content length size for exllama. Let you use more than the default 2048 value.')
+                        shared.gradio['compress_pos_emb'] = gr.Textbox(label='compress_pos_emb', info='Compression factor for positional embeddings')
 
                     with gr.Column():
                         shared.gradio['triton'] = gr.Checkbox(label="triton", value=shared.args.triton)


### PR DESCRIPTION
This adds 2 new values for the exllama/exllama_hf loaders.

This helps when loading LoRAs, and models-lora merged models like for models https://huggingface.co/Peeepy/Airoboros-33b-SuperHOT-8k-GPTQ, which need a different compression factor value, and also to set context above 2048.

* Max context size (max_ctx_length): Let you change the size of the default max context value (2048).

Fixes when trying to set a context value above 2048 in the parameters tab.
Fixes:

```
Traceback (most recent call last):
  File "F:\ChatIAs\oobabooga\text-generation-webui\modules\callbacks.py", line 55, in gentask
    ret = self.mfunc(callback=_callback, *args, **self.kwargs)
  File "F:\ChatIAs\oobabooga\text-generation-webui\modules\text_generation.py", line 289, in generate_with_callback
    shared.model.generate(**kwargs)
  File "F:\ChatIAs\oobabooga\venv\lib\site-packages\torch\utils\_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "F:\ChatIAs\oobabooga\venv\lib\site-packages\transformers\generation\utils.py", line 1572, in generate
    return self.sample(
  File "F:\ChatIAs\oobabooga\venv\lib\site-packages\transformers\generation\utils.py", line 2619, in sample
    outputs = self(
  File "F:\ChatIAs\oobabooga\text-generation-webui\modules\exllama_hf.py", line 56, in __call__
    self.ex_model.forward(torch.tensor([seq[:-1]], dtype=torch.long), cache, preprocess_only=True)
  File "F:\ChatIAs\oobabooga\text-generation-webui\repositories\exllama\model.py", line 860, in forward
    hidden_states = decoder_layer.forward(hidden_states, cache, buffers[device], lora)
  File "F:\ChatIAs\oobabooga\text-generation-webui\repositories\exllama\model.py", line 466, in forward
    hidden_states = self.self_attn.forward(hidden_states, cache, buffer, lora)
  File "F:\ChatIAs\oobabooga\text-generation-webui\repositories\exllama\model.py", line 389, in forward
    new_keys = cache.key_states[self.index].narrow(2, past_len, q_len)
RuntimeError: start (0) + length (3548) exceeds dimension size (2047).
```

* Compression factor for positional embeddings (compress_pos_emb): Let you set Compression factor for positional embeddings and change it from the default value (1).

For SuperHOT-8K models, a value of 2 is needed for 4096 context, and a value of 4 for 8192 context.
Source: https://huggingface.co/flashvenom/Airoboros-13B-SuperHOT-8K-4bit-GPTQ

Fixes empty outputs from the model when using context > 2048.

Tested with both the models mentioned on both exllama/exllama_hf.

<details>
<summary> Screenshoots:</summary>
<br>

![image](https://github.com/oobabooga/text-generation-webui/assets/19153797/2f1cb6f8-a9b4-49b5-96b4-a66c8b4af185)

![image](https://github.com/oobabooga/text-generation-webui/assets/19153797/77bcb53b-abaf-4d1d-a78a-15711f62b9e8)

![image](https://github.com/oobabooga/text-generation-webui/assets/19153797/4740ea0d-7987-463b-85ea-c8f2542447c0)
</details>
