### PR TITLE
Implement sessions + add basic multi-user support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Optionally, you can use the following command-line flags:
 | `-h`, `--help`                             | Show this help message and exit. |
 | `--notebook`                               | Launch the web UI in notebook mode, where the output is written to the same text box as the input. |
 | `--chat`                                   | Launch the web UI in chat mode. |
+| `--multi-user`                             | Multi-user mode. Chat histories are not saved or automatically loaded. WARNING: this is highly experimental. |
 | `--character CHARACTER`                    | The name of the character to load in chat mode by default. |
 | `--model MODEL`                            | Name of the model to load by default. |
 | `--lora LORA [LORA ...]`                   | The list of LoRAs to load. If you want to load more than one LoRA, write the names separated by spaces. |

--- a/characters/Assistant.yaml
+++ b/characters/Assistant.yaml
@@ -1,0 +1,5 @@
+name: Assistant
+context: This is a conversation with your Assistant. It is a computer program designed
+  to help you with various tasks such as answering questions, providing recommendations,
+  and helping with decision making. You can ask it anything you want and it will do
+  its best to give you accurate and relevant information.

--- a/characters/Assistant.yaml
+++ b/characters/Assistant.yaml
@@ -1,5 +1,0 @@
-name: Assistant
-context: This is a conversation with your Assistant. It is a computer program designed
-  to help you with various tasks such as answering questions, providing recommendations,
-  and helping with decision making. You can ask it anything you want and it will do
-  its best to give you accurate and relevant information.

--- a/css/main.css
+++ b/css/main.css
@@ -6,6 +6,12 @@
     padding-top: 2.5rem
 }
 
+.small-button {
+    max-width: 171px;
+    height: 39.594px;
+    align-self: end;
+}
+
 .refresh-button {
     max-width: 4.4em;
     min-width: 2.2em !important;
@@ -50,7 +56,7 @@ ol li p, ul li p {
     display: inline-block;
 }
 
-#main, #parameters, #chat-settings, #interface-mode, #lora, #training-tab, #model-tab {
+#main, #parameters, #chat-settings, #lora, #training-tab, #model-tab, #session-tab {
     border: 0;
 }
 
