### PR TITLE
Support LLaVA-LLaMA-2

### DIFF
--- a/extensions/multimodal/pipelines/llava/llava.py
+++ b/extensions/multimodal/pipelines/llava/llava.py
@@ -143,3 +143,32 @@ class LLaVA_v0_7B_Pipeline(LLaVA_v0_Pipeline):
     @staticmethod
     def llava_projector_repo() -> str:
         return "liuhaotian/LLaVA-7b-delta-v0"
+
+
+class LLaVA_LLaMA_2_13B_Pipeline(LLaVA_v0_13B_Pipeline):
+    def __init__(self, params: dict) -> None:
+        super().__init__(params)
+
+    @staticmethod
+    def name() -> str:
+        return "llava-llama-2-13b"
+
+    @staticmethod
+    def placeholder_token_id() -> int:
+        return 0
+
+    @staticmethod
+    def llava_projector_repo() -> str:
+        return "liuhaotian/llava-llama-2-13b-chat-lightning-preview"
+
+    @staticmethod
+    def image_start() -> str:
+        return ""
+
+    @staticmethod
+    def image_end() -> str:
+        return ""
+
+    @staticmethod
+    def placeholder_embeddings() -> torch.Tensor:
+        return LLaVA_v0_Pipeline.embed_tokens(encode("<unk>"*256, add_bos_token=False)[0])

--- a/extensions/multimodal/pipelines/llava/pipelines.py
+++ b/extensions/multimodal/pipelines/llava/pipelines.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from extensions.multimodal.abstract_pipeline import AbstractMultimodalPipeline
 
-available_pipelines = ['llava-7b', 'llava-13b']
+available_pipelines = ['llava-7b', 'llava-13b', 'llava-llama-2-13b']
 
 
 def get_pipeline(name: str, params: dict) -> Optional[AbstractMultimodalPipeline]:
@@ -12,12 +12,19 @@ def get_pipeline(name: str, params: dict) -> Optional[AbstractMultimodalPipeline
     if name == 'llava-13b':
         from .llava import LLaVA_v0_13B_Pipeline
         return LLaVA_v0_13B_Pipeline(params)
+    if name == 'llava-llama-2-13b':
+        from .llava import LLaVA_LLaMA_2_13B_Pipeline
+        return LLaVA_LLaMA_2_13B_Pipeline(params)
     return None
 
 
 def get_pipeline_from_model_name(model_name: str, params: dict) -> Optional[AbstractMultimodalPipeline]:
     if 'llava' not in model_name.lower():
         return None
+    if 'llama-2' in model_name.lower():
+        if '13b' in model_name.lower():
+            from .llava import LLaVA_LLaMA_2_13B_Pipeline
+            return LLaVA_LLaMA_2_13B_Pipeline(params)
     if '7b' in model_name.lower():
         from .llava import LLaVA_v0_7B_Pipeline
         return LLaVA_v0_7B_Pipeline(params)


### PR DESCRIPTION
**This is a PR in progress, please do not merge it yet.**

I am the author of LLaVA, and we have recently supported LLaMA-2, and will release more checkpoints this coming week. We are working on the integration of LLaVA-LLaMA-2 to `textgen-ui`.

This PR includes the initial support for the released checkpoint [LLaVA-LLaMA-2-13B-Chat-Preview](https://huggingface.co/liuhaotian/llava-llama-2-13b-chat-lightning-preview).

Command to run this checkpoint:
First download the checkpoints of [`llava-llama-2-13b-chat-lightning-4bit-128g`](https://huggingface.co/liuhaotian/llava-llama-2-13b-chat-lightning-gptq) to `models` folder under the cloned textgen-ui folder.
```Shell
python server.py \
    --chat \
    --model-dir models \
    --model llava-llama-2-13b-chat-lightning-4bit-128g \
    --multimodal-pipeline llava-llama-2-13b
```

TODO:

- [x] Currently it seems that exllama is not compatible with multimodal extension. I'll submit an issue about this.
- [x] More checkpoints will be added soon, and I'll make sure that all necessary pipelines are added before we merge the PR. (some new checkpoints involve a slight architecture change, will be addressed in a separate PR)

Screenshot
<img width="811" alt="Screen Shot 2023-07-30 at 11 16 12 PM" src="https://github.com/oobabooga/text-generation-webui/assets/6631389/ab370bdd-b347-462b-99ae-fa5e92a7233e">
