### PR TITLE
Add probability dropdown to perplexity_colors extension

### DIFF
--- a/extensions/perplexity_colors/script.py
+++ b/extensions/perplexity_colors/script.py
@@ -4,6 +4,7 @@ from transformers import LogitsProcessor
 import numpy as np
 import time
 import re
+import markdown
 
 from modules import shared
 from modules import html_generator
@@ -112,7 +113,7 @@ def output_modifier(text):
 
     i = 0
     for token, prob, ppl, top_tokens, top_probs in zip(gen_tokens, sel_probs, perplexities, top_tokens_list, top_probs_list):
-        if '`' in token:
+        if '`' in token and not params['probability_dropdown']:
             in_code = not in_code
             continue
         if in_code:
@@ -298,7 +299,7 @@ def convert_to_markdown(string):
     #t1 = time.time()
     #print(len(string))
     #print(f"Pre markdown: {(t1-t0):.3f} s")
-    if params['probability_dropdown']:
+    if params['probability_dropdown'] and '<div class="hoverable">' in string:
         # Prevents all latency introduced by trying to convert the HTML to markdown when it's not even necessary
         #print('Monkeypatched')
         return string

--- a/extensions/perplexity_colors/script.py
+++ b/extensions/perplexity_colors/script.py
@@ -1,23 +1,24 @@
+import re
+import time
+
 import gradio
+import markdown
+import numpy as np
 import torch
 from transformers import LogitsProcessor
-import numpy as np
-import time
-import re
-import markdown
 
-from modules import shared
-from modules import html_generator
+from modules import html_generator, shared
 from modules.html_generator import replace_blockquote
 
 params = {
     'active': True,
     'color_by_perplexity': False,
     'color_by_probability': False,
-    'ppl_scale': 15.0, # No slider for this right now, because I don't think it really needs to be changed. Very large perplexity scores don't show up often.
+    'ppl_scale': 15.0,  # No slider for this right now, because I don't think it really needs to be changed. Very large perplexity scores don't show up often.
     'probability_dropdown': False,
-    'verbose': False # For debugging mostly
+    'verbose': False  # For debugging mostly
 }
+
 
 class PerplexityLogits(LogitsProcessor):
     def __init__(self, verbose=False):
@@ -30,10 +31,10 @@ class PerplexityLogits(LogitsProcessor):
         self.verbose = verbose
 
     def __call__(self, input_ids, scores):
-        #t0 = time.time()
+        # t0 = time.time()
         probs = torch.softmax(scores, dim=-1, dtype=torch.float)
-        log_probs = torch.nan_to_num(torch.log(probs)) # Note: This is to convert log(0) nan to 0, but probs*log_probs makes this 0 not affect the perplexity.
-        entropy = -torch.sum(probs*log_probs)
+        log_probs = torch.nan_to_num(torch.log(probs))  # Note: This is to convert log(0) nan to 0, but probs*log_probs makes this 0 not affect the perplexity.
+        entropy = -torch.sum(probs * log_probs)
         entropy = entropy.cpu().numpy()
         perplexity = round(float(np.exp(entropy)), 4)
         self.perplexities_list.append(perplexity)
@@ -56,12 +57,12 @@ class PerplexityLogits(LogitsProcessor):
                 self.top_probs_list[-1][0].append(last_prob)
                 self.selected_probs.append(last_prob)
         else:
-            self.selected_probs.append(1.0) # Placeholder for the last token of the prompt
+            self.selected_probs.append(1.0)  # Placeholder for the last token of the prompt
 
         if self.verbose:
             pplbar = "-"
             if not np.isnan(perplexity):
-                pplbar = "*"*round(perplexity)
+                pplbar = "*" * round(perplexity)
             print(f"PPL: Token after {shared.tokenizer.decode(last_token_id)}\t{perplexity:.2f}\t{pplbar}")
 
         # Get top 5 probabilities
@@ -71,18 +72,20 @@ class PerplexityLogits(LogitsProcessor):
 
         self.top_token_ids_list.append(top_token_ids)
         self.top_probs_list.append(top_probs)
-        
+
         probs = probs.cpu().numpy().flatten()
