### PR TITLE
Add a scrollbar to notebook/default textboxes, improve chat scrollbar style

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -155,3 +155,31 @@ button {
 .markdown ul ol {
     font-size: 100% !important;
 }
+
+.pretty_scrollbar::-webkit-scrollbar {
+  width: 10px;
+}
+
+.pretty_scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.pretty_scrollbar::-webkit-scrollbar-thumb,
+.pretty_scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #c5c5d2;
+  border-radius: 10px;
+}
+
+.dark .pretty_scrollbar::-webkit-scrollbar-thumb,
+.dark .pretty_scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #374151;
+  border-radius: 10px;
+}
+
+.pretty_scrollbar::-webkit-resizer {
+  background: #c5c5d2;
+}
+
+.dark .pretty_scrollbar::-webkit-resizer {
+  background: #374151;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -183,3 +183,4 @@ button {
 .dark .pretty_scrollbar::-webkit-resizer {
   background: #374151;
 }
+

--- a/css/main.css
+++ b/css/main.css
@@ -183,4 +183,3 @@ button {
 .dark .pretty_scrollbar::-webkit-resizer {
   background: #374151;
 }
-

--- a/css/main.js
+++ b/css/main.js
@@ -20,4 +20,5 @@ main_parent.addEventListener('click', function(e) {
 const textareaElements = document.querySelectorAll('.add_scrollbar textarea');
 for(i = 0; i < textareaElements.length; i++) {
     textareaElements[i].classList.remove('scroll-hide');
+    textareaElements[i].classList.add('pretty_scrollbar');
 }

--- a/css/main.js
+++ b/css/main.js
@@ -16,3 +16,8 @@ main_parent.addEventListener('click', function(e) {
         extensions.style.display = 'none';
     }
 });
+
+const textareaElements = document.querySelectorAll('.add_scrollbar textarea');
+for(i = 0; i < textareaElements.length; i++) {
+    textareaElements[i].classList.remove('scroll-hide');
+}

--- a/css/main.js
+++ b/css/main.js
@@ -21,4 +21,5 @@ const textareaElements = document.querySelectorAll('.add_scrollbar textarea');
 for(i = 0; i < textareaElements.length; i++) {
     textareaElements[i].classList.remove('scroll-hide');
     textareaElements[i].classList.add('pretty_scrollbar');
+    textareaElements[i].style.resize = "none";
 }

--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -150,7 +150,7 @@ def get_image_cache(path):
 
 
 def generate_instruct_html(history):
-    output = f'<style>{instruct_css}</style><div class="chat" id="chat">'
+    output = f'<style>{instruct_css}</style><div class="chat pretty_scrollbar" id="chat">'
     for i, _row in enumerate(history[::-1]):
         row = [convert_to_markdown(entry) for entry in _row]
 
@@ -183,7 +183,7 @@ def generate_instruct_html(history):
 
 
 def generate_cai_chat_html(history, name1, name2, style, reset_cache=False):
-    output = f'<style>{chat_styles[style]}</style><div class="chat" id="chat">'
+    output = f'<style>{chat_styles[style]}</style><div class="chat pretty_scrollbar" id="chat">'
 
     # We use ?name2 and ?time.time() to force the browser to reset caches
     img_bot = f'<img src="file/cache/pfp_character.png?{name2}">' if Path("cache/pfp_character.png").exists() else ''
@@ -232,7 +232,7 @@ def generate_cai_chat_html(history, name1, name2, style, reset_cache=False):
 
 
 def generate_chat_html(history, name1, name2, reset_cache=False):
-    output = f'<style>{chat_styles["wpp"]}</style><div class="chat" id="chat">'
+    output = f'<style>{chat_styles["wpp"]}</style><div class="chat pretty_scrollbar" id="chat">'
 
     for i, _row in enumerate(history[::-1]):
         row = [convert_to_markdown(entry) for entry in _row]

--- a/server.py
+++ b/server.py
@@ -1069,14 +1069,14 @@ def create_interface():
         if shared.settings['dark_theme']:
             shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.add('dark')")
 
-        # Inject javascript to remove the 'scroll-hide' class from the textarea in the Raw Textbox
+        # Inject javascript to remove the 'scroll-hide' class from UI elements
         js += """
-        function fixRawTextBoxScroll() {
-            let rawTextBox_textArea = document.querySelector('#raw_textbox textarea')
-            rawTextBox_textArea.classList.remove('scroll-hide')
+        function enableScrollBarOnElement(id) {
+            let selected_element = document.querySelector(id)
+            selected_element.classList.remove('scroll-hide')
         }
 
-        fixRawTextBoxScroll();
+        enableScrollBarOnElement('#raw_textbox textarea');
         """
 
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")

--- a/server.py
+++ b/server.py
@@ -676,8 +676,8 @@ def create_interface():
 
                             shared.gradio['name1'] = gr.Textbox(value=shared.settings['name1'], lines=1, label='Your name')
                             shared.gradio['name2'] = gr.Textbox(value=shared.settings['name2'], lines=1, label='Character\'s name')
-                            shared.gradio['context'] = gr.Textbox(value=shared.settings['context'], lines=4, label='Context')
-                            shared.gradio['greeting'] = gr.Textbox(value=shared.settings['greeting'], lines=4, label='Greeting')
+                            shared.gradio['context'] = gr.Textbox(value=shared.settings['context'], lines=4, label='Context', elem_classes=['add_scrollbar'])
+                            shared.gradio['greeting'] = gr.Textbox(value=shared.settings['greeting'], lines=4, label='Greeting', elem_classes=['add_scrollbar'])
 
                         with gr.Column(scale=1):
                             shared.gradio['character_picture'] = gr.Image(label='Character picture', type='pil')
@@ -696,7 +696,7 @@ def create_interface():
                     shared.gradio['context_instruct'] = gr.Textbox(value='', lines=4, label='Context')
                     shared.gradio['turn_template'] = gr.Textbox(value=shared.settings['turn_template'], lines=1, label='Turn template', info='Used to precisely define the placement of spaces and new line characters in instruction prompts.')
                     with gr.Row():
-                        shared.gradio['chat-instruct_command'] = gr.Textbox(value=shared.settings['chat-instruct_command'], lines=4, label='Command for chat-instruct mode', info='<|character|> gets replaced by the bot name, and <|prompt|> gets replaced by the regular chat prompt.')
+                        shared.gradio['chat-instruct_command'] = gr.Textbox(value=shared.settings['chat-instruct_command'], lines=4, label='Command for chat-instruct mode', info='<|character|> gets replaced by the bot name, and <|prompt|> gets replaced by the regular chat prompt.', elem_classes=['add_scrollbar'])
 
                 with gr.Tab('Chat history'):
                     with gr.Row():
@@ -738,7 +738,7 @@ def create_interface():
                 with gr.Row():
                     with gr.Column(scale=4):
                         with gr.Tab('Raw'):
-                            shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_id="raw_textbox", elem_classes="textbox", lines=27)
+                            shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_classes=['textbox', 'add_scrollbar'], lines=27)
 
                         with gr.Tab('Markdown'):
                             shared.gradio['markdown_render'] = gr.Button('Render')
@@ -776,7 +776,7 @@ def create_interface():
             with gr.Tab("Text generation", elem_id="main"):
                 with gr.Row():
                     with gr.Column():
-                        shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_classes="textbox_default", lines=27, label='Input')
+                        shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_classes=['textbox_default', 'add_scrollbar'], lines=27, label='Input')
                         shared.gradio['max_new_tokens'] = gr.Slider(minimum=shared.settings['max_new_tokens_min'], maximum=shared.settings['max_new_tokens_max'], step=1, label='max_new_tokens', value=shared.settings['max_new_tokens'])
                         with gr.Row():
                             shared.gradio['Generate'] = gr.Button('Generate', variant='primary')
