### PR TITLE
Fix: Fixed the tokenization process of a raw dataset and improved its efficiency

### DIFF
--- a/modules/training.py
+++ b/modules/training.py
@@ -376,7 +376,7 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
             out_tokens.extend(split_chunks(tokens, cutoff_len, step))
 
         del raw_text  # Note: could be a gig for a large dataset, so delete redundant data as we go to be safe on RAM
-        text_chunks = [shared.tokenizer.decode(x, skip_special_tokens=True) for x in out_tokens]
+        text_chunks = [shared.tokenizer.decode(x) for x in out_tokens]
         del out_tokens
         if newline_favor_len > 0:
             text_chunks = [cut_chunk_for_newline(x, newline_favor_len) for x in text_chunks]


### PR DESCRIPTION
This fix was previously sent here https://github.com/oobabooga/text-generation-webui/pull/2878 but as suggested I'm splitting the different contributions of the the patch.

To summary the changes:
- Adding the parameter skip_special_tokens=True when decoding raw_text in the text preparation phase, without this flag the BOS token will be duplicated (see the discussion on the previous PR).
- I have modified the chunking process to make it substantially more efficient both in memory and time and to produce a more coherent output. (see the previous PR for a longer explanation).

I'm tagging @FartyPants as he proposed another change and suggested to split the contributions.