### PR TITLE
Fix llama.cpp truncation

### DIFF
--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -101,7 +101,6 @@ class LlamaCppModel:
 
         output = ""
         for completion_chunk in completion_chunks:
-            print(completion_chunk)
             text = completion_chunk['choices'][0]['text']
             output += text
             if callback:

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -313,21 +313,21 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
 def generate_reply_custom(question, original_question, seed, state, stopping_strings=None, is_chat=False):
     seed = set_manual_seed(state['seed'])
 
+    # Use the 'encode' function to truncate the prompt
+    truncated_prompt_encoded = encode(question, truncation_length=get_max_prompt_length(state))
+
     # Convert the truncated prompt back to a string (to avoid modifying 'generate' and 'generate_with_streaming')
     truncated_prompt_string: str
 
     if state['loader'] == 'ExLlama':
         # ExLlama model. The encoded type is 'torch.Tensor'
-        truncated_prompt_encoded = encode(question, truncation_length=get_max_prompt_length(state))
         truncated_prompt_string = shared.model.decode(truncated_prompt_encoded)
     elif state['loader'] == 'llama.cpp':
         # Llama.cpp model. The encoded type is 'numpy.ndarray'
-        truncated_prompt_encoded = encode(question, truncation_length=get_max_prompt_length(state))
         # Convert decoded value from 'bytes' to 'str'
         truncated_prompt_string = shared.model.decode(truncated_prompt_encoded[0]).decode('utf-8')
     elif state['loader'] == 'RWKV':
         # RWKV model. The encoded type is 'numpy.ndarray'
