### PR TITLE
Use chat_instruct_command in API

### DIFF
--- a/api-examples/api-example-chat-stream.py
+++ b/api-examples/api-example-chat-stream.py
@@ -38,7 +38,7 @@ async def run(user_input, history):
         '_continue': False,
         'stop_at_newline': False,
         'chat_generation_attempts': 1,
-        'chat-instruct_command': 'Continue the chat dialogue below. Write a single reply for the character "<|character|>".\n\n<|prompt|>',
+        'chat_instruct_command': 'Continue the chat dialogue below. Write a single reply for the character "<|character|>".\n\n<|prompt|>',
 
         # Generation params. If 'preset' is set to different than 'None', the values
         # in presets/preset-name.yaml are used instead of the individual numbers.

--- a/api-examples/api-example-chat.py
+++ b/api-examples/api-example-chat.py
@@ -32,7 +32,7 @@ def run(user_input, history):
         '_continue': False,
         'stop_at_newline': False,
         'chat_generation_attempts': 1,
-        'chat-instruct_command': 'Continue the chat dialogue below. Write a single reply for the character "<|character|>".\n\n<|prompt|>',
+        'chat_instruct_command': 'Continue the chat dialogue below. Write a single reply for the character "<|character|>".\n\n<|prompt|>',
 
         # Generation params. If 'preset' is set to different than 'None', the values
         # in presets/preset-name.yaml are used instead of the individual numbers.

--- a/extensions/api/util.py
+++ b/extensions/api/util.py
@@ -79,7 +79,7 @@ def build_parameters(body, chat=False):
             'name2_instruct': str(body.get('name2_instruct', name2_instruct)),
             'context_instruct': str(body.get('context_instruct', context_instruct)),
             'turn_template': str(body.get('turn_template', turn_template)),
-            'chat-instruct_command': str(body.get('chat_instruct_command') or body.get('chat-instruct_command', shared.settings['chat-instruct_command'])),
+            'chat-instruct_command': str(body.get('chat_instruct_command', body.get('chat-instruct_command', shared.settings['chat-instruct_command']))),
             'history': body.get('history', {'internal': [], 'visible': []})
         })
 

--- a/extensions/api/util.py
+++ b/extensions/api/util.py
@@ -79,7 +79,7 @@ def build_parameters(body, chat=False):
             'name2_instruct': str(body.get('name2_instruct', name2_instruct)),
             'context_instruct': str(body.get('context_instruct', context_instruct)),
             'turn_template': str(body.get('turn_template', turn_template)),
-            'chat-instruct_command': str(body.get('chat-instruct_command', shared.settings['chat-instruct_command'])),
+            'chat-instruct_command': str(body.get('chat_instruct_command') or body.get('chat-instruct_command', shared.settings['chat-instruct_command'])),
             'history': body.get('history', {'internal': [], 'visible': []})
         })
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
Improves compatibility with C++ implementations as the language does not allow variable names with `-`.

Previous name is still checked to maintain compatibility with existing implementations and to minimize confusion as the setting name itself was not changed.