### PR TITLE
Changed FormComponent to IOComponent

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -162,7 +162,7 @@ def apply_interface_values(state, use_persistent=False):
         return ans
 
 
-class ToolButton(gr.Button, gr.components.FormComponent):
+class ToolButton(gr.Button, gr.components.IOComponent):
     """Small button with single emoji as text, fits inside gradio forms"""
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Bumped into an issue where it would fail to launch due to an error like this:

```
Traceback (most recent call last):
  File "C:\AI\oobabooga\oobabooga_windows\text-generation-webui\server.py", line 35, in <module>
    from modules import chat, loaders, presets, shared, training, ui, utils
  File "C:\AI\oobabooga\oobabooga_windows\text-generation-webui\modules\chat.py", line 18, in <module>
    from modules.text_generation import (generate_reply, get_encoded_length,
  File "C:\AI\oobabooga\oobabooga_windows\text-generation-webui\modules\text_generation.py", line 17, in <module>
    from modules.models import clear_torch_cache, local_rank
  File "C:\AI\oobabooga\oobabooga_windows\text-generation-webui\modules\models.py", line 17, in <module>
    from modules.models_settings import infer_loader
  File "C:\AI\oobabooga\oobabooga_windows\text-generation-webui\modules\models_settings.py", line 6, in <module>
    from modules import shared, ui
  File "C:\AI\oobabooga\oobabooga_windows\text-generation-webui\modules\ui.py", line 69, in <module>
    class ToolButton(gr.Button, gr.components.FormComponent):
AttributeError: module 'gradio.components' has no attribute 'FormComponent'. Did you mean: 'IOComponent'?
```

Following [@byrro 's suggestion](https://github.com/oobabooga/text-generation-webui/issues/2780#issuecomment-1599572070) I replaced the `FormComponent` by a `IOComponent` in `modules/ui.py`.

I'm running `gradio==3.35.2`
