### PR TITLE
Chat history download creates more detailed file names

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -3,8 +3,8 @@ import copy
 import functools
 import json
 import re
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 import gradio as gr
 import yaml
@@ -377,23 +377,6 @@ def save_history(history, path=None):
     return p
 
 
-def save_download_history(history, character, mode):
-    def make_timestamp_path(character=None):
-        return f"logs/{character or ''}{'_' if character else ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
-
-    path = None
-    if mode in ['chat', 'chat-instruct'] and character not in  ['', 'None', None]:
-        path = make_timestamp_path(character)
-    else:
-        # Try to use mode as the file name, otherwise just use the timestamp
-        try:
-            path = make_timestamp_path(mode.capitalize())
-        except:
-            path = make_timestamp_path()
-
-    return save_history(history, path)
-
-
 def load_history(file, history):
     try:
         file = file.decode('utf-8')
@@ -406,8 +389,25 @@ def load_history(file, history):
         return history
 
 
+def save_history_at_user_request(history, character, mode):
+    def make_timestamp_path(character=None):
+        return f"logs/{character or ''}{'_' if character else ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+
+    path = None
+    if mode in ['chat', 'chat-instruct'] and character not in ['', 'None', None]:
+        path = make_timestamp_path(character)
+    else:
+        # Try to use mode as the file name, otherwise just use the timestamp
+        try:
+            path = make_timestamp_path(mode.capitalize())
+        except:
+            path = make_timestamp_path()
+
+    return save_history(history, path)
+
+
 def save_persistent_history(history, character, mode):
-    if mode in ['chat', 'chat-instruct'] and character not in  ['', 'None', None] and not shared.args.multi_user:
+    if mode in ['chat', 'chat-instruct'] and character not in ['', 'None', None] and not shared.args.multi_user:
         save_history(history, path=Path(f'logs/{character}_persistent.json'))
 
 

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -4,6 +4,7 @@ import functools
 import json
 import re
 from pathlib import Path
+from datetime import datetime
 
 import gradio as gr
 import yaml
@@ -374,6 +375,23 @@ def save_history(history, path=None):
         f.write(json.dumps(history, indent=4))
 
     return p
+
+
+def save_download_history(history, character, mode):
+    def make_timestamp_path(character=None):
+        return f"logs/{character or ''}{'_' if character else ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+
+    path = None
+    if mode in ['chat', 'chat-instruct'] and character not in  ['', 'None', None]:
+        path = make_timestamp_path(character)
+    else:
+        # Try to use mode as the file name, otherwise just use the timestamp
+        try:
+            path = make_timestamp_path(mode.capitalize())
+        except:
+            path = make_timestamp_path()
+
+    return save_history(history, path)
 
 
 def load_history(file, history):

--- a/server.py
+++ b/server.py
@@ -976,7 +976,7 @@ def create_interface():
                 lambda: 'characters/instruction-following/', None, gradio('delete_root')).then(
                 lambda: gr.update(visible=True), None, gradio('file_deleter'))
 
-            shared.gradio['download_button'].click(chat.save_history, gradio('history'), gradio('download'))
+            shared.gradio['download_button'].click(chat.save_download_history, gradio('history', 'character_menu', 'mode'), gradio('download'))
             shared.gradio['Submit character'].click(chat.upload_character, gradio('upload_json', 'upload_img_bot'), gradio('character_menu'))
             shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, gradio('Submit character'))
             shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, gradio('Submit character'))

--- a/server.py
+++ b/server.py
@@ -976,7 +976,7 @@ def create_interface():
                 lambda: 'characters/instruction-following/', None, gradio('delete_root')).then(
                 lambda: gr.update(visible=True), None, gradio('file_deleter'))
 
-            shared.gradio['download_button'].click(chat.save_download_history, gradio('history', 'character_menu', 'mode'), gradio('download'))
+            shared.gradio['download_button'].click(chat.save_history_at_user_request, gradio('history', 'character_menu', 'mode'), gradio('download'))
             shared.gradio['Submit character'].click(chat.upload_character, gradio('upload_json', 'upload_img_bot'), gradio('character_menu'))
             shared.gradio['upload_json'].upload(lambda: gr.update(interactive=True), None, gradio('Submit character'))
             shared.gradio['upload_json'].clear(lambda: gr.update(interactive=False), None, gradio('Submit character'))


### PR DESCRIPTION
Chat history downloads used to contain the name of the character or mode and a timestamp. That made it easy for me to put all my exports into a folder and have it organized, especially when using Instruct mode. However, when I recently updated to the newest version, I noticed all history downloads were now named "exported_history.json"
I decided to make a fork using the formatting code from a previous commit in order to restore the more detailed file names. Most of my changes are put into one function that works similarly to `save_persistent_history`. 
I briefly tested the code in Chat and Instruct mode on Windows.