@@ -119,10 +125,6 @@ footer {
 
 button {
     font-size: 14px !important;
-}
-
-.small-button {
-    max-width: 171px;
 }
 
 .file-saver {

--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -38,11 +38,11 @@ script.py may define the special functions and variables below.
 | `def ui()` | Creates custom gradio elements when the UI is launched. | 
 | `def custom_css()` | Returns custom CSS as a string. It is applied whenever the web UI is loaded. |
 | `def custom_js()` | Same as above but for javascript. |
-| `def input_modifier(string)`  | Modifies the input string before it enters the model. In chat mode, it is applied to the user message. Otherwise, it is applied to the entire prompt. |
-| `def output_modifier(string)`  | Modifies the output string before it is presented in the UI. In chat mode, it is applied to the bot's reply. Otherwise, it is applied to the entire output. |
+| `def input_modifier(string, state)`  | Modifies the input string before it enters the model. In chat mode, it is applied to the user message. Otherwise, it is applied to the entire prompt. |
+| `def output_modifier(string, state)`  | Modifies the output string before it is presented in the UI. In chat mode, it is applied to the bot's reply. Otherwise, it is applied to the entire output. |
+| `def bot_prefix_modifier(string, state)`  | Applied in chat mode to the prefix for the bot's reply. |
 | `def state_modifier(state)`  | Modifies the dictionary containing the UI input parameters before it is used by the text generation functions. |
 | `def history_modifier(history)`  | Modifies the chat history before the text generation in chat mode begins. |
-| `def bot_prefix_modifier(string)`  | Applied in chat mode to the prefix for the bot's reply. |
 | `def custom_generate_reply(...)` | Overrides the main text generation function. |
 | `def custom_generate_chat_prompt(...)` | Overrides the prompt generator in chat mode. |
 | `def tokenizer_modifier(state, prompt, input_ids, input_embeds)` | Modifies the `input_ids`/`input_embeds` fed to the model. Should return `prompt`, `input_ids`, `input_embeds`. See the `multimodal` extension for an example. |

--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -159,7 +159,7 @@ def ui():
         convert_confirm.click(
             lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
             remove_tts_from_history, gradio('history'), gradio('history')).then(
-            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
             chat.redraw_html, shared.reload_inputs, gradio('display'))
 
         convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
@@ -168,7 +168,7 @@ def ui():
         show_text.change(
             lambda x: params.update({"show_text": x}), show_text, None).then(
             toggle_text_in_history, gradio('history'), gradio('history')).then(
-            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
             chat.redraw_html, shared.reload_inputs, gradio('display'))
 
     # Event functions to update the parameters in the backend

--- a/extensions/elevenlabs_tts/script.py
+++ b/extensions/elevenlabs_tts/script.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import elevenlabs
 import gradio as gr
+
 from modules import chat, shared
+from modules.utils import gradio
 
 params = {
     'activate': True,
@@ -35,24 +37,24 @@ def refresh_voices_dd():
     return gr.Dropdown.update(value=all_voices[0], choices=all_voices)
 
 
-def remove_tts_from_history():
-    for i, entry in enumerate(shared.history['internal']):
-        shared.history['visible'][i] = [shared.history['visible'][i][0], entry[1]]
+def remove_tts_from_history(history):
+    for i, entry in enumerate(history['internal']):
+        history['visible'][i] = [history['visible'][i][0], entry[1]]
+
+    return history
 
 
-def toggle_text_in_history():
-    for i, entry in enumerate(shared.history['visible']):
+def toggle_text_in_history(history):
+    for i, entry in enumerate(history['visible']):
         visible_reply = entry[1]
         if visible_reply.startswith('<audio'):
             if params['show_text']:
-                reply = shared.history['internal'][i][1]
-                shared.history['visible'][i] = [
-                    shared.history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"
-                ]
+                reply = history['internal'][i][1]
+                history['visible'][i] = [history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"]
             else:
-                shared.history['visible'][i] = [
-                    shared.history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>"
-                ]
+                history['visible'][i] = [history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>"]
+
+    return history
 
 
 def remove_surrounded_chars(string):
@@ -150,25 +152,24 @@ def ui():
         convert_cancel = gr.Button('Cancel', visible=False)
         convert_confirm = gr.Button('Confirm (cannot be undone)', variant="stop", visible=False)
 
-    # Convert history with confirmation
-    convert_arr = [convert_confirm, convert, convert_cancel]
-    convert.click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, convert_arr)
-    convert_confirm.click(
-        lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
-        remove_tts_from_history, None, None).then(
-        chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-        chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+    if shared.is_chat():
+        # Convert history with confirmation
+        convert_arr = [convert_confirm, convert, convert_cancel]
+        convert.click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, convert_arr)
+        convert_confirm.click(
+            lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
+            remove_tts_from_history, gradio('history'), gradio('history')).then(
+            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.redraw_html, shared.reload_inputs, gradio('display'))
 
-    convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
+        convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
 
-    # Toggle message text in history
-    show_text.change(
-        lambda x: params.update({"show_text": x}), show_text, None).then(
-        toggle_text_in_history, None, None).then(
-        chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-        chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
-
-    convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
+        # Toggle message text in history
+        show_text.change(
+            lambda x: params.update({"show_text": x}), show_text, None).then(
+            toggle_text_in_history, gradio('history'), gradio('history')).then(
+            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.redraw_html, shared.reload_inputs, gradio('display'))
 
     # Event functions to update the parameters in the backend
     activate.change(lambda x: params.update({'activate': x}), activate, None)

--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -10,7 +10,6 @@ import requests
 import torch
 from PIL import Image
 
-import modules.shared as shared
 from modules.models import reload_model, unload_model
 from modules.ui import create_refresh_button
 
@@ -126,7 +125,7 @@ def input_modifier(string):
     return string
 
 # Get and save the Stable Diffusion-generated picture
-def get_SD_pictures(description):
+def get_SD_pictures(description, character):
 
     global params
 
@@ -160,7 +159,7 @@ def get_SD_pictures(description):
         if params['save_img']:
             img_data = base64.b64decode(img_str)
 
-            variadic = f'{date.today().strftime("%Y_%m_%d")}/{shared.character}_{int(time.time())}'
+            variadic = f'{date.today().strftime("%Y_%m_%d")}/{character}_{int(time.time())}'
             output_file = Path(f'extensions/sd_api_pictures/outputs/{variadic}.png')
             output_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -186,7 +185,7 @@ def get_SD_pictures(description):
 
 # TODO: how do I make the UI history ignore the resulting pictures (I don't want HTML to appear in history)
 # and replace it with 'text' for the purposes of logging?
-def output_modifier(string):
+def output_modifier(string, state):
     """
     This function is applied to the model outputs.
     """
@@ -213,7 +212,7 @@ def output_modifier(string):
     else:
         text = string
 
-    string = get_SD_pictures(string) + "\n" + text
+    string = get_SD_pictures(string, state['character_menu']) + "\n" + text
 
     return string
 

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -120,7 +120,7 @@ def output_modifier(string, state):
     if string == '':
         string = '*Empty reply, try regenerating*'
     else:
-        output_file = Path(f'extensions/silero_tts/outputs/{shared.character}_{int(time.time())}.wav')
+        output_file = Path(f'extensions/silero_tts/outputs/{state["character_menu"]}_{int(time.time())}.wav')
         prosody = '<prosody rate="{}" pitch="{}">'.format(params['voice_speed'], params['voice_pitch'])
         silero_input = f'<speak>{prosody}{xmlesc(string)}</prosody></speak>'
         model.save_wav(ssml_text=silero_input, speaker=params['speaker'], sample_rate=int(params['sample_rate']), audio_path=str(output_file))

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -84,7 +84,7 @@ def state_modifier(state):
     return state
 
 
-def input_modifier(string):
+def input_modifier(string, state):
     if not params['activate']:
         return string
 
@@ -103,7 +103,7 @@ def history_modifier(history):
     return history
 
 
-def output_modifier(string):
+def output_modifier(string, state):
     global model, current_params, streaming_state
     for i in params:
         if params[i] != current_params[i]:

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -167,7 +167,7 @@ def ui():
         convert_confirm.click(
             lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
             remove_tts_from_history, gradio('history'), gradio('history')).then(
-            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
             chat.redraw_html, shared.reload_inputs, gradio('display'))
 
         convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
@@ -176,7 +176,7 @@ def ui():
         show_text.change(
             lambda x: params.update({"show_text": x}), show_text, None).then(
             toggle_text_in_history, gradio('history'), gradio('history')).then(
-            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
             chat.redraw_html, shared.reload_inputs, gradio('display'))
 
     # Event functions to update the parameters in the backend

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -56,20 +56,24 @@ def load_model():
     return model
 
 
-def remove_tts_from_history():
-    for i, entry in enumerate(shared.history['internal']):
-        shared.history['visible'][i] = [shared.history['visible'][i][0], entry[1]]
+def remove_tts_from_history(history):
+    for i, entry in enumerate(history['internal']):
+        history['visible'][i] = [history['visible'][i][0], entry[1]]
+
+    return history
 
 
-def toggle_text_in_history():
-    for i, entry in enumerate(shared.history['visible']):
+def toggle_text_in_history(history):
+    for i, entry in enumerate(history['visible']):
         visible_reply = entry[1]
         if visible_reply.startswith('<audio'):
             if params['show_text']:
-                reply = shared.history['internal'][i][1]
-                shared.history['visible'][i] = [shared.history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"]
+                reply = history['internal'][i][1]
+                history['visible'][i] = [history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>\n\n{reply}"]
             else:
-                shared.history['visible'][i] = [shared.history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>"]
+                history['visible'][i] = [history['visible'][i][0], f"{visible_reply.split('</audio>')[0]}</audio>"]
+
+    return history
 
 
 def state_modifier(state):
@@ -155,23 +159,24 @@ def ui():
 
         gr.Markdown('[Click here for Silero audio samples](https://oobabooga.github.io/silero-samples/index.html)')
 
-    # Convert history with confirmation
-    convert_arr = [convert_confirm, convert, convert_cancel]
-    convert.click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, convert_arr)
-    convert_confirm.click(
-        lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
-        remove_tts_from_history, None, None).then(
-        chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-        chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+    if shared.is_chat():
+        # Convert history with confirmation
+        convert_arr = [convert_confirm, convert, convert_cancel]
+        convert.click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, convert_arr)
+        convert_confirm.click(
+            lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
+            remove_tts_from_history, shared.gradio['history'], shared.gradio['history']).then(
+            chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
+            chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
 
-    convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
+        convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
 
-    # Toggle message text in history
-    show_text.change(
-        lambda x: params.update({"show_text": x}), show_text, None).then(
-        toggle_text_in_history, None, None).then(
-        chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-        chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+        # Toggle message text in history
+        show_text.change(
+            lambda x: params.update({"show_text": x}), show_text, None).then(
+            toggle_text_in_history, shared.gradio['history'], shared.gradio['history']).then(
+            chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
+            chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
 
     # Event functions to update the parameters in the backend
     activate.change(lambda x: params.update({"activate": x}), activate, None)

--- a/extensions/silero_tts/script.py
+++ b/extensions/silero_tts/script.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 import gradio as gr
 import torch
-from modules import chat, shared
 
 from extensions.silero_tts import tts_preprocessor
+from modules import chat, shared
+from modules.utils import gradio
 
 torch._C._jit_set_profiling_mode(False)
 
@@ -165,18 +166,18 @@ def ui():
         convert.click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, convert_arr)
         convert_confirm.click(
             lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr).then(
-            remove_tts_from_history, shared.gradio['history'], shared.gradio['history']).then(
-            chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-            chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+            remove_tts_from_history, gradio('history'), gradio('history')).then(
+            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.redraw_html, shared.reload_inputs, gradio('display'))
 
         convert_cancel.click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, convert_arr)
 
         # Toggle message text in history
         show_text.change(
             lambda x: params.update({"show_text": x}), show_text, None).then(
-            toggle_text_in_history, shared.gradio['history'], shared.gradio['history']).then(
-            chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-            chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+            toggle_text_in_history, gradio('history'), gradio('history')).then(
+            chat.save_history, gradio('mode'), None, show_progress=False).then(
+            chat.redraw_html, shared.reload_inputs, gradio('display'))
 
     # Event functions to update the parameters in the backend
     activate.change(lambda x: params.update({"activate": x}), activate, None)

--- a/extensions/superbooga/script.py
+++ b/extensions/superbooga/script.py
@@ -96,6 +96,8 @@ def apply_settings(chunk_count, chunk_count_initial, time_weight):
 def custom_generate_chat_prompt(user_input, state, **kwargs):
     global chat_collector
 
+    history = state['history']
+
     if state['mode'] == 'instruct':
         results = collector.get_sorted(user_input, n_results=params['chunk_count'])
         additional_context = '\nYour reply should be based on the context below:\n\n' + '\n'.join(results)
@@ -104,29 +106,29 @@ def custom_generate_chat_prompt(user_input, state, **kwargs):
 
         def make_single_exchange(id_):
             output = ''
-            output += f"{state['name1']}: {shared.history['internal'][id_][0]}\n"
-            output += f"{state['name2']}: {shared.history['internal'][id_][1]}\n"
+            output += f"{state['name1']}: {history['internal'][id_][0]}\n"
+            output += f"{state['name2']}: {history['internal'][id_][1]}\n"
             return output
 
-        if len(shared.history['internal']) > params['chunk_count'] and user_input != '':
+        if len(history['internal']) > params['chunk_count'] and user_input != '':
             chunks = []
-            hist_size = len(shared.history['internal'])
+            hist_size = len(history['internal'])
             for i in range(hist_size-1):
                 chunks.append(make_single_exchange(i))
 
             add_chunks_to_collector(chunks, chat_collector)
-            query = '\n'.join(shared.history['internal'][-1] + [user_input])
+            query = '\n'.join(history['internal'][-1] + [user_input])
             try:
                 best_ids = chat_collector.get_ids_sorted(query, n_results=params['chunk_count'], n_initial=params['chunk_count_initial'], time_weight=params['time_weight'])
                 additional_context = '\n'
                 for id_ in best_ids:
-                    if shared.history['internal'][id_][0] != '<|BEGIN-VISIBLE-CHAT|>':
+                    if history['internal'][id_][0] != '<|BEGIN-VISIBLE-CHAT|>':
                         additional_context += make_single_exchange(id_)
 
                 logger.warning(f'Adding the following new context:\n{additional_context}')
                 state['context'] = state['context'].strip() + '\n' + additional_context
                 kwargs['history'] = {
-                    'internal': [shared.history['internal'][i] for i in range(hist_size) if i not in best_ids],
+                    'internal': [history['internal'][i] for i in range(hist_size) if i not in best_ids],
                     'visible': ''
                 }
             except RuntimeError:

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -388,6 +388,26 @@ def load_history(file, history):
         return history
 
 
+def save_persistent_history(history, character, mode):
+    if mode == 'chat' and character not in  ['', 'None', None]:
+        save_history(history, path=Path(f'logs/{character}_persistent.json'))
+
+
+def load_persistent_history(character, greeting):
+    p = Path(f'logs/{character}_persistent.json')
+    if character not in ['None', '', None] and p.exists():
+        f = json.loads(open(p, 'rb').read())
+        if 'internal' in f and 'visible' in f:
+            history = f
+    else:
+        history = {'internal': [], 'visible': []}
+        if greeting != "":
+            history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
+            history['visible'] += [['', greeting]]
+
+    return history
+
+
 def replace_character_names(text, name1, name2):
     text = text.replace('{{user}}', name1).replace('{{char}}', name2)
     return text.replace('<USER>', name1).replace('<BOT>', name2)

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -79,10 +79,10 @@ def generate_chat_prompt(user_input, state, **kwargs):
         if impersonate:
             wrapper += substrings['user_turn_stripped'].rstrip(' ')
         elif _continue:
-            wrapper += apply_extensions("bot_prefix", substrings['bot_turn_stripped'])
+            wrapper += apply_extensions('bot_prefix', substrings['bot_turn_stripped'])
             wrapper += history[-1][1]
         else:
-            wrapper += apply_extensions("bot_prefix", substrings['bot_turn_stripped'].rstrip(' '))
+            wrapper += apply_extensions('bot_prefix', substrings['bot_turn_stripped'].rstrip(' '))
     else:
         wrapper = '<|prompt|>'
 
@@ -116,7 +116,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
 
         # Add the character prefix
         if state['mode'] != 'chat-instruct':
-            rows.append(apply_extensions("bot_prefix", substrings['bot_turn_stripped'].rstrip(' ')))
+            rows.append(apply_extensions('bot_prefix', substrings['bot_turn_stripped'].rstrip(' ')))
 
     while len(rows) > min_rows and get_encoded_length(wrapper.replace('<|prompt|>', ''.join(rows))) >= max_length:
         rows.pop(1)
@@ -219,7 +219,7 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
             # We need this global variable to handle the Stop event,
             # otherwise gradio gets confused
             if shared.stop_everything:
-                output['visible'][-1][1] = apply_extensions("output", output['visible'][-1][1])
+                output['visible'][-1][1] = apply_extensions('output', output['visible'][-1][1])
                 yield output
                 return
 
@@ -245,7 +245,7 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
         else:
             cumulative_reply = reply
 
-    output['visible'][-1][1] = apply_extensions("output", output['visible'][-1][1])
+    output['visible'][-1][1] = apply_extensions('output', output['visible'][-1][1])
     yield output
 
 
@@ -325,14 +325,14 @@ def send_last_reply_to_input(history):
 def replace_last_reply(text, history):
     if len(history['visible']) > 0:
         history['visible'][-1][1] = text
-        history['internal'][-1][1] = apply_extensions("input", text)
+        history['internal'][-1][1] = apply_extensions('input', text)
 
     return history
 
 
 def send_dummy_message(text, history):
     history['visible'].append([text, ''])
-    history['internal'].append([apply_extensions("input", text), ''])
+    history['internal'].append([apply_extensions('input', text), ''])
     return history
 
 
@@ -342,7 +342,7 @@ def send_dummy_reply(text, history):
         history['internal'].append(['', ''])
 
     history['visible'][-1][1] = text
-    history['internal'][-1][1] = apply_extensions("input", text)
+    history['internal'][-1][1] = apply_extensions('input', text)
     return history
 
 
@@ -352,7 +352,7 @@ def clear_chat_log(greeting, mode, history):
     if mode != 'instruct':
         if greeting != '':
             history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
-            history['visible'] += [['', apply_extensions("output", greeting)]]
+            history['visible'] += [['', apply_extensions('output', greeting)]]
 
     return history
 
@@ -391,7 +391,7 @@ def load_persistent_history(character, greeting):
     else:
         if greeting != "":
             history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
-            history['visible'] += [['', apply_extensions("output", greeting)]]
+            history['visible'] += [['', apply_extensions('output', greeting)]]
 
     return history
 

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -392,6 +392,9 @@ def load_persistent_history(state):
     character = state['character_menu']
     greeting = state['greeting']
     history = state['history']
+    if state['mode'] != 'chat':
+        return history
+
     p = Path(f'logs/{character}_persistent.json')
     if character != 'None' and p.exists():
         f = json.loads(open(p, 'rb').read())
@@ -445,7 +448,7 @@ def load_character(character, name1, name2, instruct=False):
     if Path("cache/pfp_character.png").exists():
         Path("cache/pfp_character.png").unlink()
 
-    if character != 'None':
+    if character not in ['None', '', None]:
         folder = 'characters' if not instruct else 'characters/instruction-following'
         picture = generate_pfp_cache(character)
         for extension in ["yml", "yaml", "json"]:

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -389,12 +389,12 @@ def load_history(file, history):
 
 
 def save_persistent_history(history, character, mode):
-    if mode == 'chat' and character not in  ['', 'None', None] and not shared.args.multi_user:
+    if mode in ['chat', 'chat-instruct'] and character not in  ['', 'None', None] and not shared.args.multi_user:
         save_history(history, path=Path(f'logs/{character}_persistent.json'))
 
 
 def load_persistent_history(state):
-    if shared.args.multi_user:
+    if shared.args.multi_user or state['mode'] == 'instruct':
         return state['history']
 
     character = state['character_menu']

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -368,14 +368,6 @@ def redraw_html(history, name1, name2, mode, style, reset_cache=False):
     return chat_html_wrapper(history, name1, name2, mode, style, reset_cache=reset_cache)
 
 
-def save_history(history, path=None):
-    p = path or Path('logs/exported_history.json')
-    with open(p, 'w', encoding='utf-8') as f:
-        f.write(json.dumps(history, indent=4))
-
-    return p
-
-
 def load_history(file, history):
     try:
         file = file.decode('utf-8')
@@ -386,26 +378,6 @@ def load_history(file, history):
             return history
     except:
         return history
-
-
-def load_persistent_history(state):
-    character = state['character_menu']
-    greeting = state['greeting']
-    history = state['history']
-    if state['mode'] != 'chat':
-        return history
-
-    p = Path(f'logs/{character}_persistent.json')
-    if character != 'None' and p.exists():
-        f = json.loads(open(p, 'rb').read())
-        if 'internal' in f and 'visible' in f:
-            history = f
-    else:
-        if greeting != "":
-            history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
-            history['visible'] += [['', apply_extensions('output', greeting, state)]]
-
-    return history
 
 
 def replace_character_names(text, name1, name2):

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -393,7 +393,9 @@ def save_persistent_history(history, character, mode):
         save_history(history, path=Path(f'logs/{character}_persistent.json'))
 
 
-def load_persistent_history(character, greeting):
+def load_persistent_history(state):
+    character = state['character_menu']
+    greeting = state['greeting']
     p = Path(f'logs/{character}_persistent.json')
     if character not in ['None', '', None] and p.exists():
         f = json.loads(open(p, 'rb').read())
@@ -403,7 +405,7 @@ def load_persistent_history(character, greeting):
         history = {'internal': [], 'visible': []}
         if greeting != "":
             history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
-            history['visible'] += [['', greeting]]
+            history['visible'] += [['', apply_extensions('output', greeting, state)]]
 
     return history
 

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -389,11 +389,14 @@ def load_history(file, history):
 
 
 def save_persistent_history(history, character, mode):
-    if mode == 'chat' and character not in  ['', 'None', None]:
+    if mode == 'chat' and character not in  ['', 'None', None] and not shared.args.multi_user:
         save_history(history, path=Path(f'logs/{character}_persistent.json'))
 
 
 def load_persistent_history(state):
+    if shared.args.multi_user:
+        return state['history']
+
     character = state['character_menu']
     greeting = state['greeting']
     p = Path(f'logs/{character}_persistent.json')

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -368,6 +368,14 @@ def redraw_html(history, name1, name2, mode, style, reset_cache=False):
     return chat_html_wrapper(history, name1, name2, mode, style, reset_cache=reset_cache)
 
 
+def save_history(history, path=None):
+    p = path or Path('logs/exported_history.json')
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write(json.dumps(history, indent=4))
+
+    return p
+
+
 def load_history(file, history):
     try:
         file = file.decode('utf-8')

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -362,9 +362,6 @@ def redraw_html(history, name1, name2, mode, style, reset_cache=False):
 
 
 def save_history(history, path=None):
-    if not Path('logs').exists():
-        Path('logs').mkdir()
-
     p = path or Path('logs/exported_history.json')
     with open(p, 'w', encoding='utf-8') as f:
         f.write(json.dumps(history, indent=4))
@@ -372,7 +369,19 @@ def save_history(history, path=None):
     return p
 
 
-def load_history(character, greeting):
+def load_history(file, history):
+    try:
+        file = file.decode('utf-8')
+        j = json.loads(file)
+        if 'internal' in j and 'visible' in j:
+            return j
+        else:
+            return history
+    except:
+        return history
+
+
+def load_persistent_history(character, greeting):
     history = {'internal': [], 'visible': []}
     p = Path(f'logs/{character}_persistent.json')
     if character != 'None' and p.exists():

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -6,6 +6,8 @@ import gradio as gr
 import extensions
 import modules.shared as shared
 from modules.logging_colors import logger
+from inspect import signature
+
 
 state = {}
 available_extensions = []
@@ -52,10 +54,14 @@ def iterator():
 
 
 # Extension functions that map string -> string
-def _apply_string_extensions(function_name, text):
+def _apply_string_extensions(function_name, text, state):
     for extension, _ in iterator():
         if hasattr(extension, function_name):
-            text = getattr(extension, function_name)(text)
+            func = getattr(extension, function_name)
+            if len(signature(func).parameters) == 2:
+                text = func(text, state)
+            else:
+                text = func(text)
 
     return text
 

--- a/modules/github.py
+++ b/modules/github.py
@@ -14,16 +14,20 @@ def clone_or_pull_repository(github_url):
 
     # Check if the repository is already cloned
     if os.path.exists(repo_path):
+        yield f"Updating {github_url}..."
         # Perform a 'git pull' to update the repository
         try:
             pull_output = subprocess.check_output(["git", "-C", repo_path, "pull"], stderr=subprocess.STDOUT)
+            yield "Done."
             return pull_output.decode()
         except subprocess.CalledProcessError as e:
             return str(e)
 
     # Clone the repository
     try:
+        yield f"Cloning {github_url}..."
         clone_output = subprocess.check_output(["git", "clone", github_url, repo_path], stderr=subprocess.STDOUT)
+        yield "Done."
         return clone_output.decode()
     except subprocess.CalledProcessError as e:
         return str(e)

--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -266,8 +266,8 @@ def generate_chat_html(history, name1, name2, reset_cache=False):
 
 def chat_html_wrapper(history, name1, name2, mode, style, reset_cache=False):
     if mode == 'instruct':
-        return generate_instruct_html(history)
+        return generate_instruct_html(history['visible'])
     elif style == 'wpp':
-        return generate_chat_html(history, name1, name2)
+        return generate_chat_html(history['visible'], name1, name2)
     else:
-        return generate_cai_chat_html(history, name1, name2, style, reset_cache)
+        return generate_cai_chat_html(history['visible'], name1, name2, style, reset_cache)

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -29,11 +29,12 @@ def load_preset(name):
         'mirostat_eta': 0.1,
     }
 
-    with open(Path(f'presets/{name}.yaml'), 'r') as infile:
-        preset = yaml.safe_load(infile)
+    if name not in ['None', None, '']:
+        with open(Path(f'presets/{name}.yaml'), 'r') as infile:
+            preset = yaml.safe_load(infile)
 
-    for k in preset:
-        generate_params[k] = preset[k]
+        for k in preset:
+            generate_params[k] = preset[k]
 
     generate_params['temperature'] = min(1.99, generate_params['temperature'])
     return generate_params

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -14,8 +14,6 @@ model_name = "None"
 lora_names = []
 
 # Chat variables
-history = {'internal': [], 'visible': []}
-character = 'None'
 stop_everything = False
 processing_message = '*Is typing...*'
 
@@ -244,6 +242,15 @@ if args.multimodal_pipeline is not None:
 
 def is_chat():
     return args.chat
+
+
+def get_mode():
+    if args.chat:
+        return 'chat'
+    elif args.notebook:
+        return 'notebook'
+    else:
+        return 'default'
 
 
 # Loading model-specific settings

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -81,6 +81,7 @@ parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpForma
 # Basic settings
 parser.add_argument('--notebook', action='store_true', help='Launch the web UI in notebook mode, where the output is written to the same text box as the input.')
 parser.add_argument('--chat', action='store_true', help='Launch the web UI in chat mode with a style similar to the Character.AI website.')
+parser.add_argument('--multi-user', action='store_true', help='Multi-user mode. Chat histories are not saved or automatically loaded. WARNING: this is highly experimental.')
 parser.add_argument('--character', type=str, help='The name of the character to load in chat mode by default.')
 parser.add_argument('--model', type=str, help='Name of the model to load by default.')
 parser.add_argument('--lora', type=str, nargs="+", help='The list of LoRAs to load. If you want to load more than one LoRA, write the names separated by spaces.')
@@ -202,6 +203,8 @@ if args.trust_remote_code:
     logger.warning("trust_remote_code is enabled. This is dangerous.")
 if args.share:
     logger.warning("The gradio \"share link\" feature uses a proprietary executable to create a reverse tunnel. Use it with care.")
+if args.multi_user:
+    logger.warning("The multi-user mode is highly experimental. DO NOT EXPOSE IT TO THE INTERNET.")
 
 
 def fix_loader_name(name):

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -262,7 +262,7 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
     eos_token_ids = [shared.tokenizer.eos_token_id] if shared.tokenizer.eos_token_id is not None else []
     generate_params['eos_token_id'] = eos_token_ids
     generate_params['stopping_criteria'] = transformers.StoppingCriteriaList()
-    generate_params['stopping_criteria'].append(_StopEverythingStoppingCriteria());
+    generate_params['stopping_criteria'].append(_StopEverythingStoppingCriteria())
 
     t0 = time.time()
     try:

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -190,7 +190,7 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False):
     original_question = question
     if not is_chat:
         state = apply_extensions('state', state)
-        question = apply_extensions('input', question)
+        question = apply_extensions('input', question, state)
 
     # Finding the stopping strings
     all_stop_strings = []
@@ -223,7 +223,7 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False):
             break
 
     if not is_chat:
-        reply = apply_extensions('output', reply)
+        reply = apply_extensions('output', reply, state)
 
     yield reply
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -139,9 +139,10 @@ def gather_interface_values(*args):
     for i, element in enumerate(list_interface_input_elements()):
         output[element] = args[i]
 
-    shared.persistent_interface_state = output
-    with open(Path(f'logs/session_{shared.get_mode()}_autosave.json'), 'w') as f:
-        f.write(json.dumps(output, indent=4))
+    if not shared.args.multi_user:
+        shared.persistent_interface_state = output
+        with open(Path(f'logs/session_{shared.get_mode()}_autosave.json'), 'w') as f:
+            f.write(json.dumps(output, indent=4))
 
     return output
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -6,6 +6,7 @@ import torch
 
 from modules import shared
 
+
 with open(Path(__file__).resolve().parent / '../css/main.css', 'r') as f:
     css = f.read()
 with open(Path(__file__).resolve().parent / '../css/chat.css', 'r') as f:
@@ -138,19 +139,19 @@ def gather_interface_values(*args):
     for i, element in enumerate(list_interface_input_elements()):
         output[element] = args[i]
 
-    shared.persistent_interface_state = output
     with open(Path('logs/interface_state.json'), 'w') as f:
-        import copy
-        out = copy.deepcopy(output)
-
-        if shared.is_chat():
-            if out['character_menu'] not in ['', 'None', None]:
-                history_f = Path('logs/{}_persistent.json'.format(out['character_menu']))
-                with open(history_f, 'w') as ff:
-                    ff.write(json.dumps(out['history'], indent=4))
-
         f.write(json.dumps(output, indent=4))
 
+    if shared.is_chat():
+        if output['mode'] == 'chat' and output['character_menu'] not in ['', 'None', None]:
+            from modules.chat import save_history
+
+            save_history(
+                output['history'], 
+                path=Path('logs/{}_persistent.json'.format(output['character_menu']))
+            )
+
+    shared.persistent_interface_state = output
     return output
 
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -74,7 +74,6 @@ def list_model_elements():
 
 def list_interface_input_elements():
     elements = [
-        'preset_menu',
         'max_new_tokens',
         'seed',
         'temperature',

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -138,15 +138,6 @@ def gather_interface_values(*args):
     for i, element in enumerate(list_interface_input_elements()):
         output[element] = args[i]
 
-    if shared.is_chat():
-        if output['mode'] == 'chat' and output['character_menu'] not in ['', 'None', None]:
-            from modules.chat import save_history
-
-            save_history(
-                output['history'],
-                path=Path('logs/{}_persistent.json'.format(output['character_menu']))
-            )
-
     shared.persistent_interface_state = output
     with open(Path(f'logs/session_{shared.get_mode()}_autosave.json'), 'w') as f:
         f.write(json.dumps(output, indent=4))

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -143,7 +143,7 @@ def gather_interface_values(*args):
             from modules.chat import save_history
 
             save_history(
-                output['history'], 
+                output['history'],
                 path=Path('logs/{}_persistent.json'.format(output['character_menu']))
             )
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -139,9 +139,6 @@ def gather_interface_values(*args):
     for i, element in enumerate(list_interface_input_elements()):
         output[element] = args[i]
 
-    with open(Path('logs/interface_state.json'), 'w') as f:
-        f.write(json.dumps(output, indent=4))
-
     if shared.is_chat():
         if output['mode'] == 'chat' and output['character_menu'] not in ['', 'None', None]:
             from modules.chat import save_history
@@ -152,6 +149,9 @@ def gather_interface_values(*args):
             )
 
     shared.persistent_interface_state = output
+    with open(Path(f'logs/session_{shared.get_mode()}_autosave.json'), 'w') as f:
+        f.write(json.dumps(output, indent=4))
+
     return output
 
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import gradio as gr
@@ -14,7 +15,7 @@ with open(Path(__file__).resolve().parent / '../css/main.js', 'r') as f:
 with open(Path(__file__).resolve().parent / '../css/chat.js', 'r') as f:
     chat_js = f.read()
 
-refresh_symbol = '\U0001f504'  # 🔄
+refresh_symbol = '🔄'
 delete_symbol = '🗑️'
 save_symbol = '💾'
 
@@ -30,17 +31,103 @@ theme = gr.themes.Default(
 
 
 def list_model_elements():
-    elements = ['loader', 'cpu_memory', 'auto_devices', 'disk', 'cpu', 'bf16', 'load_in_8bit', 'trust_remote_code', 'load_in_4bit', 'compute_dtype', 'quant_type', 'use_double_quant', 'wbits', 'groupsize', 'model_type', 'pre_layer', 'triton', 'desc_act', 'no_inject_fused_attention', 'no_inject_fused_mlp', 'no_use_cuda_fp16', 'threads', 'n_batch', 'no_mmap', 'mlock', 'n_gpu_layers', 'n_ctx', 'llama_cpp_seed', 'gpu_split', 'max_seq_len', 'compress_pos_emb']
+    elements = [
+        'loader',
+        'cpu_memory',
+        'auto_devices',
+        'disk',
+        'cpu',
+        'bf16',
+        'load_in_8bit',
+        'trust_remote_code',
+        'load_in_4bit',
+        'compute_dtype',
+        'quant_type',
+        'use_double_quant',
+        'wbits',
+        'groupsize',
+        'model_type',
+        'pre_layer',
+        'triton',
+        'desc_act',
+        'no_inject_fused_attention',
+        'no_inject_fused_mlp',
+        'no_use_cuda_fp16',
+        'threads',
+        'n_batch',
+        'no_mmap',
+        'mlock',
+        'n_gpu_layers',
+        'n_ctx',
+        'llama_cpp_seed',
+        'gpu_split',
+        'max_seq_len',
+        'compress_pos_emb'
+    ]
+
     for i in range(torch.cuda.device_count()):
         elements.append(f'gpu_memory_{i}')
 
     return elements
 
 
-def list_interface_input_elements(chat=False):
-    elements = ['max_new_tokens', 'seed', 'temperature', 'top_p', 'top_k', 'typical_p', 'epsilon_cutoff', 'eta_cutoff', 'repetition_penalty', 'repetition_penalty_range', 'encoder_repetition_penalty', 'no_repeat_ngram_size', 'min_length', 'do_sample', 'penalty_alpha', 'num_beams', 'length_penalty', 'early_stopping', 'mirostat_mode', 'mirostat_tau', 'mirostat_eta', 'add_bos_token', 'ban_eos_token', 'truncation_length', 'custom_stopping_strings', 'skip_special_tokens', 'preset_menu', 'stream', 'tfs', 'top_a']
-    if chat:
-        elements += ['name1', 'name2', 'greeting', 'context', 'chat_generation_attempts', 'stop_at_newline', 'mode', 'instruction_template', 'character_menu', 'name1_instruct', 'name2_instruct', 'context_instruct', 'turn_template', 'chat_style', 'chat-instruct_command']
+def list_interface_input_elements():
+    elements = [
+        'preset_menu',
+        'max_new_tokens',
+        'seed',
+        'temperature',
+        'top_p',
+        'top_k',
+        'typical_p',
+        'epsilon_cutoff',
+        'eta_cutoff',
+        'repetition_penalty',
+        'repetition_penalty_range',
+        'encoder_repetition_penalty',
+        'no_repeat_ngram_size',
+        'min_length',
+        'do_sample',
+        'penalty_alpha',
+        'num_beams',
+        'length_penalty',
+        'early_stopping',
+        'mirostat_mode',
+        'mirostat_tau',
+        'mirostat_eta',
+        'add_bos_token',
+        'ban_eos_token',
+        'truncation_length',
+        'custom_stopping_strings',
+        'skip_special_tokens',
+        'stream',
+        'tfs',
+        'top_a',
+    ]
+
+    if shared.args.chat:
+        elements += [
+            'character_menu',
+            'history',
+            'name1',
+            'name2',
+            'greeting',
+            'context',
+            'chat_generation_attempts',
+            'stop_at_newline',
+            'mode',
+            'instruction_template',
+            'name1_instruct',
+            'name2_instruct',
+            'context_instruct',
+            'turn_template',
+            'chat_style',
+            'chat-instruct_command',
+        ]
+    else:
+        elements.append('textbox')
+        if not shared.args.notebook:
+            elements.append('output_textbox')
 
     elements += list_model_elements()
     return elements
@@ -48,10 +135,22 @@ def list_interface_input_elements(chat=False):
 
 def gather_interface_values(*args):
     output = {}
-    for i, element in enumerate(shared.input_elements):
+    for i, element in enumerate(list_interface_input_elements()):
         output[element] = args[i]
 
     shared.persistent_interface_state = output
+    with open(Path('logs/interface_state.json'), 'w') as f:
+        import copy
+        out = copy.deepcopy(output)
+
+        if shared.is_chat():
+            if out['character_menu'] not in ['', 'None', None]:
+                history_f = Path('logs/{}_persistent.json'.format(out['character_menu']))
+                with open(history_f, 'w') as ff:
+                    ff.write(json.dumps(out['history'], indent=4))
+
+        f.write(json.dumps(output, indent=4))
+
     return output
 
 
@@ -59,11 +158,12 @@ def apply_interface_values(state, use_persistent=False):
     if use_persistent:
         state = shared.persistent_interface_state
 
-    elements = list_interface_input_elements(chat=shared.is_chat())
+    elements = list_interface_input_elements()
     if len(state) == 0:
         return [gr.update() for k in elements]  # Dummy, do nothing
     else:
-        return [state[k] if k in state else gr.update() for k in elements]
+        ans = [state[k] if k in state else gr.update() for k in elements]
+        return ans
 
 
 class ToolButton(gr.Button, gr.components.FormComponent):
@@ -92,6 +192,7 @@ def create_refresh_button(refresh_component, refresh_method, refreshed_args, ele
         inputs=[],
         outputs=[refresh_component]
     )
+
     return refresh_button
 
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -74,6 +74,7 @@ def list_model_elements():
 
 def list_interface_input_elements():
     elements = [
+        'preset_menu',
         'max_new_tokens',
         'seed',
         'temperature',

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -122,4 +122,5 @@ def get_available_chat_styles():
 
 
 def get_available_sessions():
-    return sorted(set(k.stem for k in Path('logs').glob(f'session_{shared.get_mode()}*')), key=natural_keys, reverse=True)
+    items = sorted(set(k.stem for k in Path('logs').glob(f'session_{shared.get_mode()}*')), key=natural_keys, reverse=True)
+    return [item for item in items if 'autosave' in item] + [item for item in items if 'autosave' not in item]

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -114,4 +114,4 @@ def get_available_chat_styles():
 
 
 def get_available_sessions():
-    return sorted(set(k.stem for k in Path('logs').glob(f'session_{shared.get_mode()}*')), key=natural_keys)
+    return sorted(set(k.stem for k in Path('logs').glob(f'session_{shared.get_mode()}*')), key=natural_keys, reverse=True)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -111,3 +111,7 @@ def get_datasets(path: str, ext: str):
 
 def get_available_chat_styles():
     return sorted(set(('-'.join(k.stem.split('-')[1:]) for k in Path('css').glob('chat_style*.css'))), key=natural_keys)
+
+
+def get_available_sessions():
+    return sorted(set(k.stem for k in Path('logs').glob(f'session_{shared.get_mode()}*')), key=natural_keys)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -7,6 +7,14 @@ from modules import shared
 from modules.logging_colors import logger
 
 
+# Helper function to get multiple values from shared.gradio
+def gradio(*keys):
+    if len(keys) == 1 and type(keys[0]) is list:
+        keys = keys[0]
+
+    return [shared.gradio[k] for k in keys]
+
+
 def save_file(fname, contents):
     if fname == '':
         logger.error('File name is empty!')

--- a/server.py
+++ b/server.py
@@ -828,6 +828,7 @@ def create_interface():
                 lambda x: (x, ''), gradio('textbox'), gradio('Chat input', 'textbox'), show_progress=False).then(
                 chat.generate_chat_reply_wrapper, shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -836,6 +837,7 @@ def create_interface():
                 lambda x: (x, ''), gradio('textbox'), gradio('Chat input', 'textbox'), show_progress=False).then(
                 chat.generate_chat_reply_wrapper, shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -843,6 +845,7 @@ def create_interface():
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 partial(chat.generate_chat_reply_wrapper, regenerate=True), shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -850,6 +853,7 @@ def create_interface():
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 partial(chat.generate_chat_reply_wrapper, _continue=True), shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -865,34 +869,41 @@ def create_interface():
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.replace_last_reply, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
+                chat.redraw_html, shared.reload_inputs, gradio('display')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
 
             shared.gradio['Send dummy message'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.send_dummy_message, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
+                chat.redraw_html, shared.reload_inputs, gradio('display')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
 
             shared.gradio['Send dummy reply'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.send_dummy_reply, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
+                chat.redraw_html, shared.reload_inputs, gradio('display')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
 
+            shared.gradio['Clear history'].click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, clear_arr)
+            shared.gradio['Clear history-cancel'].click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr)
             shared.gradio['Clear history-confirm'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr).then(
                 chat.clear_chat_log, gradio('interface_state'), gradio('history')).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
+                chat.redraw_html, shared.reload_inputs, gradio('display')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
 
             shared.gradio['Remove last'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.remove_last_message, gradio('history'), gradio('textbox', 'history'), show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
+                chat.redraw_html, shared.reload_inputs, gradio('display')).then(
+                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
 
             shared.gradio['character_menu'].change(
-                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
+                chat.load_persistent_history, gradio('character_menu', 'greeting'), gradio('history')).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Stop'].click(
@@ -912,8 +923,6 @@ def create_interface():
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Copy last reply'].click(chat.send_last_reply_to_input, gradio('history'), gradio('textbox'), show_progress=False)
-            shared.gradio['Clear history'].click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, clear_arr)
-            shared.gradio['Clear history-cancel'].click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr)
 
             # Save/delete a character
             shared.gradio['save_character'].click(
@@ -1122,7 +1131,7 @@ if __name__ == "__main__":
     if shared.is_chat():
         shared.persistent_interface_state.update({
             'mode': shared.settings['mode'],
-            'character': shared.args.character or shared.settings['character'],
+            'character_menu': shared.args.character or shared.settings['character'],
             'instruction_template': shared.settings['instruction_template']
         })
 

--- a/server.py
+++ b/server.py
@@ -828,7 +828,7 @@ def create_interface():
                 lambda x: (x, ''), gradio('textbox'), gradio('Chat input', 'textbox'), show_progress=False).then(
                 chat.generate_chat_reply_wrapper, shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -837,7 +837,7 @@ def create_interface():
                 lambda x: (x, ''), gradio('textbox'), gradio('Chat input', 'textbox'), show_progress=False).then(
                 chat.generate_chat_reply_wrapper, shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -845,7 +845,7 @@ def create_interface():
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 partial(chat.generate_chat_reply_wrapper, regenerate=True), shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -853,7 +853,7 @@ def create_interface():
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 partial(chat.generate_chat_reply_wrapper, _continue=True), shared.input_params, gradio('display', 'history'), show_progress=False).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None)).then(
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
@@ -870,21 +870,21 @@ def create_interface():
                 chat.replace_last_reply, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None)
 
             shared.gradio['Send dummy message'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.send_dummy_message, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None)
 
             shared.gradio['Send dummy reply'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.send_dummy_reply, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None)
 
             shared.gradio['Clear history'].click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, clear_arr)
             shared.gradio['Clear history-cancel'].click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr)
@@ -893,13 +893,13 @@ def create_interface():
                 lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr).then(
                 chat.clear_chat_log, gradio('interface_state'), gradio('history')).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None)
 
             shared.gradio['Remove last'].click(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.remove_last_message, gradio('history'), gradio('textbox', 'history'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display')).then(
-                chat.save_persistent_history(gradio('history', 'character_menu', 'mode'), None))
+                chat.save_persistent_history, gradio('history', 'character_menu', 'mode'), None)
 
             shared.gradio['character_menu'].change(
                 partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(

--- a/server.py
+++ b/server.py
@@ -489,7 +489,7 @@ def create_file_saving_event_handlers():
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda x: json.dumps(x, indent=4), gradio('interface_state'), gradio('save_contents')).then(
                 lambda: 'logs/', None, gradio('save_root')).then(
-                lambda x: f'session_{shared.get_mode()}_{x}_{utils.current_time()}.json', gradio('character_menu'), gradio('save_filename')).then(
+                lambda x: f'session_{shared.get_mode()}_{x + "_" if x not in ["None", None, ""] else ""}{utils.current_time()}.json', gradio('character_menu'), gradio('save_filename')).then(
                 lambda: gr.update(visible=True), None, gradio('file_saver'))
         else:
             shared.gradio['save_session'].click(
@@ -509,6 +509,9 @@ def create_file_saving_event_handlers():
                 state.update(
                     json.loads(f.read())
                 )
+
+            if shared.is_chat():
+                chat.save_persistent_history(state['history'], state['character_menu'], state['mode'])
 
             return state
 

--- a/server.py
+++ b/server.py
@@ -903,7 +903,8 @@ def create_interface():
 
             shared.gradio['character_menu'].change(
                 partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
-                chat.load_persistent_history, gradio('character_menu', 'greeting'), gradio('history')).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.load_persistent_history, gradio('interface_state'), gradio('history')).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Stop'].click(

--- a/server.py
+++ b/server.py
@@ -869,23 +869,38 @@ def create_interface():
             )
 
             shared.gradio['Replace last reply'].click(
-                chat.replace_last_reply, gradio('textbox', 'history'), None).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.replace_last_reply, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Send dummy message'].click(
-                chat.send_dummy_message, gradio('textbox', 'history'), gradio('history')).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.send_dummy_message, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Send dummy reply'].click(
-                chat.send_dummy_reply, gradio('textbox', 'history'), gradio('history')).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.send_dummy_reply, gradio('textbox', 'interface_state'), gradio('history')).then(
                 lambda: '', None, gradio('textbox'), show_progress=False).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Clear history-confirm'].click(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr).then(
