### PR TITLE
Some more character import tweaks.

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -12,6 +12,7 @@ import gradio as gr
 from PIL import Image
 
 import modules.shared as shared
+from modules import utils
 from modules.extensions import apply_extensions
 from modules.html_generator import chat_html_wrapper, make_thumbnail
 from modules.logging_colors import logger
@@ -568,7 +569,7 @@ def upload_character(json_file, img, tavern=False):
         img.save(Path(f'characters/{outfile_name}.png'))
 
     logger.info(f'New character saved to "characters/{outfile_name}.json".')
-    return outfile_name
+    return gr.update(value=outfile_name, choices=utils.get_available_characters())
 
 
 def upload_tavern_character(img, _json):

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 
 import yaml
+import gradio as gr
 from PIL import Image
 
 import modules.shared as shared
@@ -570,15 +571,19 @@ def upload_character(json_file, img, tavern=False):
     return outfile_name
 
 
-def upload_tavern_character(img):
-    _img = Image.open(io.BytesIO(img))
-    _img.getexif()
-    decoded_string = base64.b64decode(_img.info['chara'])
+def upload_tavern_character(img, _json):
+    _json = {"char_name": _json['name'], "char_persona": _json['description'], "char_greeting": _json["first_mes"], "example_dialogue": _json['mes_example'], "world_scenario": _json['scenario']}
+    return upload_character(json.dumps(_json), img, tavern=True)
+
+
+def check_tavern_character(img):
+    if "chara" not in img.info:
+        return "Not a TavernAI card", None, None, gr.update(interactive=False)
+    decoded_string = base64.b64decode(img.info['chara'])
     _json = json.loads(decoded_string)
     if "data" in _json:
         _json = _json["data"]
-    _json = {"char_name": _json['name'], "char_persona": _json['description'], "char_greeting": _json["first_mes"], "example_dialogue": _json['mes_example'], "world_scenario": _json['scenario']}
-    return upload_character(json.dumps(_json), _img, tavern=True)
+    return _json['name'], _json['description'], _json, gr.update(interactive=True)
 
 
 def upload_your_profile_picture(img):

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -570,11 +570,13 @@ def upload_character(json_file, img, tavern=False):
     return outfile_name
 
 
-def upload_tavern_character(img, name1, name2):
+def upload_tavern_character(img):
     _img = Image.open(io.BytesIO(img))
     _img.getexif()
     decoded_string = base64.b64decode(_img.info['chara'])
     _json = json.loads(decoded_string)
+    if "data" in _json:
+        _json = _json["data"]
     _json = {"char_name": _json['name'], "char_persona": _json['description'], "char_greeting": _json["first_mes"], "example_dialogue": _json['mes_example'], "world_scenario": _json['scenario']}
     return upload_character(json.dumps(_json), _img, tavern=True)
 

--- a/server.py
+++ b/server.py
@@ -600,7 +600,13 @@ def create_interface():
                         shared.gradio['Upload character'] = gr.Button(value='Submit', interactive=False)
 
                     with gr.Tab('TavernAI'):
-                        shared.gradio['upload_img_tavern'] = gr.File(type='binary', file_types=['image'], label='TavernAI PNG File')
+                        with gr.Row():
+                            with gr.Column():
+                                shared.gradio['upload_img_tavern'] = gr.Image(type='pil', label='TavernAI PNG File', elem_id="upload_img_tavern")
+                                shared.gradio['tavern_json'] = gr.State()
+                            with gr.Column():
+                                shared.gradio['tavern_name'] = gr.Textbox(value='', lines=1, label='Name', interactive=False)
+                                shared.gradio['tavern_desc'] = gr.Textbox(value='', lines=4, max_lines=4, label='Description', interactive=False)
                         shared.gradio['Upload tavern character'] = gr.Button(value='Submit', interactive=False)
 
             with gr.Tab("Parameters", elem_id="parameters"):
@@ -851,9 +857,9 @@ def create_interface():
                 partial(chat.load_character, instruct=False), [shared.gradio[k] for k in ['character_menu', 'name1', 'name2']], [shared.gradio[k] for k in ['name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy']]).then(
                 chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
 
-            shared.gradio['Upload tavern character'].click(chat.upload_tavern_character, [shared.gradio['upload_img_tavern']], [shared.gradio['character_menu']])
-            shared.gradio['upload_img_tavern'].upload(lambda: gr.update(interactive=True), None, [shared.gradio['Upload tavern character']])
-            shared.gradio['upload_img_tavern'].clear(lambda: gr.update(interactive=False), None, [shared.gradio['Upload tavern character']])
+            shared.gradio['Upload tavern character'].click(chat.upload_tavern_character, [shared.gradio['upload_img_tavern'], shared.gradio['tavern_json']], [shared.gradio['character_menu']])
+            shared.gradio['upload_img_tavern'].upload(chat.check_tavern_character, shared.gradio['upload_img_tavern'], [shared.gradio['tavern_name'], shared.gradio['tavern_desc'], shared.gradio['tavern_json'], shared.gradio['Upload tavern character']], show_progress=False)
+            shared.gradio['upload_img_tavern'].clear(lambda: (None, None, None, gr.update(interactive=False)), None, [shared.gradio['tavern_name'], shared.gradio['tavern_desc'], shared.gradio['tavern_json'], shared.gradio['Upload tavern character']], show_progress=False)
             shared.gradio['your_picture'].change(
                 chat.upload_your_profile_picture, shared.gradio['your_picture'], None).then(
                 partial(chat.redraw_html, reset_cache=True), shared.reload_inputs, shared.gradio['display'])

--- a/server.py
+++ b/server.py
@@ -851,7 +851,7 @@ def create_interface():
                 partial(chat.load_character, instruct=False), [shared.gradio[k] for k in ['character_menu', 'name1', 'name2']], [shared.gradio[k] for k in ['name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy']]).then(
                 chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
 
-            shared.gradio['Upload tavern character'].click(chat.upload_tavern_character, [shared.gradio['upload_img_tavern'], shared.gradio['name1'], shared.gradio['name2']], [shared.gradio['character_menu']])
+            shared.gradio['Upload tavern character'].click(chat.upload_tavern_character, [shared.gradio['upload_img_tavern']], [shared.gradio['character_menu']])
             shared.gradio['upload_img_tavern'].upload(lambda: gr.update(interactive=True), None, [shared.gradio['Upload tavern character']])
             shared.gradio['upload_img_tavern'].clear(lambda: gr.update(interactive=False), None, [shared.gradio['Upload tavern character']])
             shared.gradio['your_picture'].change(


### PR DESCRIPTION
- Refresh list when importing character (character would be selected but absent from the list).
- Change TavernAI image upload to `gr.Image()`. Image can be edited (assuming [this](https://github.com/gradio-app/gradio/issues/4677) ever gets fixed) without losing metadata.
- Check if image is a TavernAI card. Display name/description and enable Submit button if it is, display error message if it's not.
- Add support for V2 cards.
![Untitled](https://github.com/oobabooga/text-generation-webui/assets/4073789/8da18fe0-98cd-4cc3-b4e4-8ef848425531)
