### PR TITLE
Update LoRA.py - avoid potential error

### DIFF
--- a/modules/LoRA.py
+++ b/modules/LoRA.py
@@ -106,8 +106,10 @@ def add_lora_transformers(lora_names):
 
     # If any LoRA needs to be removed, start over
     if len(removed_set) > 0:
-        shared.model.disable_adapter()
-        shared.model = shared.model.base_model.model
+        # shared.model may no longer be PeftModel
+        if hasattr(shared.model, 'disable_adapter'):  
+            shared.model.disable_adapter()  
+            shared.model = shared.model.base_model.model
 
     if len(lora_names) > 0:
         params = {}


### PR DESCRIPTION
This is a third part of the lora qptq_for_llama  fix

Check if the model is still PEFT. Prevents rare issue that "could" occur when you reloading qptq-for-llama models then applying LoRA

As per issue
https://github.com/oobabooga/text-generation-webui/issues/2939

