### PR TITLE
Add links/reference to new multimodal instructblip-pipeline in multimodal readme

### DIFF
--- a/extensions/multimodal/README.md
+++ b/extensions/multimodal/README.md
@@ -38,6 +38,8 @@ As of now, the following multimodal pipelines are supported:
 |[LLaVA 7B](https://github.com/haotian-liu/LLaVA)|`llava-7b`|[LLaVA 7B](https://huggingface.co/wojtab/llava-7b-v0-4bit-128g)|GPTQ 4-bit quant, old CUDA|built-in|
 |[MiniGPT-4 7B](https://github.com/Vision-CAIR/MiniGPT-4)|`minigpt4-7b`|[Vicuna v0 7B](https://huggingface.co/TheBloke/vicuna-7B-GPTQ-4bit-128g)|GPTQ 4-bit quant, new format|[Wojtab/minigpt-4-pipeline](https://github.com/Wojtab/minigpt-4-pipeline)|
 |[MiniGPT-4 13B](https://github.com/Vision-CAIR/MiniGPT-4)|`minigpt4-13b`|[Vicuna v0 13B](https://huggingface.co/anon8231489123/vicuna-13b-GPTQ-4bit-128g)|GPTQ 4-bit quant, old CUDA|[Wojtab/minigpt-4-pipeline](https://github.com/Wojtab/minigpt-4-pipeline)|
+|[InstructBLIP 7B](https://github.com/salesforce/LAVIS/tree/main/projects/instructblip)|`instructblip-7b`|[Vicuna v1.1 7B](https://huggingface.co/TheBloke/vicuna-7B-1.1-GPTQ-4bit-128g)|GPTQ 4-bit quant|[kjerk/instructblip-pipeline](https://github.com/kjerk/instructblip-pipeline)|
+|[InstructBLIP 13B](https://github.com/salesforce/LAVIS/tree/main/projects/instructblip)|`instructblip-13b`|[Vicuna v1.1 13B](https://huggingface.co/TheBloke/vicuna-13B-1.1-GPTQ-4bit-128g)|GPTQ 4-bit quant|[kjerk/instructblip-pipeline](https://github.com/kjerk/instructblip-pipeline)|
 
 Some pipelines could support different LLMs but do note that while it might work, it isn't a supported configuration.
 


### PR DESCRIPTION
Simply adding links/references in the multimodal readme.

tl;dr is: New pipeline for Vicuna-7b and 13b interop for multimodal interrogation, including almost any related 7b/13b networks like `nous-hermes` or `airoboros`, though the vanilla 1.1 networks are the 'canonically' correct ones, the context transfers well enough to get a good user experience out of most related or downhill networks.

This is a pipeline for one of the SOTA (at least for the next few weeks 😭) image captioning networks called [InstructBLIP](https://github.com/salesforce/LAVIS/tree/main/projects/instructblip). It was extremely taxing to run with vanilla transformers (7b maxing out a 4090, whyyyyy) so wanted it running on quantized models ASAP because the quality can be very high.

Thanks to this repo, the multimodal pipeline abstraction, and all the work on bitsandbytes/AutoGPTQ, now 7b can run on 8gb and 13b can run on 12gb.

Pipeline repo is here, with a fully fleshed out readme: https://github.com/kjerk/instructblip-pipeline/tree/main#-examples

---

Edit: Examples
![example 1](https://raw.githubusercontent.com/kjerk/instructblip-pipeline/main/_res/example_1.png)

![example 2](https://raw.githubusercontent.com/kjerk/instructblip-pipeline/main/_res/example_2.png)