-        truncated_prompt_encoded = encode(question, truncation_length=get_max_prompt_length(state))
         truncated_prompt_string = shared.tokenizer.decode(truncated_prompt_encoded[0])
     else:
         # In default case, don't touch the prompt string

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -333,9 +333,6 @@ def generate_reply_custom(question, original_question, seed, state, stopping_str
         # In default case, don't touch the prompt string
         truncated_prompt_string = question
 
-    print(f"loader: {state['loader']}")
-    print(f"truncated_prompt_string: {truncated_prompt_string}")
-
     t0 = time.time()
     reply = ''
     try:

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -313,26 +313,6 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
 def generate_reply_custom(question, original_question, seed, state, stopping_strings=None, is_chat=False):
     seed = set_manual_seed(state['seed'])
 
-    # Use the 'encode' function to truncate the prompt
-    truncated_prompt_encoded = encode(question, truncation_length=get_max_prompt_length(state))
-
-    # Convert the truncated prompt back to a string (to avoid modifying 'generate' and 'generate_with_streaming')
-    truncated_prompt_string: str
-
-    if state['loader'] == 'ExLlama':
-        # ExLlama model. The encoded type is 'torch.Tensor'
-        truncated_prompt_string = shared.model.decode(truncated_prompt_encoded)
-    elif state['loader'] == 'llama.cpp':
-        # Llama.cpp model. The encoded type is 'numpy.ndarray'
-        # Convert decoded value from 'bytes' to 'str'
-        truncated_prompt_string = shared.model.decode(truncated_prompt_encoded[0]).decode('utf-8')
-    elif state['loader'] == 'RWKV':
-        # RWKV model. The encoded type is 'numpy.ndarray'
-        truncated_prompt_string = shared.tokenizer.decode(truncated_prompt_encoded[0])
-    else:
-        # In default case, don't touch the prompt string
-        truncated_prompt_string = question
-
     t0 = time.time()
     reply = ''
     try:
@@ -340,17 +320,17 @@ def generate_reply_custom(question, original_question, seed, state, stopping_str
             yield ''
 
         if not state['stream']:
-            reply = shared.model.generate(truncated_prompt_string, state)
+            reply = shared.model.generate(question, state)
             yield reply
         else:
-            for reply in shared.model.generate_with_streaming(truncated_prompt_string, state):
+            for reply in shared.model.generate_with_streaming(question, state):
                 yield reply
 
     except Exception:
         traceback.print_exc()
     finally:
         t1 = time.time()
-        original_tokens = len(truncated_prompt_encoded[0])
-        new_tokens = len(encode(reply)[0])
+        original_tokens = len(encode(original_question)[0])
+        new_tokens = len(encode(original_question + reply)[0]) - original_tokens
         print(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens}, seed {seed})')
         return

--- a/settings-template.yaml
+++ b/settings-template.yaml
@@ -1,4 +1,4 @@
-dark_theme: false
+dark_theme: true
 autoload_model: false
 max_new_tokens: 200
 max_new_tokens_min: 1
@@ -7,10 +7,7 @@ seed: -1
 character: None
 name1: You
 name2: Assistant
-context: This is a conversation with your Assistant. It is a computer program designed
-  to help you with various tasks such as answering questions, providing recommendations,
-  and helping with decision making. You can ask it anything you want and it will do
-  its best to give you accurate and relevant information.
+context: This is a conversation with your Assistant. It is a computer program designed to help you with various tasks such as answering questions, providing recommendations, and helping with decision making. You can ask it anything you want and it will do its best to give you accurate and relevant information.
 greeting: ''
 turn_template: ''
 custom_stopping_strings: ''
@@ -23,18 +20,17 @@ truncation_length_min: 0
 truncation_length_max: 16384
 mode: chat
 start_with: ''
-chat_style: cai-chat
+chat_style: TheEncrypted777
 instruction_template: None
-chat-instruct_command: 'Continue the chat dialogue below. Write a single reply for
-  the character "<|character|>".
+chat-instruct_command: |-
+  Continue the chat dialogue below. Write a single reply for the character "<|character|>".
 
-
-  <|prompt|>'
+  <|prompt|>
 chat_generation_attempts: 1
 chat_generation_attempts_min: 1
 chat_generation_attempts_max: 10
 default_extensions: []
 chat_default_extensions:
 - gallery
-preset: 'Divine Intellect'
+preset: simple-1
 prompt: QA

--- a/settings-template.yaml
+++ b/settings-template.yaml
@@ -1,4 +1,4 @@
-dark_theme: true
+dark_theme: false
 autoload_model: false
 max_new_tokens: 200
 max_new_tokens_min: 1
@@ -7,7 +7,10 @@ seed: -1
 character: None
 name1: You
 name2: Assistant
-context: This is a conversation with your Assistant. It is a computer program designed to help you with various tasks such as answering questions, providing recommendations, and helping with decision making. You can ask it anything you want and it will do its best to give you accurate and relevant information.
+context: This is a conversation with your Assistant. It is a computer program designed
+  to help you with various tasks such as answering questions, providing recommendations,
+  and helping with decision making. You can ask it anything you want and it will do
+  its best to give you accurate and relevant information.
 greeting: ''
 turn_template: ''
 custom_stopping_strings: ''
@@ -20,17 +23,18 @@ truncation_length_min: 0
 truncation_length_max: 16384
 mode: chat
 start_with: ''
-chat_style: TheEncrypted777
+chat_style: cai-chat
 instruction_template: None
-chat-instruct_command: |-
-  Continue the chat dialogue below. Write a single reply for the character "<|character|>".
+chat-instruct_command: 'Continue the chat dialogue below. Write a single reply for
+  the character "<|character|>".
 
-  <|prompt|>
+
+  <|prompt|>'
 chat_generation_attempts: 1
 chat_generation_attempts_min: 1
 chat_generation_attempts_max: 10
 default_extensions: []
 chat_default_extensions:
 - gallery
-preset: simple-1
+preset: 'Divine Intellect'
 prompt: QA


### PR DESCRIPTION
This PR fixes a bug where llama.cpp models never had their prompts truncated in Notebook mode.

Example output before PR (the model is given too many tokens, ignoring the 2048 limit):
```
llama_tokenize_with_model: too many tokens
llama_tokenize_with_model: too many tokens
llama_tokenize_with_model: too many tokens
Output generated in 0.92 seconds (0.00 tokens/s, 0 tokens, context 132731, seed 957470463)
```

Example output after PR (the model is given the correct amount of context):
```
llama_print_timings:        load time =  1081.64 ms
llama_print_timings:      sample time =    44.30 ms /   199 runs   (    0.22 ms per token,  4492.00 tokens per second)
llama_print_timings: prompt eval time =  3794.33 ms /  1849 tokens (    2.05 ms per token,   487.31 tokens per second)
llama_print_timings:        eval time =  5315.49 ms /   198 runs   (   26.85 ms per token,    37.25 tokens per second)
llama_print_timings:       total time = 19681.72 ms
Output generated in 58.74 seconds (3.41 tokens/s, 200 tokens, context 1848, seed 1490272512)
```

This also fixes the "context" number reported in the console for LlamaCppModel, RWKVModel, and ExllamaModel. Previously this message would claim that the model had 'x' context where 'x' was however many tokens were present in the UI. Now it reports the actual number of tokens that the model received as context.

Should fix these issues: (https://github.com/oobabooga/text-generation-webui/issues/3043), (https://github.com/oobabooga/text-generation-webui/issues/2665), (https://github.com/oobabooga/text-generation-webui/issues/2511), (https://github.com/oobabooga/text-generation-webui/issues/2538)

I looked into having verbose mode only show the truncated context, but there's an issue with AutoGPTQ and similar loaders handled by `generate_reply_HF` being able to decode their encoded context (`input_ids`).

@oobabooga I accidentally closed the original PR when syncing with the main branch. This should be ready to merge now if you want.