### PR TITLE
Whisper_stt params for model, language, and auto_submit

### DIFF
--- a/extensions/whisper_stt/readme.md
+++ b/extensions/whisper_stt/readme.md
@@ -1,0 +1,15 @@
+# whisper_stt
+
+Allows you to enter your inputs in chat mode using your microphone.
+
+## Settings
+
+To adjust your default settings, you can add the following to your settings.yaml file.
+
+```
+whisper_stt-whipser_language: chinese
+whisper_stt-whipser_model: tiny
+whisper_stt-auto_submit: False
+```
+
+See source documentation for [model names](https://github.com/openai/whisper#available-models-and-languages) and (languages)[https://github.com/openai/whisper/blob/main/whisper/tokenizer.py] you can use.

--- a/extensions/whisper_stt/script.py
+++ b/extensions/whisper_stt/script.py
@@ -8,8 +8,15 @@ input_hijack = {
     'value': ["", ""]
 }
 
+# parameters which can be customized in settings.json of webui
+params = {
+    'whipser_language': 'english',
+    'whipser_model': 'small.en',
+    'auto_submit': True
+}
 
-def do_stt(audio):
+
+def do_stt(audio,whipser_model,whipser_language):
     transcription = ""
     r = sr.Recognizer()
 
@@ -17,7 +24,7 @@ def do_stt(audio):
     audio_data = sr.AudioData(sample_rate=audio[0], frame_data=audio[1], sample_width=4)
 
     try:
-        transcription = r.recognize_whisper(audio_data, language="english", model="base.en")
+        transcription = r.recognize_whisper(audio_data, language=whipser_language, model=whipser_model)
     except sr.UnknownValueError:
         print("Whisper could not understand audio")
     except sr.RequestError as e:
@@ -26,11 +33,10 @@ def do_stt(audio):
     return transcription
 
 
-def auto_transcribe(audio, auto_submit):
+def auto_transcribe(audio, auto_submit,whipser_model,whipser_language):
     if audio is None:
         return "", ""
-
-    transcription = do_stt(audio)
+    transcription = do_stt(audio,whipser_model,whipser_language)
     if auto_submit:
         input_hijack.update({"state": True, "value": [transcription, transcription]})
 
@@ -38,10 +44,18 @@ def auto_transcribe(audio, auto_submit):
 
 
 def ui():
-    with gr.Row():
-        audio = gr.Audio(source="microphone")
-        auto_submit = gr.Checkbox(label='Submit the transcribed audio automatically', value=True)
+    with gr.Accordion("Whisper STT", open=True):
+        with gr.Row():
+            audio = gr.Audio(source="microphone")
+        with gr.Row():
+            with gr.Accordion("Settings", open=False):
+                auto_submit = gr.Checkbox(label='Submit the transcribed audio automatically', value=params['auto_submit'])
+                whipser_model = gr.Dropdown(label='Whisper Model', value=params['whipser_model'],choices=["tiny.en","base.en", "small.en","medium.en","tiny","base","small","medium","large"])
+                whipser_language = gr.Dropdown(label='Whisper Language', value=params['whipser_language'],choices=["chinese","german","spanish","russian","korean","french","japanese","portuguese","turkish","polish","catalan","dutch","arabic","swedish","italian","indonesian","hindi","finnish","vietnamese","hebrew","ukrainian","greek","malay","czech","romanian","danish","hungarian","tamil","norwegian","thai","urdu","croatian","bulgarian","lithuanian","latin","maori","malayalam","welsh","slovak","telugu","persian","latvian","bengali","serbian","azerbaijani","slovenian","kannada","estonian","macedonian","breton","basque","icelandic","armenian","nepali","mongolian","bosnian","kazakh","albanian","swahili","galician","marathi","punjabi","sinhala","khmer","shona","yoruba","somali","afrikaans","occitan","georgian","belarusian","tajik","sindhi","gujarati","amharic","yiddish","lao","uzbek","faroese","haitian creole","pashto","turkmen","nynorsk","maltese","sanskrit","luxembourgish","myanmar","tibetan","tagalog","malagasy","assamese","tatar","hawaiian","lingala","hausa","bashkir","javanese","sundanese"])
 
     audio.change(
-        auto_transcribe, [audio, auto_submit], [shared.gradio['textbox'], audio]).then(
+        auto_transcribe, [audio, auto_submit,whipser_model,whipser_language], [shared.gradio['textbox'], audio]).then(
         None, auto_submit, None, _js="(check) => {if (check) { document.getElementById('Generate').click() }}")
+    whipser_model.change(lambda x: params.update({"whipser_model": x}), whipser_model, None)
+    whipser_language.change(lambda x: params.update({"whipser_language": x}), whipser_language, None)
+    auto_submit.change(lambda x: params.update({"auto_submit": x}), auto_submit, None)


### PR DESCRIPTION
The Whisper_stt extension is great, but I want to use a different model instead of the `base.en` one to get more accuracy at the cost of speed. This adds the model, language, and auto_submit as params so I can set my defaults in settings.yaml, while still changing them in the UI if I want to. I did move the UI around a bit to hide the settings under an accordion and make the record button a little more front and center. 

I also included a small readme to link to the upstream documentation about the different model/language options available. 