-                chat.clear_chat_log, gradio('greeting', 'mode', 'history'), gradio('history')).then(
+                chat.clear_chat_log, gradio('interface_state'), gradio('history')).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
+
+            shared.gradio['Remove last'].click(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                chat.remove_last_message, gradio('history'), gradio('textbox', 'history'), show_progress=False).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
+
+            shared.gradio['character_menu'].change(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
+                chat.load_persistent_history, gradio('interface_state'), gradio('history')).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Stop'].click(
@@ -907,9 +922,6 @@ def create_interface():
             shared.gradio['Copy last reply'].click(chat.send_last_reply_to_input, gradio('history'), gradio('textbox'), show_progress=False)
             shared.gradio['Clear history'].click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, clear_arr)
             shared.gradio['Clear history-cancel'].click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr)
-            shared.gradio['Remove last'].click(
-                chat.remove_last_message, gradio('history'), gradio('textbox', 'history'), show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             # Save/delete a character
             shared.gradio['save_character'].click(
@@ -933,11 +945,6 @@ def create_interface():
             shared.gradio['Submit character'].click(chat.upload_character, gradio('upload_json', 'upload_img_bot'), gradio('character_menu'))
             shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, gradio('Submit character'))
             shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, gradio('Submit character'))
-
-            shared.gradio['character_menu'].change(
-                partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
-                chat.load_persistent_history, gradio('character_menu', 'greeting'), gradio('history')).then(
-                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Submit tavern character'].click(chat.upload_tavern_character, gradio('upload_img_tavern', 'tavern_json'), gradio('character_menu'))
             shared.gradio['upload_img_tavern'].upload(chat.check_tavern_character, gradio('upload_img_tavern'), gradio('tavern_name', 'tavern_desc', 'tavern_json', 'Submit tavern character'), show_progress=False)

--- a/server.py
+++ b/server.py
@@ -1112,15 +1112,10 @@ if __name__ == "__main__":
             add_lora_to_model(shared.args.lora)
 
     # Forcing some events to be triggered on page load
-    # saved_state_path = Path('logs/interface_state.json')
-    # if saved_state_path.exists():
-    #     with open(saved_state_path, 'r') as f:
-    #         saved_state = json.loads(f.read())
-    # shared.persistent_interface_state.update(saved_state)
-
     shared.persistent_interface_state.update({
         'loader': shared.args.loader or 'Transformers',
     })
+
     if shared.is_chat():
         shared.persistent_interface_state.update({
             'mode': shared.settings['mode'],

--- a/server.py
+++ b/server.py
@@ -921,7 +921,7 @@ def create_interface():
                 lambda: 'characters/instruction-following/', None, gradio('delete_root')).then(
                 lambda: gr.update(visible=True), None, gradio('file_deleter'))
 
-            shared.gradio['download_button'].click(partial(chat.save_history, timestamp=True, user_request=True), gradio('history', 'mode'), gradio('download'))
+            shared.gradio['download_button'].click(chat.save_history, gradio('history'), gradio('download'))
             shared.gradio['Submit character'].click(chat.upload_character, gradio('upload_json', 'upload_img_bot'), gradio('character_menu'))
             shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, gradio('Submit character'))
             shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, gradio('Submit character'))

