### PR TITLE
Fix: Fix to load LoRAs in models loaded in 4 or 8 bits

### DIFF
--- a/modules/LoRA.py
+++ b/modules/LoRA.py
@@ -114,11 +114,12 @@ def add_lora_transformers(lora_names):
     if len(lora_names) > 0:
         params = {}
         if not shared.args.cpu:
-            params['dtype'] = shared.model.dtype
-            if hasattr(shared.model, "hf_device_map"):
-                params['device_map'] = {"base_model.model." + k: v for k, v in shared.model.hf_device_map.items()}
-            elif shared.args.load_in_8bit:
-                params['device_map'] = {'': 0}
+            if shared.args.load_in_4bit or shared.args.load_in_8bit: 
+                params['peft_type'] = shared.model.dtype
+            else:
+                params['dtype'] = shared.model.dtype
+                if hasattr(shared.model, "hf_device_map"):
+                    params['device_map'] = {"base_model.model." + k: v for k, v in shared.model.hf_device_map.items()}
 
         logger.info("Applying the following LoRAs to {}: {}".format(shared.model_name, ', '.join(lora_names)))
         shared.model = PeftModel.from_pretrained(shared.model, Path(f"{shared.args.lora_dir}/{lora_names[0]}"), adapter_name=lora_names[0], **params)


### PR DESCRIPTION
This fix was previously sent here https://github.com/oobabooga/text-generation-webui/pull/2878 but as suggested I'm splitting the different contributions of the the patch.

To summary the changes:
- PeftConfig doesn't take a dtype and device_map parameters so the code fails when loading a LoRA using a model loaded in 8 or 4 bits. The fix checks if the model was loaded in 4 or 8 bits and if that's the case it uses the appropriate type name.
- https://huggingface.co/docs/peft/package_reference/config#peft.PeftConfig