### PR TITLE
Remove auto-loading when only one model is available

### DIFF
--- a/server.py
+++ b/server.py
@@ -1125,10 +1125,6 @@ if __name__ == "__main__":
     if shared.args.model is not None:
         shared.model_name = shared.args.model
 
-    # Only one model is available
-    elif len(available_models) == 1:
-        shared.model_name = available_models[0]
-
     # Select the model from a command-line menu
     elif shared.args.model_menu:
         if len(available_models) == 0:


### PR DESCRIPTION
This is causing issues when the only model available is one that is incompatible with the current setup, preventing loading the webui without workarounds. Most commonly, this issue is experienced with the popular Pygmalion model, which is largely incompatible with the version of AutoGPTQ and GPTQ-for-LLaMa that we are using.

This also makes downloading a new model more challenging for people not used to using the command-line due to preventing access to the model downloader through the UI itself.