### PR TITLE
Fix: Rope freq base by alpha value in llamacpp module

### DIFF
--- a/modules/llamacpp_hf.py
+++ b/modules/llamacpp_hf.py
@@ -103,6 +103,18 @@ class LlamacppHF(PreTrainedModel):
             model_file = list(path.glob('*ggml*.bin'))[0]
 
         logger.info(f"llama.cpp weights detected: {model_file}\n")
+
+        rope_freq_base = 10000 * shared.args.alpha_value ** (64/63.)
+        rope_freq_base_by_alphascaling = {
+            1: 10000,
+            2: 32000,
+            3: 54000,
+            4: 82684
+        }
+        alpha_value = shared.args.alpha_value
+        if alpha_value in rope_freq_base_by_alphascaling:
+            rope_freq_base = rope_freq_base_by_alphascaling[alpha_value]
+
         params = {
             'model_path': str(model_file),
             'n_ctx': shared.args.n_ctx,
@@ -113,7 +125,7 @@ class LlamacppHF(PreTrainedModel):
             'use_mlock': shared.args.mlock,
             'low_vram': shared.args.low_vram,
             'n_gpu_layers': shared.args.n_gpu_layers,
-            'rope_freq_base': 10000 * shared.args.alpha_value ** (64/63.),
+            'rope_freq_base': rope_freq_base,
             'rope_freq_scale': 1.0 / shared.args.compress_pos_emb,
             'n_gqa': shared.args.n_gqa or None,
             'rms_norm_eps': shared.args.rms_norm_eps or None,

--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -55,6 +55,18 @@ class LlamaCppModel:
                 cache_capacity = int(shared.args.cache_capacity)
 
         logger.info("Cache capacity is " + str(cache_capacity) + " bytes")
+        
+        rope_freq_base = 10000 * shared.args.alpha_value ** (64/63.)
+        rope_freq_base_by_alphascaling = {
+            1: 10000,
+            2: 32000,
+            3: 54000,
+            4: 82684
+        }
+        alpha_value = shared.args.alpha_value
+        if alpha_value in rope_freq_base_by_alphascaling:
+            rope_freq_base = rope_freq_base_by_alphascaling[alpha_value]
+
         params = {
             'model_path': str(path),
             'n_ctx': shared.args.n_ctx,
@@ -65,7 +77,7 @@ class LlamaCppModel:
             'use_mlock': shared.args.mlock,
             'low_vram': shared.args.low_vram,
             'n_gpu_layers': shared.args.n_gpu_layers,
-            'rope_freq_base': 10000 * shared.args.alpha_value ** (64/63.),
+            'rope_freq_base': rope_freq_base,
             'rope_freq_scale': 1.0 / shared.args.compress_pos_emb,
             'n_gqa': shared.args.n_gqa or None,
             'rms_norm_eps': shared.args.rms_norm_eps or None,


### PR DESCRIPTION
## About the fix
This fix aims to make the rope_freq_base as accurate as possible according to alpha_scaling, the fix I made only supports up to alpha scaling = 4, if alpha scaling more than 4 use a old formula to obtain rope_freq_base. I noticed this issue because some people were getting incorrect answers using alpha_scaling in llamacpp module. These values were all taken according to koboldcpp's code
## Reference
- [KoboldCPP Code](https://github.com/LostRuins/koboldcpp/blob/b2eaec426178504a11554585885ec13c645ceb80/gpttype_adapter.cpp#L377)  that ntk rope scaling increase according to context size is still only according to llama 1
- [KoboldCPP Documentation](https://github.com/LostRuins/koboldcpp/wiki#koboldcpp-general-usage-and-troubleshooting)
