### PR TITLE
Honor settings mode

### DIFF
--- a/server.py
+++ b/server.py
@@ -998,7 +998,10 @@ if __name__ == "__main__":
             shared.settings[item] = new_settings[item]
         mode = new_settings.get('mode', None)
         if mode is not None:
-            set_interface_mode(mode)
+            if mode not in VALID_MODES:
+                logger.error(f'Unknown mode {mode} ignoring it')
+            else:
+                set_interface_mode(mode)
 
     # Set default model settings based on settings file
     shared.model_config['.*'] = {


### PR DESCRIPTION
This patch splits `set_interface_arguments` in `set_interface_mode` and the rest.
The code now uses `set_interface_mode` to set the mode when the settings file has a `mode` option.
The list of modes was in two places, now is a global variable `VALID_MODES`. Note that one instance mentioned `cai_chat` which I think is no longer an individual mode.
Now we also check that the mode indicated in the settings is a valid one. If it isn't we generate an error and ignore the selected mode.

Fixes #2973 