### PR TITLE
Make it possible to evaluate exllama perplexity

### DIFF
--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -56,15 +56,15 @@ class ExllamaHF(PreTrainedModel):
 
         if labels is None:
             if cache is None:
-                cache = self.ex_cache
                 self.ex_cache.current_seq_len = 0
+                cache = self.ex_cache
                 self.ex_model.forward(torch.tensor([seq[:-1]], dtype=torch.long), cache, preprocess_only=True, lora=self.lora)
 
             logits = self.ex_model.forward(torch.tensor([seq[-1:]], dtype=torch.long), cache, lora=self.lora).to(kwargs['input_ids'].device)
         else:
             if cache is None:
-                cache = self.ex_cache
                 self.ex_cache.current_seq_len = 0
+                cache = self.ex_cache
 
             logits = self.ex_model.forward(torch.tensor([seq], dtype=torch.long), cache, last_id_only=False, lora=self.lora)
 

--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -29,6 +29,7 @@ class ExllamaHF(PreTrainedModel):
         super().__init__(PretrainedConfig())
         self.ex_config = config
         self.ex_model = ExLlama(self.ex_config)
+        self.ex_cache = ExLlamaCache(self.ex_model)
         self.generation_config = GenerationConfig()
         self.lora = None
 
@@ -52,11 +53,20 @@ class ExllamaHF(PreTrainedModel):
         labels = kwargs.get('labels', None)
         seq = kwargs['input_ids'][0].tolist()
         cache = kwargs['past_key_values'] if 'past_key_values' in kwargs else None
-        if cache is None:
-            cache = ExLlamaCache(self.ex_model)
-            self.ex_model.forward(torch.tensor([seq[:-1]], dtype=torch.long), cache, preprocess_only=True, lora=self.lora)
 
-        logits = self.ex_model.forward(torch.tensor([seq[-1:]], dtype=torch.long), cache, lora=self.lora).to(kwargs['input_ids'].device)
+        if labels is None:
+            if cache is None:
+                cache = self.ex_cache
+                self.ex_cache.current_seq_len = 0
+                self.ex_model.forward(torch.tensor([seq[:-1]], dtype=torch.long), cache, preprocess_only=True, lora=self.lora)
+
+            logits = self.ex_model.forward(torch.tensor([seq[-1:]], dtype=torch.long), cache, lora=self.lora).to(kwargs['input_ids'].device)
+        else:
+            if cache is None:
+                cache = self.ex_cache
+                self.ex_cache.current_seq_len = 0
+
+            logits = self.ex_model.forward(torch.tensor([seq], dtype=torch.long), cache, last_id_only=False, lora=self.lora)
 
         loss = None
         if labels is not None:
@@ -71,7 +81,7 @@ class ExllamaHF(PreTrainedModel):
             shift_labels = shift_labels.to(shift_logits.device)
             loss = loss_fct(shift_logits, shift_labels)
 
-        return CausalLMOutputWithPast(logits=logits, past_key_values=cache if use_cache else None)
+        return CausalLMOutputWithPast(logits=logits, past_key_values=cache if use_cache else None, loss=loss)
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], *model_args, **kwargs):


### PR DESCRIPTION
Similar to what I'm trying to do with https://github.com/oobabooga/text-generation-webui/pull/3062, but this time for exllama. It's already functional and the perplexity can be evaluated.

This allows ExLlama/AutoGPTQ/Transformers to be directly compared.

The only question is whether I am handling the cache properly or not.

I'll tag @turboderp for awareness 