### PR TITLE
Proposal, augment context with date, day, etc...

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -5,6 +5,7 @@ import json
 import re
 from datetime import datetime
 from pathlib import Path
+from datetime import date
 
 import gradio as gr
 import yaml
@@ -90,7 +91,21 @@ def generate_chat_prompt(user_input, state, **kwargs):
     # Build the prompt
     min_rows = 3
     i = len(history) - 1
-    rows = [state['context_instruct'] if is_instruct else f"{state['context'].strip()}\n"]
+
+    # augment context
+    current_date = date.today()
+    context_str = state['context_instruct'] if is_instruct else f"{state['context'].strip()}\n"
+
+    date_replacements = {
+        '<|date|>': current_date.strftime("%d %B %Y"),
+        '<|day|>':current_date.strftime("%A")
+    }
+
+    for j, k in date_replacements.items():
+        context_str = context_str.replace(j, k)
+    
+    rows = [context_str]
+
     while i >= 0 and get_encoded_length(wrapper.replace('<|prompt|>', ''.join(rows))) < max_length:
         if _continue and i == len(history) - 1:
             if state['mode'] != 'chat-instruct':


### PR DESCRIPTION
This is a proposal to augment the context string of chat/instruct with date and perhaps other relevant info.
This is not heavy handed, it's entirely on user to use it or not, by augmenting the context string. Honk, honk! Repetition!

![image](https://github.com/oobabooga/text-generation-webui/assets/23346289/bbba6a04-843d-4941-b801-ee4514af8cc5)

Note: having a date in system prompt even without some special need for it may be beneficial to prime LLM to be more relevant in answers. 

Again, this is a proposal. A "no, go to hell FartPants with your uneducated ideas," is perfectly acceptable outcome. It's commonly used by the members of my family, so it feels warm and cozy.