-        self.last_probs = probs # Need to keep this as a reference for top probs
-        
-        #t1 = time.time()
-        #print(f"PPL Processor: {(t1-t0):.3f} s")
+        self.last_probs = probs  # Need to keep this as a reference for top probs
+
+        # t1 = time.time()
+        # print(f"PPL Processor: {(t1-t0):.3f} s")
         # About 1 ms, though occasionally up to around 100 ms, not sure why...
         # Doesn't actually modify the logits!
         return scores
 
+
 # Stores the perplexity and top probabilities
 ppl_logits_processor = None
+
 
 def logits_processor_modifier(logits_processor_list, input_ids):
     global ppl_logits_processor
@@ -90,9 +93,10 @@ def logits_processor_modifier(logits_processor_list, input_ids):
         ppl_logits_processor = PerplexityLogits(verbose=params['verbose'])
         logits_processor_list.append(ppl_logits_processor)
 
+
 def output_modifier(text):
     global ppl_logits_processor
-    #t0 = time.time()
+    # t0 = time.time()
 
     if not params['active']:
         return text
@@ -108,8 +112,8 @@ def output_modifier(text):
     gen_tokens = [shared.tokenizer.decode(token_id) for token_id in gen_token_ids]
     sel_probs = ppl_logits_processor.selected_probs[1:]
 
-    end_part = '</div></div>' if params['probability_dropdown'] else '</span>' # Helps with finding the index after replacing part of the text.
-    in_code = False # Since the <span> tags mess up code blocks, avoid coloring while inside a code block, based on finding tokens with '`' in them
+    end_part = '</div></div>' if params['probability_dropdown'] else '</span>'  # Helps with finding the index after replacing part of the text.
+    in_code = False  # Since the <span> tags mess up code blocks, avoid coloring while inside a code block, based on finding tokens with '`' in them
 
     i = 0
     for token, prob, ppl, top_tokens, top_probs in zip(gen_tokens, sel_probs, perplexities, top_tokens_list, top_probs_list):
@@ -128,7 +132,7 @@ def output_modifier(text):
         if token in text[i:]:
             if params['probability_dropdown']:
                 after_token_index = text[i:].find(token) + len(token)
-                whitespace = text[i:][after_token_index:(after_token_index+1)]
+                whitespace = text[i:][after_token_index:(after_token_index + 1)]
                 if whitespace != ' ':
                     whitespace = ''
                 text = text[:i] + text[i:].replace(token, add_dropdown_html(token, color, top_tokens, top_probs[0], whitespace, ppl), 1)
@@ -140,56 +144,73 @@ def output_modifier(text):
     print('Average perplexity:', round(np.mean(ppl_logits_processor.perplexities_list[:-1]), 4))
     # Optional hacky workaround: Without this, spaces get added between every token. With this, there is a little extra whitespace at the top.
     # This fixes the tokenization spaces, somehow. However, this also removes any paragraph breaks in the message.
-    #return '<p>' + text + '</p>'
-    #t1 = time.time()
-    #print(f"Modifier: {(t1-t0):.3f} s")
+    # return '<p>' + text + '</p>'
+    # t1 = time.time()
+    # print(f"Modifier: {(t1-t0):.3f} s")
     # About 50 ms
     return text
 
-# Green-yellow-red color scale
+
 def probability_color_scale(prob):
+    '''
+    Green-yellow-red color scale
+    '''
+
     rv = 0
     gv = 0
     if prob <= 0.5:
         rv = 'ff'
-        gv = hex(int(255*prob*2))[2:]
+        gv = hex(int(255 * prob * 2))[2:]
         if len(gv) < 2:
-            gv = '0'*(2 - len(gv)) + gv
+            gv = '0' * (2 - len(gv)) + gv
     else:
-        rv = hex(int(255 - 255*(prob - 0.5)*2))[2:]
+        rv = hex(int(255 - 255 * (prob - 0.5) * 2))[2:]
         gv = 'ff'
         if len(rv) < 2:
-            rv = '0'*(2 - len(rv)) + rv
+            rv = '0' * (2 - len(rv)) + rv
+
     return rv + gv + '00'
 
-# Red component only, white for 0 perplexity (sorry if you're not in dark mode)
+
 def perplexity_color_scale(ppl):