--- a/server.py
+++ b/server.py
@@ -51,6 +51,14 @@ from modules.text_generation import (
 )
 
 
+# Helper function to get multiple values from shared.gradio
+def gradio(*keys):
+    if len(keys) == 1 and type(keys[0]) is list:
+        keys = keys[0]
+
+    return [shared.gradio[k] for k in keys]
+
+
 def load_model_wrapper(selected_model, loader, autoload=False):
     if not autoload:
         yield f"The settings for {selected_model} have been updated.\nClick on \"Load the model\" to load it."
@@ -257,40 +265,40 @@ def create_model_menus():
             with gr.Row():
                 shared.gradio['model_status'] = gr.Markdown('No model is loaded' if shared.model_name == 'None' else 'Ready')
 
-    shared.gradio['loader'].change(loaders.make_loader_params_visible, shared.gradio['loader'], [shared.gradio[k] for k in loaders.get_all_params()])
+    shared.gradio['loader'].change(loaders.make_loader_params_visible, gradio('loader'), gradio(loaders.get_all_params()))
 
     # In this event handler, the interface state is read and updated
     # with the model defaults (if any), and then the model is loaded
     # unless "autoload_model" is unchecked
     shared.gradio['model_menu'].change(
-        ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-        apply_model_settings_to_state, [shared.gradio[k] for k in ['model_menu', 'interface_state']], shared.gradio['interface_state']).then(
-        ui.apply_interface_values, shared.gradio['interface_state'], [shared.gradio[k] for k in ui.list_interface_input_elements(chat=shared.is_chat())], show_progress=False).then(
-        update_model_parameters, shared.gradio['interface_state'], None).then(
-        load_model_wrapper, [shared.gradio[k] for k in ['model_menu', 'loader', 'autoload_model']], shared.gradio['model_status'], show_progress=False)
+        ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+        apply_model_settings_to_state, gradio('model_menu', 'interface_state'), gradio('interface_state')).then(
+        ui.apply_interface_values, gradio('interface_state'), gradio(ui.list_interface_input_elements()), show_progress=False).then(
+        update_model_parameters, gradio('interface_state'), None).then(
+        load_model_wrapper, gradio('model_menu', 'loader', 'autoload_model'), gradio('model_status'), show_progress=False)
 
     load.click(
-        ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-        update_model_parameters, shared.gradio['interface_state'], None).then(
-        partial(load_model_wrapper, autoload=True), [shared.gradio[k] for k in ['model_menu', 'loader']], shared.gradio['model_status'], show_progress=False)
+        ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+        update_model_parameters, gradio('interface_state'), None).then(
+        partial(load_model_wrapper, autoload=True), gradio('model_menu', 'loader'), gradio('model_status'), show_progress=False)
 
     unload.click(
         unload_model, None, None).then(
-        lambda: "Model unloaded", None, shared.gradio['model_status'])
+        lambda: "Model unloaded", None, gradio('model_status'))
 
     reload.click(
         unload_model, None, None).then(
-        ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-        update_model_parameters, shared.gradio['interface_state'], None).then(
-        partial(load_model_wrapper, autoload=True), [shared.gradio[k] for k in ['model_menu', 'loader']], shared.gradio['model_status'], show_progress=False)
+        ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+        update_model_parameters, gradio('interface_state'), None).then(
+        partial(load_model_wrapper, autoload=True), gradio('model_menu', 'loader'), gradio('model_status'), show_progress=False)
 
     save_settings.click(
-        ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-        save_model_settings, [shared.gradio[k] for k in ['model_menu', 'interface_state']], shared.gradio['model_status'], show_progress=False)
+        ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+        save_model_settings, gradio('model_menu', 'interface_state'), gradio('model_status'), show_progress=False)
 
