### PR TITLE
[Bug fix] Remove html tags form the Prompt sent to Stable Diffusion

### DIFF
--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -133,6 +133,11 @@ def get_SD_pictures(description, character):
     if params['manage_VRAM']:
         give_VRAM_priority('SD')
 
+    import re
+
+    description = re.sub('<audio.*?</audio>', ' ', description)
+    description = f"({description}:1)"
+
     payload = {
         "prompt": params['prompt_prefix'] + description,
         "seed": params['seed'],

--- a/extensions/sd_api_pictures/script.py
+++ b/extensions/sd_api_pictures/script.py
@@ -133,8 +133,6 @@ def get_SD_pictures(description, character):
     if params['manage_VRAM']:
         give_VRAM_priority('SD')
 
-    import re
-
     description = re.sub('<audio.*?</audio>', ' ', description)
     description = f"({description}:1)"
 


### PR DESCRIPTION
When user use **sd_api_pictures** and **silero_tts** at the same time, the Prompt sent to SD will contains the following HTML elements:

`<audio src=file/extensions/silero_tts/outputs/XXX_161233316.wav controls autoplay></audio>  `

It will strongly scramble the result of the image generation.

Here is a simple code to reduce the pollution of prompt when using TTS, and add brackets to make it more tidy.

```
    import re

    description = re.sub('<audio.*?</audio>', ' ', description)
    description = f"({description}:1)"
```

![2](https://github.com/oobabooga/text-generation-webui/assets/139355831/dc1a4edc-c23d-491c-ba03-1a5f5d809c4f)

![1](https://github.com/oobabooga/text-generation-webui/assets/139355831/c22c9518-9ed8-48f2-bd27-76ba2d1cbc53)


