### PR TITLE
Improvement about llama.cpp and a little about chat

### DIFF
--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -72,7 +72,9 @@ class LlamaCppModel:
     def generate(self, prompt, state, callback=None):
         prompt = prompt if type(prompt) is str else prompt.decode()
         prompt_tokens = self.model.tokenize(b" " + prompt.encode("utf-8"))
-        
+        max_prompt_tokens = state['truncation_length']
+        if len(prompt_tokens) > max_prompt_tokens:
+            prompt_tokens = prompt_tokens[-max_prompt_tokens::]
         max_tokens = state['max_new_tokens']
         completion_tokens = []
 
@@ -94,7 +96,7 @@ class LlamaCppModel:
                 partial(ban_eos_logits_processor, self.model.token_eos()),
             ]) if state['ban_eos_token'] else None,
         ):
-            if token == self.model._token_eos:
+            if token == self.model.token_eos():
                 break
 
             completion_tokens.append(token)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -38,7 +38,7 @@ settings = {
     'max_new_tokens_max': 2000,
     'seed': -1,
     'character': 'None',
-    'name1': 'You',
+    'name1': 'User',
     'name2': 'Assistant',
     'context': 'This is a conversation with your Assistant. It is a computer program designed to help you with various tasks such as answering questions, providing recommendations, and helping with decision making. You can ask it anything you want and it will do its best to give you accurate and relevant information.',
     'greeting': '',

--- a/server.py
+++ b/server.py
@@ -938,6 +938,7 @@ def create_interface():
 
             shared.gradio['character_menu'].change(
                 partial(chat.load_character, instruct=False), gradio('character_menu', 'name1', 'name2'), gradio('name1', 'name2', 'character_picture', 'greeting', 'context', 'dummy')).then(
+                lambda character_menu, mode: gr.Radio.update(value='chat' if not character_menu == 'None' and mode not in ['chat', 'chat-instruct'] else mode), inputs=[shared.gradio['character_menu'], shared.gradio['mode']], outputs=[shared.gradio['mode']]).then(
                 ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
                 chat.load_persistent_history, gradio('interface_state'), gradio('history')).then(
                 chat.redraw_html, shared.reload_inputs, gradio('display'))


### PR DESCRIPTION
### modules/llamacpp_model.py #3106 
llama_cpp lib has some known issues which will cause some tokens fail to decode without any error (hard to spot but impact the outcome).
After tweaking the generate function you can avoid those issues.

Update: 
I don't know whether it is intended or something. But it seems that llamacpp_model.py:generate() didn't use the value 'truncation_length'. 
It seems that it is causing model to stop generating when the context limit is reached.
So I added the 'truncation_length' support. It seems working just fine!

### server.py
This is about chat mode.
The radio 'mode' is set to 'instruct' by default.
This will cause some issues when you change the character.
Before the fix, it won't load the persistent history normally, and won't show the greeting.
There is seemingly no way to load history besides set mode to chat/chat-instruct and load None then load the character or download and upload the history(currently it seems that you can't download the persistent history).
This patch will automatically change the radio to 'chat' if it is not 'chat' or 'chat-instruct' when you select a character.
So that the history and greeting will load normally.

### modules/shared.py
Set user name to 'You' is not good.
It makes characters confuse.
They are going to assume that the pronoun 'You' is the user 'You'.
e.x.
```
<user>: You are an AI!
<bot>: Wow! How do you feel when you know that?
```
It is obvious that 'You' is a confusing name.
I changed it to 'User' for disambiguation.

My personal comment:
Chat mode is my favorite feature and I'd love to improve it.