-    shared.gradio['lora_menu_apply'].click(load_lora_wrapper, shared.gradio['lora_menu'], shared.gradio['model_status'], show_progress=False)
-    shared.gradio['download_model_button'].click(download_model_wrapper, shared.gradio['custom_model_menu'], shared.gradio['model_status'], show_progress=True)
-    shared.gradio['autoload_model'].change(lambda x: gr.update(visible=not x), shared.gradio['autoload_model'], load)
+    shared.gradio['lora_menu_apply'].click(load_lora_wrapper, gradio('lora_menu'), gradio('model_status'), show_progress=False)
+    shared.gradio['download_model_button'].click(download_model_wrapper, gradio('custom_model_menu'), gradio('model_status'), show_progress=True)
+    shared.gradio['autoload_model'].change(lambda x: gr.update(visible=not x), gradio('autoload_model'), load)
 
 
 def create_chat_settings_menus():
@@ -409,7 +417,7 @@ def create_settings_menus(default_preset):
                         shared.gradio['skip_special_tokens'] = gr.Checkbox(value=shared.settings['skip_special_tokens'], label='Skip special tokens', info='Some specific models need this unset.')
                         shared.gradio['stream'] = gr.Checkbox(value=not shared.args.no_stream, label='Activate text streaming')
 
-    shared.gradio['preset_menu'].change(presets.load_preset_for_ui, [shared.gradio[k] for k in ['preset_menu', 'interface_state']], [shared.gradio[k] for k in ['interface_state', 'do_sample', 'temperature', 'top_p', 'typical_p', 'epsilon_cutoff', 'eta_cutoff', 'repetition_penalty', 'repetition_penalty_range', 'encoder_repetition_penalty', 'top_k', 'min_length', 'no_repeat_ngram_size', 'num_beams', 'penalty_alpha', 'length_penalty', 'early_stopping', 'mirostat_mode', 'mirostat_tau', 'mirostat_eta', 'tfs', 'top_a']])
+    shared.gradio['preset_menu'].change(presets.load_preset_for_ui, gradio('preset_menu', 'interface_state'), gradio('interface_state', 'do_sample', 'temperature', 'top_p', 'typical_p', 'epsilon_cutoff', 'eta_cutoff', 'repetition_penalty', 'repetition_penalty_range', 'encoder_repetition_penalty', 'top_k', 'min_length', 'no_repeat_ngram_size', 'num_beams', 'penalty_alpha', 'length_penalty', 'early_stopping', 'mirostat_mode', 'mirostat_tau', 'mirostat_eta', 'tfs', 'top_a'))
 
 
 def create_file_saving_menus():
@@ -448,39 +456,63 @@ def create_file_saving_menus():
 
 def create_file_saving_event_handlers():
     shared.gradio['save_confirm'].click(
-        lambda x, y, z: utils.save_file(x + y, z), [shared.gradio[k] for k in ['save_root', 'save_filename', 'save_contents']], None).then(
-        lambda: gr.update(visible=False), None, shared.gradio['file_saver'])
+        lambda x, y, z: utils.save_file(x + y, z), gradio('save_root', 'save_filename', 'save_contents'), None).then(
+        lambda: gr.update(visible=False), None, gradio('file_saver'))
 
     shared.gradio['delete_confirm'].click(
-        lambda x, y: utils.delete_file(x + y), [shared.gradio[k] for k in ['delete_root', 'delete_filename']], None).then(
-        lambda: gr.update(visible=False), None, shared.gradio['file_deleter'])
+        lambda x, y: utils.delete_file(x + y), gradio('delete_root', 'delete_filename'), None).then(
+        lambda: gr.update(visible=False), None, gradio('file_deleter'))
 
