### PR TITLE
models/config.yaml: set +landmark, +superhot-8k to 8k length

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -236,3 +236,7 @@ TheBloke_WizardLM-30B-GPTQ:
 .*orca_mini:
   mode: 'instruct'
   instruction_template: 'Orca Mini'
+.*landmark:
+  truncation_length: 8192
+.*superhot-8k:
+  truncation_length: 8192


### PR DESCRIPTION
set +landmark, +superhot-8k to 8k length

landmark could be higher, but practically speaking it's probably too high for most people anyways.
4k might be a better default for most - can we auto-detect this from the model? Seems like something we shouldn't be setting in a config file except as an exceptional override.