### PR TITLE
Add an option to ban the \n character in chat mode

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -45,6 +45,7 @@ settings = {
     'turn_template': '',
     'custom_stopping_strings': '',
     'stop_at_newline': False,
+    'ban_newline': False,
     'add_bos_token': True,
     'ban_eos_token': False,
     'skip_special_tokens': True,

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -234,8 +234,12 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
         if state[k] > 0:
             generate_params[k] = state[k] * 1e-4
 
+    generate_params['suppress_tokens'] = []
     if state['ban_eos_token']:
-        generate_params['suppress_tokens'] = [shared.tokenizer.eos_token_id]
+        generate_params['suppress_tokens'].append(shared.tokenizer.eos_token_id)
+
+    if state['ban_newline']:
+        generate_params['suppress_tokens'].append(shared.tokenizer.encode('\n')[-1])
 
     if shared.args.no_cache:
         generate_params.update({'use_cache': False})

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -120,6 +120,7 @@ def list_interface_input_elements():
             'context',
             'chat_generation_attempts',
             'stop_at_newline',
+            'ban_newline',
             'mode',
             'instruction_template',
             'name1_instruct',

--- a/server.py
+++ b/server.py
@@ -316,6 +316,7 @@ def create_chat_settings_menus():
 
             with gr.Column():
                 shared.gradio['stop_at_newline'] = gr.Checkbox(value=shared.settings['stop_at_newline'], label='Stop generating at new line character')
+                shared.gradio['ban_newline'] = gr.Checkbox(value=shared.settings['ban_newline'], label='Ban the new line character')
 
 
 def create_settings_menus(default_preset):

--- a/settings-template.yaml
+++ b/settings-template.yaml
@@ -15,6 +15,7 @@ greeting: ''
 turn_template: ''
 custom_stopping_strings: ''
 stop_at_newline: false
+ban_newline: false
 add_bos_token: true
 ban_eos_token: false
 skip_special_tokens: true


### PR DESCRIPTION
This is a guaranteed way to get long replies in chat mode. 

The caveat is that the reply never ends, so it must be stopped early using some criterion.