### PR TITLE
Update server.py - clear LORA after reload

### DIFF
--- a/server.py
+++ b/server.py
@@ -272,17 +272,20 @@ def create_model_menus():
     load.click(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
         update_model_parameters, shared.gradio['interface_state'], None).then(
-        partial(load_model_wrapper, autoload=True), [shared.gradio[k] for k in ['model_menu', 'loader']], shared.gradio['model_status'], show_progress=False)
+        partial(load_model_wrapper, autoload=True), [shared.gradio[k] for k in ['model_menu', 'loader']], shared.gradio['model_status'], show_progress=False).then(
+        lambda: shared.lora_names, None,shared.gradio['lora_menu'])
 
     unload.click(
         unload_model, None, None).then(
-        lambda: "Model unloaded", None, shared.gradio['model_status'])
+        lambda: "Model unloaded", None, shared.gradio['model_status']).then(
+        lambda: shared.lora_names, None,shared.gradio['lora_menu'])
 
     reload.click(
         unload_model, None, None).then(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
         update_model_parameters, shared.gradio['interface_state'], None).then(
-        partial(load_model_wrapper, autoload=True), [shared.gradio[k] for k in ['model_menu', 'loader']], shared.gradio['model_status'], show_progress=False)
+        partial(load_model_wrapper, autoload=True), [shared.gradio[k] for k in ['model_menu', 'loader']], shared.gradio['model_status'], show_progress=False).then(
+        lambda: shared.lora_names, None,shared.gradio['lora_menu'])
 
     save_settings.click(
         ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(


### PR DESCRIPTION
This is second part of the issue (related to UI interface - the lora needs to be cleared from the menu after reload/load)
https://github.com/oobabooga/text-generation-webui/issues/2939

see the first part (necessary for this 2nd to work) that clears lora names after unload:
https://github.com/oobabooga/text-generation-webui/pull/2951