-    shared.gradio['delete_cancel'].click(lambda: gr.update(visible=False), None, shared.gradio['file_deleter'])
-    shared.gradio['save_cancel'].click(lambda: gr.update(visible=False), None, shared.gradio['file_saver'])
+    shared.gradio['delete_cancel'].click(lambda: gr.update(visible=False), None, gradio('file_deleter'))
+    shared.gradio['save_cancel'].click(lambda: gr.update(visible=False), None, gradio('file_saver'))
     if shared.is_chat():
         shared.gradio['save_character_confirm'].click(
-            chat.save_character, [shared.gradio[k] for k in ['name2', 'greeting', 'context', 'character_picture', 'save_character_filename']], None).then(
-            lambda: gr.update(visible=False), None, shared.gradio['character_saver'])
+            chat.save_character, gradio('name2', 'greeting', 'context', 'character_picture', 'save_character_filename'), None).then(
+            lambda: gr.update(visible=False), None, gradio('character_saver'))
 
         shared.gradio['delete_character_confirm'].click(
-            chat.delete_character, shared.gradio['character_menu'], None).then(
-            lambda: gr.update(visible=False), None, shared.gradio['character_deleter']).then(
-            lambda: gr.update(choices=utils.get_available_characters()), outputs=shared.gradio['character_menu'])
+            chat.delete_character, gradio('character_menu'), None).then(
+            lambda: gr.update(visible=False), None, gradio('character_deleter')).then(
+            lambda: gr.update(choices=utils.get_available_characters()), None, gradio('character_menu'))
 
-        shared.gradio['save_character_cancel'].click(lambda: gr.update(visible=False), None, shared.gradio['character_saver'])
-        shared.gradio['delete_character_cancel'].click(lambda: gr.update(visible=False), None, shared.gradio['character_deleter'])
+        shared.gradio['save_character_cancel'].click(lambda: gr.update(visible=False), None, gradio('character_saver'))
+        shared.gradio['delete_character_cancel'].click(lambda: gr.update(visible=False), None, gradio('character_deleter'))
 
     shared.gradio['save_preset'].click(
-        ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-        presets.generate_preset_yaml, shared.gradio['interface_state'], shared.gradio['save_contents']).then(
-        lambda: 'presets/', None, shared.gradio['save_root']).then(
-        lambda: 'My Preset.yaml', None, shared.gradio['save_filename']).then(
-        lambda: gr.update(visible=True), None, shared.gradio['file_saver'])
+        ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+        presets.generate_preset_yaml, gradio('interface_state'), gradio('save_contents')).then(
+        lambda: 'presets/', None, gradio('save_root')).then(
+        lambda: 'My Preset.yaml', None, gradio('save_filename')).then(
+        lambda: gr.update(visible=True), None, gradio('file_saver'))
 
     shared.gradio['delete_preset'].click(
-        lambda x: f'{x}.yaml', shared.gradio['preset_menu'], shared.gradio['delete_filename']).then(
-        lambda: 'presets/', None, shared.gradio['delete_root']).then(
-        lambda: gr.update(visible=True), None, shared.gradio['file_deleter'])
+        lambda x: f'{x}.yaml', gradio('preset_menu'), gradio('delete_filename')).then(
+        lambda: 'presets/', None, gradio('delete_root')).then(
+        lambda: gr.update(visible=True), None, gradio('file_deleter'))
+
+    shared.gradio['save_session'].click(
+        ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+        lambda x: json.dumps(x, indent=4), gradio('interface_state'), gradio('save_contents')).then(
+        lambda: 'logs/', None, gradio('save_root')).then(
+        lambda x: f'session_{shared.get_mode()}_{x}_{utils.current_time()}.json', gradio('character_menu'), gradio('save_filename')).then(
+        lambda: gr.update(visible=True), None, gradio('file_saver'))
+
+    shared.gradio['delete_session'].click(
+        lambda x: f'{x}.json', gradio('session_menu'), gradio('delete_filename')).then(
+        lambda: 'logs/', None, gradio('delete_root')).then(
+        lambda: gr.update(visible=True), None, gradio('file_deleter'))
+
+    def load_session(session, state):
+        with open(Path(f'logs/{session}.json'), 'r') as f:
+            state.update(
+                json.loads(f.read())
+            )
+
+        return state
+
+    shared.gradio['session_menu'].change(
+        load_session, gradio('session_menu', 'interface_state'), gradio('interface_state')).then(
+        ui.apply_interface_values, gradio('interface_state'), gradio(ui.list_interface_input_elements()), show_progress=False)
 
 
 def set_interface_arguments(interface_mode, extensions, bool_active):
@@ -544,13 +576,17 @@ def create_interface():
 
         # Create chat mode interface
         if shared.is_chat():
-            shared.input_elements = ui.list_interface_input_elements(chat=True)
-            shared.gradio['interface_state'] = gr.State({k: None for k in shared.input_elements})
-            shared.gradio['Chat input'] = gr.State()
-            shared.gradio['dummy'] = gr.State()
+            shared.input_elements = ui.list_interface_input_elements()
+
+            shared.gradio.update({
+                'interface_state': gr.State({k: None for k in shared.input_elements}),
+                'Chat input': gr.State(),
+                'dummy': gr.State(),
+                'history': gr.State({'internal': [], 'visible': []}),
+            })
 
             with gr.Tab('Text generation', elem_id='main'):
