### PR TITLE
Fix exllama_hf gibbersh above 2048 context, and fixes >5000 context.

### DIFF
--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -54,7 +54,15 @@ class ExllamaHF(PreTrainedModel):
         cache = kwargs['past_key_values'] if 'past_key_values' in kwargs else None
         if cache is None:
             cache = ExLlamaCache(self.ex_model)
-            self.ex_model.forward(torch.tensor([seq[:-1]], dtype=torch.long), cache, preprocess_only=True, lora=self.lora)
+
+            nseq = seq[:-1]
+            for seqs in [nseq[i : i + 2048] for i in range(0, len(nseq), 2048)]:
+                self.ex_model.forward(
+                    torch.tensor([seqs], dtype=torch.long),
+                    cache,
+                    preprocess_only=True,
+                    lora=self.lora,
+                )
 
         logits = self.ex_model.forward(torch.tensor([seq[-1:]], dtype=torch.long), cache, lora=self.lora).to(kwargs['input_ids'].device)
 


### PR DESCRIPTION
Info and fix from https://github.com/turboderp/exllama/issues/110

Using text-gen webui with Exllama loader gives different results than with Exllama_HF. Specifically, Exllama_HF gives gibberish with SuperHOT 8K models past 2048 tokens. Even the logits of the two loaders produce completely different values.

This piece of code from @kaiokendev fixes it.

Also, fixes https://github.com/oobabooga/text-generation-webui/issues/2891, which was an issue when trying to use above 5000 context on SuperHOT 8K 33B models while using exllama_hf.

`Output generated in 6.05 seconds (1.49 tokens/s, 9 tokens, context 6629, seed 1111456590)`

Note that this is a temporal fix while turbo fixes sents a new commit.