-    value = hex(max(int(255.0 - params['ppl_scale']*(float(ppl)-1.0)), 0))[2:]
+    '''
+    Red component only, white for 0 perplexity (sorry if you're not in dark mode)
+    '''
+    value = hex(max(int(255.0 - params['ppl_scale'] * (float(ppl) - 1.0)), 0))[2:]
     if len(value) < 2:
-        value = '0'*(2 - len(value)) + value
+        value = '0' * (2 - len(value)) + value
+
     return 'ff' + value + value
 
-# Green-yellow-red for probability and blue component for perplexity
+
 def probability_perplexity_color_scale(prob, ppl):
+    '''
+    Green-yellow-red for probability and blue component for perplexity
+    '''
+
     rv = 0
     gv = 0
-    bv = hex(min(max(int(params['ppl_scale']*(float(ppl)-1.0)), 0), 255))[2:]
+    bv = hex(min(max(int(params['ppl_scale'] * (float(ppl) - 1.0)), 0), 255))[2:]
     if len(bv) < 2:
-            bv = '0'*(2 - len(bv)) + bv
+        bv = '0' * (2 - len(bv)) + bv
+
     if prob <= 0.5:
         rv = 'ff'
-        gv = hex(int(255*prob*2))[2:]
+        gv = hex(int(255 * prob * 2))[2:]
         if len(gv) < 2:
-            gv = '0'*(2 - len(gv)) + gv
+            gv = '0' * (2 - len(gv)) + gv
     else:
-        rv = hex(int(255 - 255*(prob - 0.5)*2))[2:]
+        rv = hex(int(255 - 255 * (prob - 0.5) * 2))[2:]
         gv = 'ff'
         if len(rv) < 2:
-            rv = '0'*(2 - len(rv)) + rv
+            rv = '0' * (2 - len(rv)) + rv
+
     return rv + gv + bv
+
 
 def add_color_html(token, color):
     return f'<span style="color: #{color}">{token}</span>'
+
 
 # TODO: Major issue: Applying this to too many tokens will cause a permanent slowdown in generation speed until the messages are removed from the history.
 # I think the issue is from HTML elements taking up space in the visible history, and things like history deepcopy add latency proportional to the size of the history.
