### PR TITLE
Add new possible bin file name regex

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -73,7 +73,7 @@ class ModelDownloader:
                 if not is_lora and fname.endswith(('adapter_config.json', 'adapter_model.bin')):
                     is_lora = True
 
-                is_pytorch = re.match("(pytorch|adapter)_model.*\.bin", fname)
+                is_pytorch = re.match("(pytorch|adapter|gptq)_model.*\.bin", fname)
                 is_safetensors = re.match(".*\.safetensors", fname)
                 is_pt = re.match(".*\.pt", fname)
                 is_ggml = re.match(".*ggml.*\.bin", fname)


### PR DESCRIPTION
for some models in hugging face like https://huggingface.co/cczhong/internlm-chat-7b-4bit-gptq/tree/main , it is possible that gptq bin file in the folder, e.g "[gptq_model-4bit-128g.bin](https://huggingface.co/cczhong/internlm-chat-7b-4bit-gptq/blob/main/gptq_model-4bit-128g.bin)"
Add this to support to download this kind of bin