-                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper(shared.history['visible'], shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'))
+                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'))
                 shared.gradio['textbox'] = gr.Textbox(label='Input')
                 with gr.Row():
                     shared.gradio['Stop'] = gr.Button('Stop', elem_id='stop')
@@ -586,7 +622,7 @@ def create_interface():
                     with gr.Row():
                         with gr.Column(scale=8):
                             with gr.Row():
-                                shared.gradio['character_menu'] = gr.Dropdown(choices=utils.get_available_characters(), label='Character', elem_id='character-menu', info='Used in chat and chat-instruct modes.', elem_classes='slim-dropdown')
+                                shared.gradio['character_menu'] = gr.Dropdown(value='None', choices=utils.get_available_characters(), label='Character', elem_id='character-menu', info='Used in chat and chat-instruct modes.', elem_classes='slim-dropdown')
                                 ui.create_refresh_button(shared.gradio['character_menu'], lambda: None, lambda: {'choices': utils.get_available_characters()}, 'refresh-button')
                                 shared.gradio['save_character'] = gr.Button('💾', elem_classes='refresh-button')
                                 shared.gradio['delete_character'] = gr.Button('🗑️', elem_classes='refresh-button')
@@ -648,7 +684,7 @@ def create_interface():
 
         # Create notebook mode interface
         elif shared.args.notebook:
-            shared.input_elements = ui.list_interface_input_elements(chat=False)
+            shared.input_elements = ui.list_interface_input_elements()
             shared.gradio['interface_state'] = gr.State({k: None for k in shared.input_elements})
             shared.gradio['last_input'] = gr.State('')
             with gr.Tab("Text generation", elem_id="main"):
@@ -687,7 +723,7 @@ def create_interface():
 
         # Create default mode interface
         else:
-            shared.input_elements = ui.list_interface_input_elements(chat=False)
+            shared.input_elements = ui.list_interface_input_elements()
             shared.gradio['interface_state'] = gr.State({k: None for k in shared.input_elements})
             shared.gradio['last_input'] = gr.State('')
             with gr.Tab("Text generation", elem_id="main"):
@@ -731,8 +767,8 @@ def create_interface():
         with gr.Tab("Training", elem_id="training-tab"):
             training.create_train_interface()
 
-        # Interface mode tab
-        with gr.Tab("Interface mode", elem_id="interface-mode"):
+        # Session tab
+        with gr.Tab("Session", elem_id="session-tab"):
             modes = ["default", "notebook", "chat"]
             current_mode = "default"
             for mode in modes[1:]:
@@ -745,223 +781,232 @@ def create_interface():
             bool_active = [k for k in bool_list if vars(shared.args)[k]]
 
             with gr.Row():
-                shared.gradio['interface_modes_menu'] = gr.Dropdown(choices=modes, value=current_mode, label="Mode")
-                shared.gradio['reset_interface'] = gr.Button("Apply and restart the interface", elem_classes="small-button")
-                shared.gradio['toggle_dark_mode'] = gr.Button('Toggle dark/light mode', elem_classes="small-button")
-
-            with gr.Row():
-                with gr.Column():
-                    shared.gradio['extensions_menu'] = gr.CheckboxGroup(choices=utils.get_available_extensions(), value=shared.args.extensions, label="Available extensions", info='Note that some of these extensions may require manually installing Python requirements through the command: pip install -r extensions/extension_name/requirements.txt', elem_classes='checkboxgroup-table')
 
                 with gr.Column():
-                    shared.gradio['bool_menu'] = gr.CheckboxGroup(choices=bool_list, value=bool_active, label="Boolean command-line flags", elem_classes='checkboxgroup-table')
+                    with gr.Row():
+                        shared.gradio['interface_modes_menu'] = gr.Dropdown(choices=modes, value=current_mode, label="Mode", elem_classes='slim-dropdown')
+                        shared.gradio['reset_interface'] = gr.Button("Apply and restart", elem_classes="small-button", variant="primary")
+                        shared.gradio['toggle_dark_mode'] = gr.Button('Toggle 💡', elem_classes="small-button")
 
-            with gr.Row():
-                extension_name = gr.Textbox(lines=1, label='Install or update an extension', info='Enter the GitHub URL below. For a list of extensions, see: https://github.com/oobabooga/text-generation-webui-extensions ⚠️  WARNING ⚠️ : extensions can execute arbitrary code. Make sure to inspect their source code before activating them.')
-                extension_install = gr.Button('Install or update', elem_classes="small-button")
+                    with gr.Row():
+                        with gr.Column():
+                            shared.gradio['extensions_menu'] = gr.CheckboxGroup(choices=utils.get_available_extensions(), value=shared.args.extensions, label="Available extensions", info='Note that some of these extensions may require manually installing Python requirements through the command: pip install -r extensions/extension_name/requirements.txt', elem_classes='checkboxgroup-table')
 
-            extension_status = gr.Markdown()
+                        with gr.Column():
+                            shared.gradio['bool_menu'] = gr.CheckboxGroup(choices=bool_list, value=bool_active, label="Boolean command-line flags", elem_classes='checkboxgroup-table')
 
-            extension_install.click(
+                with gr.Column():
+                    with gr.Row():
+                        shared.gradio['session_menu'] = gr.Dropdown(choices=utils.get_available_sessions(), value='None', label='Session', elem_classes='slim-dropdown')
+                        ui.create_refresh_button(shared.gradio['session_menu'], lambda: None, lambda: {'choices': utils.get_available_sessions()}, ['refresh-button'])
+                        shared.gradio['save_session'] = gr.Button('💾', elem_classes=['refresh-button'])
+                        shared.gradio['delete_session'] = gr.Button('🗑️', elem_classes=['refresh-button'])
+
+                    extension_name = gr.Textbox(lines=1, label='Install or update an extension', info='Enter the GitHub URL below and press Enter. For a list of extensions, see: https://github.com/oobabooga/text-generation-webui-extensions ⚠️  WARNING ⚠️ : extensions can execute arbitrary code. Make sure to inspect their source code before activating them.')
+                    extension_status = gr.Markdown()
+
+            extension_name.submit(
                 clone_or_pull_repository, extension_name, extension_status, show_progress=False).then(
-                lambda: gr.update(choices=utils.get_available_extensions(), value=shared.args.extensions), outputs=shared.gradio['extensions_menu'])
+                lambda: gr.update(choices=utils.get_available_extensions(), value=shared.args.extensions), None, gradio('extensions_menu'))
 
             # Reset interface event
             shared.gradio['reset_interface'].click(
-                set_interface_arguments, [shared.gradio[k] for k in ['interface_modes_menu', 'extensions_menu', 'bool_menu']], None).then(
+                set_interface_arguments, gradio('interface_modes_menu', 'extensions_menu', 'bool_menu'), None).then(
                 lambda: None, None, None, _js='() => {document.body.innerHTML=\'<h1 style="font-family:monospace;margin-top:20%;color:lightgray;text-align:center;">Reloading...</h1>\'; setTimeout(function(){location.reload()},2500); return []}')
 
             shared.gradio['toggle_dark_mode'].click(lambda: None, None, None, _js='() => {document.getElementsByTagName("body")[0].classList.toggle("dark")}')
 
         # chat mode event handlers
         if shared.is_chat():
-            shared.input_params = [shared.gradio[k] for k in ['Chat input', 'start_with', 'interface_state']]
-            clear_arr = [shared.gradio[k] for k in ['Clear history-confirm', 'Clear history', 'Clear history-cancel']]
-            shared.reload_inputs = [shared.gradio[k] for k in ['name1', 'name2', 'mode', 'chat_style']]
+            shared.input_params = gradio('Chat input', 'start_with', 'interface_state')
+            clear_arr = gradio('Clear history-confirm', 'Clear history', 'Clear history-cancel')
+            shared.reload_inputs = gradio('history', 'name1', 'name2', 'mode', 'chat_style')
 
             gen_events.append(shared.gradio['Generate'].click(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-                lambda x: (x, ''), shared.gradio['textbox'], [shared.gradio['Chat input'], shared.gradio['textbox']], show_progress=False).then(
-                chat.generate_chat_reply_wrapper, shared.input_params, shared.gradio['display'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                lambda x: (x, ''), gradio('textbox'), gradio('Chat input', 'textbox'), show_progress=False).then(
+                chat.generate_chat_reply_wrapper, shared.input_params, gradio('display', 'history'), show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
             gen_events.append(shared.gradio['textbox'].submit(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-                lambda x: (x, ''), shared.gradio['textbox'], [shared.gradio['Chat input'], shared.gradio['textbox']], show_progress=False).then(
-                chat.generate_chat_reply_wrapper, shared.input_params, shared.gradio['display'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                lambda x: (x, ''), gradio('textbox'), gradio('Chat input', 'textbox'), show_progress=False).then(
+                chat.generate_chat_reply_wrapper, shared.input_params, gradio('display', 'history'), show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
             gen_events.append(shared.gradio['Regenerate'].click(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-                partial(chat.generate_chat_reply_wrapper, regenerate=True), shared.input_params, shared.gradio['display'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                partial(chat.generate_chat_reply_wrapper, regenerate=True), shared.input_params, gradio('display', 'history'), show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
             gen_events.append(shared.gradio['Continue'].click(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-                partial(chat.generate_chat_reply_wrapper, _continue=True), shared.input_params, shared.gradio['display'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                partial(chat.generate_chat_reply_wrapper, _continue=True), shared.input_params, gradio('display', 'history'), show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
             gen_events.append(shared.gradio['Impersonate'].click(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-                lambda x: x, shared.gradio['textbox'], shared.gradio['Chat input'], show_progress=False).then(
-                chat.impersonate_wrapper, shared.input_params, shared.gradio['textbox'], show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                lambda x: x, gradio('textbox'), gradio('Chat input'), show_progress=False).then(
+                chat.impersonate_wrapper, shared.input_params, gradio('textbox'), show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
             )
 
             shared.gradio['Replace last reply'].click(
-                chat.replace_last_reply, shared.gradio['textbox'], None).then(
-                lambda: '', None, shared.gradio['textbox'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                chat.replace_last_reply, gradio('textbox', 'history'), None).then(
+                lambda: '', None, gradio('textbox'), show_progress=False).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Send dummy message'].click(
-                chat.send_dummy_message, shared.gradio['textbox'], None).then(
-                lambda: '', None, shared.gradio['textbox'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                chat.send_dummy_message, gradio('textbox', 'history'), gradio('history')).then(
+                lambda: '', None, gradio('textbox'), show_progress=False).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Send dummy reply'].click(
-                chat.send_dummy_reply, shared.gradio['textbox'], None).then(
-                lambda: '', None, shared.gradio['textbox'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                chat.send_dummy_reply, gradio('textbox', 'history'), gradio('history')).then(
+                lambda: '', None, gradio('textbox'), show_progress=False).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Clear history-confirm'].click(
                 lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr).then(
-                chat.clear_chat_log, [shared.gradio[k] for k in ['greeting', 'mode']], None).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                chat.clear_chat_log, gradio('greeting', 'mode', 'history'), gradio('history')).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Stop'].click(
                 stop_everything_event, None, None, queue=False, cancels=gen_events if shared.args.no_stream else None).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['mode'].change(
-                lambda x: gr.update(visible=x != 'instruct'), shared.gradio['mode'], shared.gradio['chat_style'], show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                lambda x: gr.update(visible=x != 'instruct'), gradio('mode'), gradio('chat_style'), show_progress=False).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
-            shared.gradio['chat_style'].change(chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+            shared.gradio['chat_style'].change(chat.redraw_html, shared.reload_inputs, gradio('display'))
             shared.gradio['instruction_template'].change(
-                partial(chat.load_character, instruct=True), [shared.gradio[k] for k in ['instruction_template', 'name1_instruct', 'name2_instruct']], [shared.gradio[k] for k in ['name1_instruct', 'name2_instruct', 'dummy', 'dummy', 'context_instruct', 'turn_template']])
+                partial(chat.load_character, instruct=True), gradio('instruction_template', 'name1_instruct', 'name2_instruct'), gradio('name1_instruct', 'name2_instruct', 'dummy', 'dummy', 'context_instruct', 'turn_template'))
 
             shared.gradio['upload_chat_history'].upload(
-                chat.load_history, [shared.gradio[k] for k in ['upload_chat_history', 'name1', 'name2']], None).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                # chat.load_history, gradio('upload_chat_history', 'name1', 'name2'), None).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
-            shared.gradio['Copy last reply'].click(chat.send_last_reply_to_input, None, shared.gradio['textbox'], show_progress=False)
+            shared.gradio['Copy last reply'].click(chat.send_last_reply_to_input, gradio('history'), gradio('textbox'), show_progress=False)
             shared.gradio['Clear history'].click(lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True)], None, clear_arr)
             shared.gradio['Clear history-cancel'].click(lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)], None, clear_arr)
             shared.gradio['Remove last'].click(
-                chat.remove_last_message, None, shared.gradio['textbox'], show_progress=False).then(
-                chat.save_history, shared.gradio['mode'], None, show_progress=False).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                chat.remove_last_message, gradio('history'), gradio('textbox', 'history'), show_progress=False).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             # Save/delete a character
             shared.gradio['save_character'].click(
-                lambda x: x, shared.gradio['name2'], shared.gradio['save_character_filename']).then(
-                lambda: gr.update(visible=True), None, shared.gradio['character_saver'])
+                lambda x: x, gradio('name2'), gradio('save_character_filename')).then(
+                lambda: gr.update(visible=True), None, gradio('character_saver'))
 
-            shared.gradio['delete_character'].click(lambda: gr.update(visible=True), None, shared.gradio['character_deleter'])
+            shared.gradio['delete_character'].click(lambda: gr.update(visible=True), None, gradio('character_deleter'))
 
             shared.gradio['save_template'].click(
-                lambda: 'My Template.yaml', None, shared.gradio['save_filename']).then(
-                lambda: 'characters/instruction-following/', None, shared.gradio['save_root']).then(
-                chat.generate_instruction_template_yaml, [shared.gradio[k] for k in ['name1_instruct', 'name2_instruct', 'context_instruct', 'turn_template']], shared.gradio['save_contents']).then(
-                lambda: gr.update(visible=True), None, shared.gradio['file_saver'])
+                lambda: 'My Template.yaml', None, gradio('save_filename')).then(
+                lambda: 'characters/instruction-following/', None, gradio('save_root')).then(
+                chat.generate_instruction_template_yaml, gradio('name1_instruct', 'name2_instruct', 'context_instruct', 'turn_template'), gradio('save_contents')).then(
+                lambda: gr.update(visible=True), None, gradio('file_saver'))
 
             shared.gradio['delete_template'].click(
-                lambda x: f'{x}.yaml', shared.gradio['instruction_template'], shared.gradio['delete_filename']).then(
-                lambda: 'characters/instruction-following/', None, shared.gradio['delete_root']).then(
-                lambda: gr.update(visible=True), None, shared.gradio['file_deleter'])
+                lambda x: f'{x}.yaml', gradio('instruction_template'), gradio('delete_filename')).then(
+                lambda: 'characters/instruction-following/', None, gradio('delete_root')).then(
+                lambda: gr.update(visible=True), None, gradio('file_deleter'))
 
-            shared.gradio['download_button'].click(lambda x: chat.save_history(x, timestamp=True, user_request=True), shared.gradio['mode'], shared.gradio['download'])
-            shared.gradio['Submit character'].click(chat.upload_character, [shared.gradio['upload_json'], shared.gradio['upload_img_bot']], [shared.gradio['character_menu']])
-            shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, [shared.gradio['Submit character']])
-            shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, [shared.gradio['Submit character']])
+            shared.gradio['download_button'].click(partial(chat.save_history, timestamp=True, user_request=True), gradio('history', 'mode'), gradio('download'))
+            shared.gradio['Submit character'].click(chat.upload_character, gradio('upload_json', 'upload_img_bot'), gradio('character_menu'))
+            shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, gradio('Submit character'))
+            shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, gradio('Submit character'))
 
             shared.gradio['character_menu'].change(
-                partial(chat.load_character, instruct=False), [shared.gradio[k] for k in ['character_menu', 'name1', 'name2']], [shared.gradio[k] for k in ['name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy']]).then(
-                chat.redraw_html, shared.reload_inputs, shared.gradio['display'])
+                partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
+                chat.load_history, gradio('character_menu', 'greeting'), gradio('history')).then(
+                chat.redraw_html, shared.reload_inputs, gradio('display'))
 
-            shared.gradio['Submit tavern character'].click(chat.upload_tavern_character, [shared.gradio['upload_img_tavern'], shared.gradio['tavern_json']], [shared.gradio['character_menu']])
-            shared.gradio['upload_img_tavern'].upload(chat.check_tavern_character, shared.gradio['upload_img_tavern'], [shared.gradio[k] for k in ['tavern_name', 'tavern_desc', 'tavern_json', 'Submit tavern character']], show_progress=False)
-            shared.gradio['upload_img_tavern'].clear(lambda: (None, None, None, gr.update(interactive=False)), None, [shared.gradio[k] for k in ['tavern_name', 'tavern_desc', 'tavern_json', 'Submit tavern character']], show_progress=False)
+            shared.gradio['Submit tavern character'].click(chat.upload_tavern_character, gradio('upload_img_tavern', 'tavern_json'), gradio('character_menu'))
+            shared.gradio['upload_img_tavern'].upload(chat.check_tavern_character, gradio('upload_img_tavern'), gradio('tavern_name', 'tavern_desc', 'tavern_json', 'Submit tavern character'), show_progress=False)
+            shared.gradio['upload_img_tavern'].clear(lambda: (None, None, None, gr.update(interactive=False)), None, gradio('tavern_name', 'tavern_desc', 'tavern_json', 'Submit tavern character'), show_progress=False)
             shared.gradio['your_picture'].change(
-                chat.upload_your_profile_picture, shared.gradio['your_picture'], None).then(
-                partial(chat.redraw_html, reset_cache=True), shared.reload_inputs, shared.gradio['display'])
+                chat.upload_your_profile_picture, gradio('your_picture'), None).then(
+                partial(chat.redraw_html, reset_cache=True), shared.reload_inputs, gradio('display'))
 
         # notebook/default modes event handlers
         else:
