### PR TITLE
Added the logic for starchat model series

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -231,6 +231,7 @@ TheBloke_WizardLM-30B-GPTQ:
 .*starchat-beta:
   mode: 'instruct'
   instruction_template: 'Starchat-Beta'
+  custom_stopping_strings: '"<|end|>"'
 .*minotaur:
   mode: 'instruct'
   instruction_template: 'Minotaur'

--- a/modules/models.py
+++ b/modules/models.py
@@ -2,7 +2,6 @@ import gc
 import os
 import re
 import time
-import json
 from pathlib import Path
 import hashlib
 
@@ -129,17 +128,6 @@ def load_tokenizer(model_name, model):
                 file_hash = hashlib.sha256(bytes).hexdigest()
                 if file_hash != pair[1]:
                     logger.warning(f"{p} is different from the original LlamaTokenizer file. It is either customized or outdated.")
-    elif tokenizer.__class__.__name__ == "GPT2Tokenizer" and model_name.startswith("HuggingFaceH4_starchat"):
-        tokenizer.pad_token_id = tokenizer.eos_token_id
-        p = Path(f"{path_to_model}/dialogue_template.json")
-        k = 'end_token'
-        try:
-            with open(p, "r") as f:
-                dialogue_template = json.load(f)
-                tokenizer.eos_token = dialogue_template[k]
-        except (FileNotFoundError, KeyError) as e:
-            logger.warning(f"Field k in {p} not found. Check the file and properties. Using '<|end|>' as eos token.")
-            tokenizer.eos_token = '<|end|>'
 
     return tokenizer
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -2,6 +2,7 @@ import gc
 import os
 import re
 import time
+import json
 from pathlib import Path
 import hashlib
 
@@ -128,6 +129,17 @@ def load_tokenizer(model_name, model):
                 file_hash = hashlib.sha256(bytes).hexdigest()
                 if file_hash != pair[1]:
                     logger.warning(f"{p} is different from the original LlamaTokenizer file. It is either customized or outdated.")
+    elif tokenizer.__class__.__name__ == "GPT2Tokenizer" and model_name.startswith("HuggingFaceH4_starchat"):
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        p = Path(f"{path_to_model}/dialogue_template.json")
+        k = 'end_token'
+        try:
+            with open(p, "r") as f:
+                dialogue_template = json.load(f)
+                tokenizer.eos_token = dialogue_template[k]
+        except (FileNotFoundError, KeyError) as e:
+            logger.warning(f"Field k in {p} not found. Check the file and properties. Using '<|end|>' as eos token.")
+            tokenizer.eos_token = '<|end|>'
 
     return tokenizer
 


### PR DESCRIPTION
#3184 

The eos_token value of "special_tokens_map.json" in the storage of starchat(alpha, beta and later) is not actually specified to eos_token during instruction tuning.
(It should be <|end|> but specified to <|endoftext|>)

Changing the eos_token value in starchat-beta's "special_tokens_map.json" could be an alternative, but owner of the repo doesn't want to change that because it could cause problems in other existing downstream applications.
https://huggingface.co/HuggingFaceH4/starchat-beta/discussions/3

Therefore, as part of a downstream task, I'd like to add the logic for starchat model series to modules/models.py in this repository.