### PR TITLE
ctransformers improvements

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -131,6 +131,7 @@ llama-65b-gptq-3bit:
 .*mpt-.*chat:
   mode: 'instruct'
   instruction_template: 'MPT-Chat'
+  model_type: 'mpt'
 (?!.*-flan-)(?!.*-t5-).*lamini-:
   mode: 'instruct'
   instruction_template: 'Alpaca'
@@ -224,6 +225,7 @@ llama-65b-gptq-3bit:
   mode: 'instruct'
   instruction_template: 'Starchat-Beta'
   custom_stopping_strings: '"<|end|>"'
+  model_type: 'starcoder'
 .*minotaur:
   mode: 'instruct'
   instruction_template: 'Minotaur'
@@ -281,3 +283,6 @@ llama-65b-gptq-3bit:
 .*openchat:
   mode: 'instruct'
   instruction_template: 'OpenChat'
+.*falcon.*-instruct:
+  mode: 'instruct;'
+  model_type: 'falcon'

--- a/modules/ctransformers_model.py
+++ b/modules/ctransformers_model.py
@@ -18,6 +18,7 @@ class CtransformersModel:
             threads=shared.args.threads,
             gpu_layers=shared.args.n_gpu_layers,
             batch_size=shared.args.n_batch,
+            context_length=shared.args.n_ctx,
             stream=True
         )
 

--- a/modules/ctransformers_model.py
+++ b/modules/ctransformers_model.py
@@ -49,7 +49,7 @@ class CtransformersModel:
     def generate(self, prompt, state, callback=None):
         prompt = prompt if type(prompt) is str else prompt.decode()
         # ctransformers uses -1 for random seed
-        generator = self.model._stream(
+        generator = self.model(
             prompt=prompt,
             max_new_tokens=state['max_new_tokens'],
             temperature=state['temperature'],

--- a/modules/ctransformers_model.py
+++ b/modules/ctransformers_model.py
@@ -32,7 +32,7 @@ class CtransformersModel:
         return result, result
 
     def model_type_is_auto(self):
-        return shared.args.model_type == "Auto" or shared.args.model_type == "None"
+        return shared.args.model_type is None or shared.args.model_type == "Auto" or shared.args.model_type == "None"
 
     def model_dir(self, path):
         if path.is_file():

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -92,6 +92,7 @@ loaders_and_params = OrderedDict({
         'llamacpp_HF_info',
     ],
     'ctransformers': [
+        'n_ctx',
         'n_gpu_layers',
         'n_batch',
         'threads',


### PR DESCRIPTION
1. Context length setting.
2. Better "None" type guessing since infer loader does not set model_type.
3. Stop using _stream internal function calls.
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