-            shared.input_params = [shared.gradio[k] for k in ['textbox', 'interface_state']]
+            shared.input_params = gradio('textbox', 'interface_state')
             if shared.args.notebook:
-                output_params = [shared.gradio[k] for k in ['textbox', 'html']]
+                output_params = gradio('textbox', 'html')
             else:
-                output_params = [shared.gradio[k] for k in ['output_textbox', 'html']]
+                output_params = gradio('output_textbox', 'html')
 
             gen_events.append(shared.gradio['Generate'].click(
-                lambda x: x, shared.gradio['textbox'], shared.gradio['last_input']).then(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
+                lambda x: x, gradio('textbox'), gradio('last_input')).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 generate_reply_wrapper, shared.input_params, output_params, show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
                 # lambda: None, None, None, _js="() => {element = document.getElementsByTagName('textarea')[0]; element.scrollTop = element.scrollHeight}")
             )
 
             gen_events.append(shared.gradio['textbox'].submit(
-                lambda x: x, shared.gradio['textbox'], shared.gradio['last_input']).then(
-                ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
+                lambda x: x, gradio('textbox'), gradio('last_input')).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 generate_reply_wrapper, shared.input_params, output_params, show_progress=False).then(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
                 # lambda: None, None, None, _js="() => {element = document.getElementsByTagName('textarea')[0]; element.scrollTop = element.scrollHeight}")
             )
 
             if shared.args.notebook:
-                shared.gradio['Undo'].click(lambda x: x, shared.gradio['last_input'], shared.gradio['textbox'], show_progress=False)
-                shared.gradio['markdown_render'].click(lambda x: x, shared.gradio['textbox'], shared.gradio['markdown'], queue=False)
+                shared.gradio['Undo'].click(lambda x: x, gradio('last_input'), gradio('textbox'), show_progress=False)
+                shared.gradio['markdown_render'].click(lambda x: x, gradio('textbox'), gradio('markdown'), queue=False)
                 gen_events.append(shared.gradio['Regenerate'].click(
-                    lambda x: x, shared.gradio['last_input'], shared.gradio['textbox'], show_progress=False).then(
-                    ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
+                    lambda x: x, gradio('last_input'), gradio('textbox'), show_progress=False).then(
+                    ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                     generate_reply_wrapper, shared.input_params, output_params, show_progress=False).then(
+                    ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                     lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
                     # lambda: None, None, None, _js="() => {element = document.getElementsByTagName('textarea')[0]; element.scrollTop = element.scrollHeight}")
                 )
             else:
-                shared.gradio['markdown_render'].click(lambda x: x, shared.gradio['output_textbox'], shared.gradio['markdown'], queue=False)
+                shared.gradio['markdown_render'].click(lambda x: x, gradio('output_textbox'), gradio('markdown'), queue=False)
                 gen_events.append(shared.gradio['Continue'].click(
-                    ui.gather_interface_values, [shared.gradio[k] for k in shared.input_elements], shared.gradio['interface_state']).then(
-                    generate_reply_wrapper, [shared.gradio['output_textbox']] + shared.input_params[1:], output_params, show_progress=False).then(
+                    ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                    generate_reply_wrapper, get('output_textbox') + shared.input_params[1:], output_params, show_progress=False).then(
+                    ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                     lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
                     # lambda: None, None, None, _js="() => {element = document.getElementsByTagName('textarea')[1]; element.scrollTop = element.scrollHeight}")
                 )
 
             shared.gradio['Stop'].click(stop_everything_event, None, None, queue=False, cancels=gen_events if shared.args.no_stream else None)
-            shared.gradio['prompt_menu'].change(load_prompt, shared.gradio['prompt_menu'], shared.gradio['textbox'], show_progress=False)
+            shared.gradio['prompt_menu'].change(load_prompt, gradio('prompt_menu'), gradio('textbox'), show_progress=False)
             shared.gradio['save_prompt'].click(
-                lambda x: x, shared.gradio['textbox'], shared.gradio['save_contents']).then(
-                lambda: 'prompts/', None, shared.gradio['save_root']).then(
-                lambda: utils.current_time() + '.txt', None, shared.gradio['save_filename']).then(
-                lambda: gr.update(visible=True), None, shared.gradio['file_saver'])
+                lambda x: x, gradio('textbox'), gradio('save_contents')).then(
+                lambda: 'prompts/', None, gradio('save_root')).then(
+                lambda: utils.current_time() + '.txt', None, gradio('save_filename')).then(
+                lambda: gr.update(visible=True), None, gradio('file_saver'))
 
             shared.gradio['delete_prompt'].click(
-                lambda: 'prompts/', None, shared.gradio['delete_root']).then(
-                lambda x: x + '.txt', shared.gradio['prompt_menu'], shared.gradio['delete_filename']).then(
-                lambda: gr.update(visible=True), None, shared.gradio['file_deleter'])
+                lambda: 'prompts/', None, gradio('delete_root')).then(
+                lambda x: x + '.txt', gradio('prompt_menu'), gradio('delete_filename')).then(
+                lambda: gr.update(visible=True), None, gradio('file_deleter'))
 
-            shared.gradio['count_tokens'].click(count_tokens, shared.gradio['textbox'], shared.gradio['status'], show_progress=False)
+            shared.gradio['count_tokens'].click(count_tokens, gradio('textbox'), gradio('status'), show_progress=False)
 
         create_file_saving_event_handlers()
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
         if shared.settings['dark_theme']:
             shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.add('dark')")
 
-        shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, [shared.gradio[k] for k in ui.list_interface_input_elements(chat=shared.is_chat())], show_progress=False)
+        shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, gradio(ui.list_interface_input_elements()), show_progress=False)
+        shared.gradio['interface'].load(chat.redraw_html, shared.reload_inputs, gradio('display'))
 
         # Extensions tabs
         extensions_module.create_extensions_tabs()
@@ -1058,19 +1103,28 @@ if __name__ == "__main__":
         if shared.args.lora:
             add_lora_to_model(shared.args.lora)
 
-    # Force a character to be loaded
-    if shared.is_chat():
-        shared.persistent_interface_state.update({
-            'mode': shared.settings['mode'],
-            'character_menu': shared.args.character or shared.settings['character'],
-            'instruction_template': shared.settings['instruction_template']
-        })
+    # Forcing some events to be triggered on page load
+    # saved_state_path = Path('logs/interface_state.json')
+    # if saved_state_path.exists():
+    #     with open(saved_state_path, 'r') as f:
+    #         saved_state = json.loads(f.read())
+    # shared.persistent_interface_state.update(saved_state)
 
     shared.persistent_interface_state.update({
         'loader': shared.args.loader or 'Transformers',
     })
+    if shared.is_chat():
+        shared.persistent_interface_state.update({
+            'mode': shared.settings['mode'],
+            'character': shared.args.character or shared.settings['character'],
+            'instruction_template': shared.settings['instruction_template']
+        })
+
+        if Path("cache/pfp_character.png").exists():
+            Path("cache/pfp_character.png").unlink()
 
     shared.generation_lock = Lock()
+
     # Launch the web UI
     create_interface()
     while True:

--- a/server.py
+++ b/server.py
@@ -26,10 +26,12 @@ from functools import partial
 from pathlib import Path
 from threading import Lock
 
-import modules.extensions as extensions_module
 import psutil
 import torch
 import yaml
+from PIL import Image
+
+import modules.extensions as extensions_module
 from modules import chat, loaders, presets, shared, training, ui, utils
 from modules.extensions import apply_extensions
 from modules.github import clone_or_pull_repository
@@ -48,7 +50,6 @@ from modules.text_generation import (
     stop_everything_event
 )
 from modules.utils import gradio
-from PIL import Image
 
 
 def load_model_wrapper(selected_model, loader, autoload=False):

--- a/server.py
+++ b/server.py
@@ -979,7 +979,7 @@ def create_interface():
                 shared.gradio['markdown_render'].click(lambda x: x, gradio('output_textbox'), gradio('markdown'), queue=False)
                 gen_events.append(shared.gradio['Continue'].click(
                     ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
-                    generate_reply_wrapper, get('output_textbox') + shared.input_params[1:], output_params, show_progress=False).then(
+                    generate_reply_wrapper, [shared.gradio['output_textbox']] + shared.input_params[1:], output_params, show_progress=False).then(
                     ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                     lambda: None, None, None, _js=f"() => {{{audio_notification_js}}}")
                     # lambda: None, None, None, _js="() => {element = document.getElementsByTagName('textarea')[1]; element.scrollTop = element.scrollHeight}")

--- a/server.py
+++ b/server.py
@@ -893,7 +893,6 @@ def create_interface():
             shared.gradio['character_menu'].change(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
-                chat.load_persistent_history, gradio('interface_state'), gradio('history')).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))
 
             shared.gradio['Stop'].click(

--- a/server.py
+++ b/server.py
@@ -1009,11 +1009,14 @@ def create_interface():
             shared.gradio['count_tokens'].click(count_tokens, gradio('textbox'), gradio('status'), show_progress=False)
 
         create_file_saving_event_handlers()
-        shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
+
+        shared.gradio['interface'].load(
+            lambda: None, None, None, _js=f"() => {{{js}}}").then(
+            partial(ui.apply_interface_values, {}, use_persistent=True), None, gradio(ui.list_interface_input_elements()), show_progress=False)
+
         if shared.settings['dark_theme']:
             shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.add('dark')")
 
-        shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, gradio(ui.list_interface_input_elements()), show_progress=False)
         if shared.is_chat():
             shared.gradio['interface'].load(chat.redraw_html, shared.reload_inputs, gradio('display'))
 

--- a/server.py
+++ b/server.py
@@ -26,12 +26,10 @@ from functools import partial
 from pathlib import Path
 from threading import Lock
 
+import modules.extensions as extensions_module
 import psutil
 import torch
 import yaml
-from PIL import Image
-
-import modules.extensions as extensions_module
 from modules import chat, loaders, presets, shared, training, ui, utils
 from modules.extensions import apply_extensions
 from modules.github import clone_or_pull_repository
@@ -49,14 +47,8 @@ from modules.text_generation import (
     get_encoded_length,
     stop_everything_event
 )
-
-
-# Helper function to get multiple values from shared.gradio
-def gradio(*keys):
-    if len(keys) == 1 and type(keys[0]) is list:
-        keys = keys[0]
-
-    return [shared.gradio[k] for k in keys]
+from modules.utils import gradio
+from PIL import Image
 
 
 def load_model_wrapper(selected_model, loader, autoload=False):


### PR DESCRIPTION
~This implements many changes, so some things may still be broken.~

**Sessions**

In the Sessions tab, you can save the entire session, including input and output texts, generation parameters, and chat history.

Use cases:

* Saving multiple histories for the same character.
* Saving a story and returning to it later.

For that to be possible, the chat history hard to be turned into a `gr.State` variable and is no longer a global variable. This will make it easy to add multi-user support after this PR is merged. The disadvantage is that many extensions relied on accessing `shared.history` to work, so I had to rework a lot of the extensions framework.

**Interface persistence**

* When you reload the page, your text in default/notebook modes is no longer lost.
* The entire session is automatically saved as `session_chat_autosave.json`, `session_notebook_autosave.json`, or `session_default_autosave.json` depending on the mode, so that you can come back to where you were even if you turn off the computer.

**Multi-user support**

Implemented through the `--multi-user` flag. When it is used, chat histories are no longer automatically saved or loaded. Instead, they are only kept in memory for the duration of the session.

It is possible that there are bugs.

**Syntax simplifications**

A new `gradio(...)` helper function has been added to `server.py`. What it does is allow you to write

```python
button.click(function, gradio('interface_state', 'history', 'character_menu'), None)
```

instead of

```python
button.click(function, [shared.gradio[k] for k in ['interface_state', 'history', 'character_menu']], None)
```

this makes event handler declarations a lot more readable.