### PR TITLE
Create logs dir if missing when saving history

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -394,6 +394,8 @@ def redraw_html(history, name1, name2, mode, style, reset_cache=False):
 
 def save_history(history, path=None):
     p = path or Path('logs/exported_history.json')
+    if not p.parent.is_dir():
+        p.parent.mkdir(parents=True)
     with open(p, 'w', encoding='utf-8') as f:
         f.write(json.dumps(history, indent=4))
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---

When using chat mode with a character, a `FileNotFoundError` exception is raised when the `logs` directory is missing.
This results in the command-line window being spammed with errors while chatting on a new installation.

I was unsure whether to have `parents=True` or not. I assumed an extension or something else might save logs to a different path. In that case, `parents=True` would create folders as needed to save to that path.

`is_dir()` is used here to check if the parent path both exists and points to a directory.