### PR TITLE
Fix: Mirostat fails on models split across multiple GPUs.

### DIFF
--- a/modules/sampler_hijack.py
+++ b/modules/sampler_hijack.py
@@ -104,7 +104,7 @@ class MirostatLogitsWarper(LogitsWarper):
                 break
 
         # Normalize the probabilities of the remaining words
-        prob_topk = torch.softmax(sorted_logits, dim=0)
+        prob_topk = torch.softmax(sorted_logits, dim=0).to('cuda')
 
         prev_i = torch.multinomial(prob_topk, num_samples=1, replacement=True).to('cuda')
 


### PR DESCRIPTION
Used mirostat again recently, and when using a 65b/70b I would get this error:

```
Traceback (most recent call last):
  File "/home/supermicro/ai/text-generation-webui-testing/modules/callbacks.py", line 55, in gentask
    ret = self.mfunc(callback=_callback, *args, **self.kwargs)
  File "/home/supermicro/ai/text-generation-webui-testing/modules/text_generation.py", line 294, in generate_with_callback
    shared.model.generate(**kwargs)
  File "/home/supermicro/miniconda3/envs/nvidia/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/supermicro/miniconda3/envs/nvidia/lib/python3.10/site-packages/transformers/generation/utils.py", line 1588, in generate
    return self.sample(
  File "/home/supermicro/miniconda3/envs/nvidia/lib/python3.10/site-packages/transformers/generation/utils.py", line 2656, in sample
    next_token_scores = logits_warper(input_ids, next_token_scores)
  File "/home/supermicro/miniconda3/envs/nvidia/lib/python3.10/site-packages/transformers/generation/logits_process.py", line 97, in __call__
    scores = processor(input_ids, scores)
  File "/home/supermicro/ai/text-generation-webui-testing/modules/sampler_hijack.py", line 111, in __call__
    observed_surprise = -math.log2(prob_topk[prev_i])
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cuda:1)
```

Putting prob_topk on the cuda device appears to solve it and allow the model to generate text again. Someone had done it with the other variable but not this one.



## Checklist:

- [ x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
