### PR TITLE
Elevenlabs tts fixes

### DIFF
--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -12,10 +12,12 @@ params = {
     'selected_voice': 'None',
     'autoplay': False,
     'show_text': True,
+    'model': 'eleven_monolingual_v1',
 }
 
 voices = None
 wav_idx = 0
+LANG_MODELS = ['eleven_monolingual_v1', 'eleven_multilingual_v1']
 
 
 def update_api_key(key):
@@ -107,7 +109,7 @@ def output_modifier(string):
     output_file = Path(f'extensions/elevenlabs_tts/outputs/{wav_idx:06d}.mp3'.format(wav_idx))
     print(f'Outputting audio to {str(output_file)}')
     try:
-        audio = elevenlabs.generate(text=string, voice=params['selected_voice'], model="eleven_monolingual_v1")
+        audio = elevenlabs.generate(text=string, voice=params['selected_voice'], model=params['model'])
         elevenlabs.save(audio, str(output_file))
 
         autoplay = 'autoplay' if params['autoplay'] else ''
@@ -156,6 +158,9 @@ def ui():
             api_key = gr.Textbox(placeholder="Enter your API key.", label='API Key')
 
     with gr.Row():
+         model = gr.Dropdown(value=params['model'], choices=LANG_MODELS, label='Language model')
+
+    with gr.Row():
         convert = gr.Button('Permanently replace audios with the message texts')
         convert_cancel = gr.Button('Cancel', visible=False)
         convert_confirm = gr.Button('Confirm (cannot be undone)', variant="stop", visible=False)
@@ -184,6 +189,7 @@ def ui():
     activate.change(lambda x: params.update({'activate': x}), activate, None)
     voice.change(lambda x: params.update({'selected_voice': x}), voice, None)
     api_key.change(update_api_key, api_key, None)
+    model.change(lambda x: params.update({'model': x}), model, None)
     # connect.click(check_valid_api, [], connection_status)
     refresh.click(refresh_voices_dd, [], voice)
     # Event functions to update the parameters in the backend

--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import elevenlabs
 import gradio as gr
 from modules import chat, shared
+from modules.logging_colors import logger
 
 params = {
     'activate': True,
@@ -130,7 +131,12 @@ def ui():
     global voices
     if not voices:
         voices = refresh_voices()
-        params['selected_voice'] = voices[0]
+        selected = params['selected_voice']
+        if selected == 'None':
+            params['selected_voice'] = voices[0]
+        elif selected not in voices:
+            logger.error(f'Selected voice {selected} not available, switching to {voices[0]}')
+            params['selected_voice'] = voices[0]
 
     # Gradio elements
     with gr.Row():

--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -149,7 +149,11 @@ def ui():
         refresh = gr.Button(value='Refresh')
 
     with gr.Row():
-        api_key = gr.Textbox(placeholder="Enter your API key.", label='API Key')
+        if params['api_key']:
+            api_key = gr.Textbox(value=params['api_key'], label='API Key')
+            update_api_key(params['api_key'])
+        else:
+            api_key = gr.Textbox(placeholder="Enter your API key.", label='API Key')
 
     with gr.Row():
         convert = gr.Button('Permanently replace audios with the message texts')


### PR DESCRIPTION
Two fixes and an addition. 
The fixes are related to the use of options in the *settings.yaml* file:
- The selected voice was ignored. The code always calls *refresh_voices()*, but the old code always selected the first available voice, discarding the option from the config file. Now we keep the selected option, unless the voice doesn't exist. In this case we issue an error and select the first available.
- The API key was ignored, and the input box displayed "Enter your API key.". This is because we must call *update_api_key* and also use the value for the input box.

The addition is related to languages other than English, the code always selected *eleven_monolingual_v1*, but for other languages it sound awful, so now we have a drop down to select *eleven_multilingual_v1*, much better for Spanish ;-)