### PR TITLE
[Fix] The mode from settings was ignored

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,6 +50,7 @@ from modules.text_generation import (
     stop_everything_event
 )
 from modules.utils import gradio
+VALID_MODES = ["default", "notebook", "chat"]
 
 
 def load_model_wrapper(selected_model, loader, autoload=False):
@@ -548,16 +549,28 @@ def create_file_saving_event_handlers():
             lambda: gr.update(visible=True), None, gradio('file_deleter'))
 
 
+def mode_from_cli():
+    """ Returns the mode selected by the command line.
+        The 'default' value means nothing was specified. """
+    for k in VALID_MODES[1:]:
+        if getattr(shared.args, k):
+            return k
+    return VALID_MODES[0]
+
+
+def set_interface_mode(interface_mode):
+    for k in VALID_MODES[1:]:
+        setattr(shared.args, k, False)
+    if interface_mode != VALID_MODES[0]:
+        setattr(shared.args, interface_mode, True)
+
+
 def set_interface_arguments(interface_mode, extensions, bool_active):
-    modes = ["default", "notebook", "chat", "cai_chat"]
     cmd_list = vars(shared.args)
-    bool_list = [k for k in cmd_list if type(cmd_list[k]) is bool and k not in modes]
+    bool_list = [k for k in cmd_list if type(cmd_list[k]) is bool and k not in VALID_MODES]
 
     shared.args.extensions = extensions
-    for k in modes[1:]:
-        setattr(shared.args, k, False)
-    if interface_mode != "default":
-        setattr(shared.args, interface_mode, True)
+    set_interface_mode(interface_mode)
 
     for k in bool_list:
         setattr(shared.args, k, False)
@@ -802,22 +815,21 @@ def create_interface():
 
         # Session tab
         with gr.Tab("Session", elem_id="session-tab"):
-            modes = ["default", "notebook", "chat"]
             current_mode = "default"
-            for mode in modes[1:]:
+            for mode in VALID_MODES[1:]:
                 if getattr(shared.args, mode):
                     current_mode = mode
                     break
 
             cmd_list = vars(shared.args)
-            bool_list = sorted([k for k in cmd_list if type(cmd_list[k]) is bool and k not in modes + ui.list_model_elements()])
+            bool_list = sorted([k for k in cmd_list if type(cmd_list[k]) is bool and k not in VALID_MODES + ui.list_model_elements()])
             bool_active = [k for k in bool_list if vars(shared.args)[k]]
 
             with gr.Row():
 
                 with gr.Column():
                     with gr.Row():
-                        shared.gradio['interface_modes_menu'] = gr.Dropdown(choices=modes, value=current_mode, label="Mode", elem_classes='slim-dropdown')
+                        shared.gradio['interface_modes_menu'] = gr.Dropdown(choices=VALID_MODES, value=current_mode, label="Mode", elem_classes='slim-dropdown')
                         shared.gradio['reset_interface'] = gr.Button("Apply and restart", elem_classes="small-button", variant="primary")
                         shared.gradio['toggle_dark_mode'] = gr.Button('Toggle 💡', elem_classes="small-button")
 
@@ -1090,6 +1102,11 @@ if __name__ == "__main__":
         new_settings = json.loads(file_contents) if settings_file.suffix == "json" else yaml.safe_load(file_contents)
         for item in new_settings:
             shared.settings[item] = new_settings[item]
+        mode = new_settings.get('mode', None)
+        if mode is not None:
+            if mode not in VALID_MODES:
+                logger.error(f'Unknown mode {mode} ignoring it')
+                shared.settings['mode'] = None
 
     # Set default model settings based on settings file
     shared.model_config['.*'] = {
@@ -1097,6 +1114,7 @@ if __name__ == "__main__":
         'model_type': 'None',
         'groupsize': 'None',
         'pre_layer': 0,
+        # The mode will be applied when loading the model, and only if not modified by the command line or the model
         'mode': shared.settings['mode'],
         'skip_special_tokens': shared.settings['skip_special_tokens'],
         'custom_stopping_strings': shared.settings['custom_stopping_strings'],
@@ -1104,19 +1122,6 @@ if __name__ == "__main__":
     }
 
     shared.model_config.move_to_end('.*', last=False)  # Move to the beginning
-
-    # Default extensions
-    extensions_module.available_extensions = utils.get_available_extensions()
-    if shared.is_chat():
-        for extension in shared.settings['chat_default_extensions']:
-            shared.args.extensions = shared.args.extensions or []
-            if extension not in shared.args.extensions:
-                shared.args.extensions.append(extension)
-    else:
-        for extension in shared.settings['default_extensions']:
-            shared.args.extensions = shared.args.extensions or []
-            if extension not in shared.args.extensions:
-                shared.args.extensions.append(extension)
 
     available_models = utils.get_available_models()
 
@@ -1150,6 +1155,11 @@ if __name__ == "__main__":
         shared.settings.update(model_settings)  # hijacking the interface defaults
         update_model_parameters(model_settings, initial=True)  # hijacking the command-line arguments
 
+        # Apply the mode if specified
+        mode = model_settings.get('mode', None)
+        if mode_from_cli() == VALID_MODES[0] and mode is not None and mode in VALID_MODES:
+            set_interface_mode(mode)
+
         # Load the model
         shared.model, shared.tokenizer = load_model(shared.model_name)
         if shared.args.lora:
@@ -1160,6 +1170,20 @@ if __name__ == "__main__":
         'loader': shared.args.loader or 'Transformers',
     })
 
+    # Default extensions
+    extensions_module.available_extensions = utils.get_available_extensions()
+    if shared.is_chat():
+        for extension in shared.settings['chat_default_extensions']:
+            shared.args.extensions = shared.args.extensions or []
+            if extension not in shared.args.extensions:
+                shared.args.extensions.append(extension)
+    else:
+        for extension in shared.settings['default_extensions']:
+            shared.args.extensions = shared.args.extensions or []
+            if extension not in shared.args.extensions:
+                shared.args.extensions.append(extension)
+
+    # Force a character to be loaded
     if shared.is_chat():
         shared.persistent_interface_state.update({
             'mode': shared.settings['mode'],


### PR DESCRIPTION
- Now it takes effect
- Note that the modes included `cai_chat` in one instance, I think this is no longer a mode, but a chat flavor. I'm using a global list of valid modes.
- Informs about wrong modes from settings
- A mode from the command line has more precedence
- A mode from a model has more precedence

Some explanations:
The mechanism used to set the mode is complex. What the code does (regardless of this patch) is to set the mode as the default mode selected by any model. This means that we must load a model to get the mode applied, this is confusing to me, but it works because a model will be loaded soon or latter. 
But the old code has a major drawback: the model was loaded *after* loading the extensions, so when the code asked for *is_chat()* didn't take into account the model potentially selected from the *settings*. So I moved the extensions load to be done *after* loading the model.
Also: the old code takes care of the model parameter (using `update_model_parameters`) but this doesn't include the mode. So the mode was never honored. Even when it was set as the default for any model.
Additionally: the VALID_MODES should be moved to a better place and the code should be scanned for uses of these names and force to use only one list. The old code had two lists, one was wrong.

Fixes #2973