### PR TITLE
Api http auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Optionally, you can use the following command-line flags:
 | `--public-api-id PUBLIC_API_ID`       | Tunnel ID for named Cloudflare Tunnel. Use together with public-api option. |
 | `--api-blocking-port BLOCKING_PORT`   | The listening port for the blocking API. |
 | `--api-streaming-port STREAMING_PORT` | The listening port for the streaming API. |
+| `--http_auth`                         | Enables (very) basic authentication for the API. If set call the API with HTTP Header X-TEXT-UI-AUTH and the value from the console. Use togehter with api option |
 
 #### Multimodal
 

--- a/api-examples/api-example.py
+++ b/api-examples/api-example.py
@@ -49,6 +49,7 @@ def run(prompt):
     }
 
     response = requests.post(URI, json=request)
+    #response = requests.post(URI, json=request, headers={'X-TEXT-UI-AUTH':'SEE CONSOLE FOR CURRENT KEY'})
 
     if response.status_code == 200:
         result = response.json()['results'][0]['text']

--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -33,16 +33,16 @@ def get_model_info():
 
 
 class Handler(BaseHTTPRequestHandler):
+
     def authentication(self):
+        # No authentication
         if not shared.args.http_auth:
             return True
-
-        AUTHENTICATED = False
-        if "X-TEXT-UI-AUTH" in self.headers:
-            authz = self.headers['X-TEXT-UI-AUTH']
-            if str(authz) == str(AUTH_TOKEN):
-                AUTHENTICATED = True
-        return AUTHENTICATED
+        # Token missing from the header
+        if "X-TEXT-UI-AUTH" not in self.headers:
+            return False
+        # Validate token
+        return str(self.headers['X-TEXT-UI-AUTH']) == str(AUTH_TOKEN)
 
     def do_GET(self):
         is_auth = self.authentication()

--- a/extensions/api/script.py
+++ b/extensions/api/script.py
@@ -4,5 +4,5 @@ from modules import shared
 
 
 def setup():
-    blocking_api.start_server(shared.args.api_blocking_port, share=shared.args.public_api, tunnel_id=shared.args.public_api_id)
+    blocking_api.start_server(shared.args.api_blocking_port, share=shared.args.public_api, tunnel_id=shared.args.public_api_id, http_auth=shared.args.http_auth)
     streaming_api.start_server(shared.args.api_streaming_port, share=shared.args.public_api, tunnel_id=shared.args.public_api_id)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -180,6 +180,7 @@ parser.add_argument('--api-blocking-port', type=int, default=5000, help='The lis
 parser.add_argument('--api-streaming-port', type=int, default=5005, help='The listening port for the streaming API.')
 parser.add_argument('--public-api', action='store_true', help='Create a public URL for the API using Cloudfare.')
 parser.add_argument('--public-api-id', type=str, help='Tunnel ID for named Cloudflare Tunnel. Use together with public-api option.', default=None)
+parser.add_argument('--http_auth', action="store_true", help='Enforce basic API authentication via a HTTP header X-TEXT-UI-AUTH with a randomly generated value (see log)')
 
 # Multimodal
 parser.add_argument('--multimodal-pipeline', type=str, default=None, help='The multimodal pipeline to use. Examples: llava-7b, llava-13b.')


### PR DESCRIPTION
## HTTP AUTH for API
This pull request gives the user the option to protect their API with a custom HTTP header that is generated randomly once on startup. If enabled users need to pass the HTTP header X-TEXT-UI-AUTH with the value printed to the console on startup.

Is this the best possible solution?
No. A reverse proxy would for sure be endlessly better, non the less this is better than the current state where there are tons of unprotected APIs up and running exposed to the public internet.

This does not affect the streaming API.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
