### PR TITLE
Update models.py to clear LORA names after unload

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -326,6 +326,7 @@ def clear_torch_cache():
 
 def unload_model():
     shared.model = shared.tokenizer = None
+    shared.lora_names = []
     clear_torch_cache()
 
 


### PR DESCRIPTION
As per issue
https://github.com/oobabooga/text-generation-webui/issues/2939

The second part PR that deals with interface:
https://github.com/oobabooga/text-generation-webui/pull/2952

Third part to prevent potential error when the model is no longer PEFT, but we still want unload LORA for some reason or other (it happened)
https://github.com/oobabooga/text-generation-webui/pull/2953
