### PR TITLE
Replace deprecated Pillow constant 

### DIFF
--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -129,7 +129,7 @@ def generate_4chan_html(f):
 def make_thumbnail(image):
     image = image.resize((350, round(image.size[1] / image.size[0] * 350)), Image.Resampling.LANCZOS)
     if image.size[1] > 470:
-        image = ImageOps.fit(image, (350, 470), Image.ANTIALIAS)
+        image = ImageOps.fit(image, (350, 470), Image.LANCZOS)
 
     return image
 


### PR DESCRIPTION
With version 10.0.0 of Pillow the constant Image.ANTIALIAS has been removed. Instead Image.LANCZOS should be used.
https://pillow.readthedocs.io/en/stable/deprecations.html#constants