@@ -211,16 +232,17 @@ def add_dropdown_html(token, color, top_tokens, top_probs, whitespace='', perple
     if perplexity != 0:
         ppl_color = perplexity_color_scale(perplexity)
         html += f'<tr><td>Perplexity:</td><td style="color: #{ppl_color}">{perplexity:.4f}</td></tr>'
-    html += '</tbody></table></div></div>\n' # The newline would normally be added by markdown.markdown() but this is faster.
-    return html # About 750 characters per token...
+    html += '</tbody></table></div></div>\n'  # The newline would normally be added by markdown.markdown() but this is faster.
+    return html  # About 750 characters per token...
+
 
 def custom_css():
     return """
         .dropdown {
             display: none;
             position: absolute;
-            z-index: 50; 
-            background-color: var(--block-background-fill); 
+            z-index: 50;
+            background-color: var(--block-background-fill);
             box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
             width: max-content;
             overflow: visible;
@@ -237,7 +259,7 @@ def custom_css():
         .dropdown-content tr.selected {
             background-color: var(--block-label-background-fill);
         }
-        
+
         .dropdown-content td {
             color: var(--body-text-color);
         }
@@ -270,7 +292,7 @@ def custom_css():
 # This fixes an issue where the markdown conversion was causing a large slowdown in generation speeds if too many tokens had probability dropdowns added.
 # I'd rather have a more long-term solution, since this really shouldn't be called on all messages for each token, but this works for now.
 def convert_to_markdown(string):
-    #t0 = time.time()
+    # t0 = time.time()
     # Blockquote
     pattern = re.compile(r'\\begin{blockquote}(.*?)\\end{blockquote}', re.DOTALL)
     string = pattern.sub(replace_blockquote, string)
@@ -296,42 +318,45 @@ def convert_to_markdown(string):
         result = result + '```'  # Unfinished code block
 
     string = result.strip()
-    #t1 = time.time()
-    #print(len(string))
-    #print(f"Pre markdown: {(t1-t0):.3f} s")
+    # t1 = time.time()
+    # print(len(string))
+    # print(f"Pre markdown: {(t1-t0):.3f} s")
     if params['probability_dropdown'] and '<div class="hoverable">' in string:
         # Prevents all latency introduced by trying to convert the HTML to markdown when it's not even necessary
-        #print('Monkeypatched')
+        # print('Monkeypatched')
         return string
     else:
-        #t0 = time.time()
+        # t0 = time.time()
         return markdown.markdown(string, extensions=['fenced_code', 'tables'])
-        #t1 = time.time()
-        #print(f"Markdown: {(t1-t0):.3f} s for string of length {len(string)}")
-        #print(string)
-        #print(res)
-        #return res
+        # t1 = time.time()
+        # print(f"Markdown: {(t1-t0):.3f} s for string of length {len(string)}")
+        # print(string)
+        # print(res)
+        # return res
+
 
 html_generator.convert_to_markdown = convert_to_markdown
 
 
 def ui():
-    active_check = gradio.Checkbox(value=True, label="Compute probabilities and perplexity scores", info="Activate this extension. Note that this extension currently does not work with exllama or llama.cpp.")
     def update_active_check(x):
         params.update({'active': x})
-    active_check.change(update_active_check, active_check, None)
 
-    color_by_ppl_check = gradio.Checkbox(value=False, label="Color by perplexity", info="Higher perplexity is more red. If also showing probability, higher perplexity has more blue component.")
     def update_color_by_ppl_check(x):
         params.update({'color_by_perplexity': x})
-    color_by_ppl_check.change(update_color_by_ppl_check, color_by_ppl_check, None)
 
-    color_by_prob_check = gradio.Checkbox(value=False, label="Color by probability", info="Green-yellow-red linear scale, with 100% green, 50% yellow, 0% red.")
     def update_color_by_prob_check(x):
         params.update({'color_by_probability': x})
-    color_by_prob_check.change(update_color_by_prob_check, color_by_prob_check, None)
 
-    prob_dropdown_check = gradio.Checkbox(value=False, label="Probability dropdown", info="Hover over a token to show a dropdown of top token probabilities. Currently slightly buggy with whitespace between tokens.")
     def update_prob_dropdown_check(x):
         params.update({'probability_dropdown': x})
+
+    active_check = gradio.Checkbox(value=True, label="Compute probabilities and perplexity scores", info="Activate this extension. Note that this extension currently does not work with exllama or llama.cpp.")
+    color_by_ppl_check = gradio.Checkbox(value=False, label="Color by perplexity", info="Higher perplexity is more red. If also showing probability, higher perplexity has more blue component.")
+    color_by_prob_check = gradio.Checkbox(value=False, label="Color by probability", info="Green-yellow-red linear scale, with 100% green, 50% yellow, 0% red.")
+    prob_dropdown_check = gradio.Checkbox(value=False, label="Probability dropdown", info="Hover over a token to show a dropdown of top token probabilities. Currently slightly buggy with whitespace between tokens.")
+
+    active_check.change(update_active_check, active_check, None)
+    color_by_ppl_check.change(update_color_by_ppl_check, color_by_ppl_check, None)
+    color_by_prob_check.change(update_color_by_prob_check, color_by_prob_check, None)
     prob_dropdown_check.change(update_prob_dropdown_check, prob_dropdown_check, None)


### PR DESCRIPTION
@oobabooga I've expanded the functionality of the perplexity_colors extension to be able to show a probability dropdown when hovering over a token of the output. This can be activated independently of the options to color by probability/perplexity. It shows the top 5 tokens and probabilities, and a 6th row with the selected token if it wasn't in the top 5. It also includes a row at the end with the perplexity of this next token distribution.
Using dev as the PR target because it currently has the logits processors update that is required as a dependency for this extension.

Issues: Doesn't look good outside of dark mode, and using the probability dropdown messes up some whitespace like removing paragraph breaks

Example of the kind of hover-activated dropdown menu that this creates for each token:
![probability_dropdown](https://github.com/oobabooga/text-generation-webui/assets/64337075/c94efb83-65c6-4fe6-8bf4-48225369e870)