### PR TITLE
Add support for requesting Token-Length to the Websocket API / graceful handling when no model is loaded

### DIFF
--- a/api-examples/api-example-stream.py
+++ b/api-examples/api-example-stream.py
@@ -23,8 +23,8 @@ URI = f'ws://{HOST}/api/v1/stream'
 # the server responds with:
 # {
 #	'event': 'token-count', 
-#	'count' : 42, 
-#	'prompt' : 'a copy of your prompt' 
+#	'count': 42, 
+#	'prompt': 'a copy of your prompt' 
 # }
 
 

--- a/api-examples/api-example-stream.py
+++ b/api-examples/api-example-stream.py
@@ -15,6 +15,21 @@ URI = f'ws://{HOST}/api/v1/stream'
 # URI = 'wss://your-uri-here.trycloudflare.com/api/v1/stream'
 
 
+# token count can be requested from '/api/v1/token-count'
+# request = {
+#        'prompt': 'the prompt you want to know the token length of'
+# }
+#
+# the server responds with:
+# {
+#	'event': 'token-count', 
+#	'count' : 42, 
+#	'prompt' : 'a copy of your prompt' 
+# }
+
+
+
+
 async def run(context):
     # Note: the selected defaults change from time to time.
     request = {

--- a/extensions/api/streaming_api.py
+++ b/extensions/api/streaming_api.py
@@ -14,6 +14,7 @@ from modules.text_generation import (
     generate_reply
 )
 from websockets.server import serve
+from modules.logging_colors import logger
 
 PATH = '/api/v1/stream'
 
@@ -21,7 +22,7 @@ async def ensureModelLoaded(websocket):
     if shared.model_name != 'None':
         return True
     else:
-        print('websocket request not handled, no model is loaded')
+        logger.warning('websocket request not handled, no model is loaded')
         await websocket.send(json.dumps({
             'event': 'warning',
             'message': 'no model loaded'
@@ -100,7 +101,7 @@ async def _handle_chat_stream_message(websocket, message):
 @with_api_lock
 async def _handle_token_count_request(websocket, message):
     body = json.loads(message)
-    
+
     await websocket.send(json.dumps({
         'event': 'token-count',
         'count': get_encoded_length(body['prompt']),
@@ -126,7 +127,7 @@ async def _handle_connection(websocket, path):
                 await _handle_token_count_request(websocket, message)
 
     else:
-        print(f'Streaming api: unknown path: {path}')
+        logger.warning(f'Streaming api: unknown path: {path}')
         return
 
 
@@ -140,7 +141,7 @@ def _run_server(port: int, share: bool = False, tunnel_id=str):
 
     def on_start(public_url: str):
         public_url = public_url.replace('https://', 'wss://')
-        print(f'Starting streaming server at public url {public_url}{PATH}')
+        logger.info(f'Starting streaming server at public url {public_url}{PATH}')
 
     if share:
         try:
@@ -148,7 +149,7 @@ def _run_server(port: int, share: bool = False, tunnel_id=str):
         except Exception as e:
             print(e)
     else:
-        print(f'Starting streaming server at ws://{address}:{port}{PATH}')
+        logger.info(f'Starting streaming server at ws://{address}:{port}{PATH}')
 
     asyncio.run(_run(host=address, port=port))
 


### PR DESCRIPTION
Hi,

first three commits add support for requesting the token length for a prompt via the websocket API. This is useful if you want to truncate on your own rather than relying on the servers truncation (since this could cut off important context)

I'm aware that the example comment isn't the best solution, over all i would suggest that API usage would be a good topic that could be handled in the GitHub wiki. (Eventually opening it for public or restricted edits for trusted users!?)

the last commit handles requests more graceful when there is no model loaded, currently this would just print an error stacktrace on the console, this was replaced by a console message and a websocket response which indicates that no model is loaded.

edit: added another commit which replaces print() statements with logger calls, except... for the exception as i wasn't sure how that output would look like and if it qualifies for logger calls. (also got no idea what the character at the beginning of the string is for, probably some formatting, i can get rid of it if you intend to merge the PR and want that changed)