### PR TITLE
add rwkv world tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Its goal is to become the [AUTOMATIC1111/stable-diffusion-webui](https://github.
 ## Features
 
 * 3 interface modes: default, notebook, and chat
-* Multiple model backends: tranformers, llama.cpp, AutoGPTQ, GPTQ-for-LLaMa, ExLlama, RWKV, FlexGen
+* Multiple model backends: tranformers, llama.cpp, AutoGPTQ, GPTQ-for-LLaMa, ExLlama, RWKV, RWKV-World, FlexGen
 * Dropdown menu for quickly switching between different models
 * LoRA: load and unload LoRAs on the fly, load multiple LoRAs at the same time, train a new LoRA
 * Precise instruction templates for chat mode, including Alpaca, Vicuna, Open Assistant, Dolly, Koala, ChatGLM, MOSS, RWKV-Raven, Galactica, StableLM, WizardLM, Baize, Ziya, Chinese-Vicuna, MPT, INCITE, Wizard Mega, KoAlpaca, Vigogne, Bactrian, h2o, and OpenBuddy
@@ -303,6 +303,7 @@ Optionally, you can use the following command-line flags:
 |---------------------------------|-------------|
 | `--rwkv-strategy RWKV_STRATEGY` | RWKV: The strategy to use while loading the model. Examples: "cpu fp32", "cuda fp16", "cuda fp16i8". |
 | `--rwkv-cuda-on`                | RWKV: Compile the CUDA kernel for better performance. |
+| `--rwkv-world`                  | RWKV: Use the World tokenizer. Required for the newer RWKV-World family of models. |
 
 #### Gradio
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -248,10 +248,10 @@ def flexgen_loader(model_name):
 
 
 def RWKV_loader(model_name):
-    from modules.RWKV import RWKVModel, RWKVTokenizer
+    from modules.RWKV import RWKVModel, RWKVTokenizer, RWKVWorldTokenizer
 
-    model = RWKVModel.from_pretrained(Path(f'{shared.args.model_dir}/{model_name}'), dtype="fp32" if shared.args.cpu else "bf16" if shared.args.bf16 else "fp16", device="cpu" if shared.args.cpu else "cuda")
-    tokenizer = RWKVTokenizer.from_pretrained(Path(shared.args.model_dir))
+    tokenizer = RWKVTokenizer.from_pretrained(Path(shared.args.model_dir)) if not shared.args.rwkv_world else RWKVWorldTokenizer(Path(shared.args.model_dir) / 'rwkv_vocab_v20230424.txt')
+    model = RWKVModel.from_pretrained(Path(f'{shared.args.model_dir}/{model_name}'), dtype="fp32" if shared.args.cpu else "bf16" if shared.args.bf16 else "fp16", device="cpu" if shared.args.cpu else "cuda", world=shared.args.rwkv_world is True)
     return model, tokenizer
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -168,6 +168,7 @@ parser.add_argument('--local_rank', type=int, default=0, help='DeepSpeed: Option
 # RWKV
 parser.add_argument('--rwkv-strategy', type=str, default=None, help='RWKV: The strategy to use while loading the model. Examples: "cpu fp32", "cuda fp16", "cuda fp16i8".')
 parser.add_argument('--rwkv-cuda-on', action='store_true', help='RWKV: Compile the CUDA kernel for better performance.')
+parser.add_argument('--rwkv-world', action='store_true', help='RWKV: Use the World tokenizer. Required for the newer RWKV-World family of models.')
 
 # Gradio
 parser.add_argument('--listen', action='store_true', help='Make the web UI reachable from your local network.')


### PR DESCRIPTION
I had written multiple screens of text here but gpg-agent was unresponsive so .git deleted all my hard work when I tried to re-commit.

Gist is:

- Support world models with --rwkv-world flag.
- Load tokenizer before model to avoid wasting work if tokenizer fails to load. Rwkv python package is slow.

Tokenizer implementation used is my own, <https://github.com/BlinkDL/ChatRWKV/pull/137>. It outperforms everything else, but hasn't been accepted upstream, so I just pasted it. It'll be fine.

Notes:

- Rwkv package not installed by windows auto installer, had to manually enter conda env and use pip.
- Can't load pth files by web interface due to #2314, falsely closed by retarded stale bot, which is useless and counterproductive. But I digress. When it's possible to load from the web interface again, there should be a way to specify whether to use the world tokenizer there, so you can switch between raven and world models freely.
- Could autodetect the type of model perfectly by checking size of emb tensor, which represents vocab size, raven is 50277 and world is 65536, but can't do that without loading the whole thing into memory because pytorch is the world's worst library and can't read a single tensor from a pth file. Very bad idea as `rwkv` already loads the entire file due to pytorch's brain death, loading it a second time would be insane.

Sorry, I wrote 3-4x more than this last time, but I am not doing that again, because git overwrote it permanently, because it is a stupid piece of garbage. Hope this is an apt description.

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch rwkv-world
# Changes to be committed:
#       modified:   README.md
#       modified:   modules/RWKV.py
#       modified:   modules/models.py
#       modified:   modules/shared.py
#