### PR TITLE
Add checks for ROCm and unsupported architectures to llama_cpp_cuda loading

### DIFF
--- a/modules/llamacpp_hf.py
+++ b/modules/llamacpp_hf.py
@@ -10,8 +10,11 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 from modules import shared
 from modules.logging_colors import logger
 
-if torch.cuda.is_available():
-    from llama_cpp_cuda import Llama
+if torch.cuda.is_available() and not torch.version.hip:
+    try:
+        from llama_cpp_cuda import Llama
+    except:
+        from llama_cpp import Llama
 else:
     from llama_cpp import Llama
 

--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -15,8 +15,11 @@ from modules import shared
 from modules.callbacks import Iteratorize
 from modules.logging_colors import logger
 
-if torch.cuda.is_available():
-    from llama_cpp_cuda import Llama, LlamaCache, LogitsProcessorList
+if torch.cuda.is_available() and not torch.version.hip:
+    try:
+        from llama_cpp_cuda import Llama, LlamaCache, LogitsProcessorList
+    except:
+        from llama_cpp import Llama, LlamaCache, LogitsProcessorList
 else:
     from llama_cpp import Llama, LlamaCache, LogitsProcessorList
 


### PR DESCRIPTION
This will hopefully prevent issues with AMD GPUs and CPUs that don't have a compatible wheel available.

Most of Pytorch's cuda code is made to be re-used by their ROCm build. This results in pretty much all checks like `torch.cuda.is_available()` returning true for ROCm AMD GPUs. Simple enough to work around with checking `torch.version.hip`