@@ -794,7 +794,7 @@ def create_interface():
 
                     with gr.Column():
                         with gr.Tab('Raw'):
-                            shared.gradio['output_textbox'] = gr.Textbox(elem_classes="textbox_default_output", lines=27, label='Output')
+                            shared.gradio['output_textbox'] = gr.Textbox(lines=27, label='Output', elem_classes=['textbox_default_output', 'add_scrollbar'])
 
                         with gr.Tab('Markdown'):
                             shared.gradio['markdown_render'] = gr.Button('Render')
@@ -1068,16 +1068,6 @@ def create_interface():
 
         if shared.settings['dark_theme']:
             shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.add('dark')")
-
-        # Inject javascript to remove the 'scroll-hide' class from UI elements
-        js += """
-        function enableScrollBarOnElement(id) {
-            let selected_element = document.querySelector(id)
-            selected_element.classList.remove('scroll-hide')
-        }
-
-        enableScrollBarOnElement('#raw_textbox textarea');
-        """
 
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
         shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, gradio(ui.list_interface_input_elements()), show_progress=False)

--- a/server.py
+++ b/server.py
@@ -738,7 +738,7 @@ def create_interface():
                 with gr.Row():
                     with gr.Column(scale=4):
                         with gr.Tab('Raw'):
-                            shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_classes="textbox", lines=27)
+                            shared.gradio['textbox'] = gr.Textbox(value=default_text, elem_id="raw_textbox", elem_classes="textbox", lines=27)
 
                         with gr.Tab('Markdown'):
                             shared.gradio['markdown_render'] = gr.Button('Render')

--- a/server.py
+++ b/server.py
@@ -1069,6 +1069,16 @@ def create_interface():
         if shared.settings['dark_theme']:
             shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.add('dark')")
 
+        # Inject javascript to remove the 'scroll-hide' class from the textarea in the Raw Textbox
+        js += """
+        function fixRawTextBoxScroll() {
+            let rawTextBox_textArea = document.querySelector('#raw_textbox textarea')
+            rawTextBox_textArea.classList.remove('scroll-hide')
+        }
+
+        fixRawTextBoxScroll();
+        """
+
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
         shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, gradio(ui.list_interface_input_elements()), show_progress=False)
         if shared.is_chat():


### PR DESCRIPTION
This lets the "Raw" Textbox in Notebook Mode show a vertical scrollbar when there is enough text. This is a workaround for a Gradio issue (see: https://github.com/gradio-app/gradio/issues/4050, https://github.com/gradio-app/gradio/issues/4044). Tested working on Edge and Chrome.

This is achieved by injecting a simple JavaScript function while creating the Gradio interface and then firing it as soon as the document loads. The same effect could be applied to any UI element by calling `enableScrollBarOnElement` like I do on the raw textbox here.

I tried various CSS modifications but Gradio's `scroll-hide` ultimately prevents CSS fixes from working. The scrollbar seems finicky and would not display even if I overrode Gradio's CSS with `!important`. So JavaScript was necessary.

Before:
![no scrollbar](https://github.com/oobabooga/text-generation-webui/assets/33569918/6d51b64a-f118-4ea1-9099-6d3c34442670)

After:
![scrollbar](https://github.com/oobabooga/text-generation-webui/assets/33569918/e5a29ca8-0e81-4607-9c1d-7e39791c9ea4)
