### PR TITLE
ctransformers: Fix up model_type name consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Optionally, you can use the following command-line flags:
 
 | Flag        | Description |
 |-------------|-------------|
-| `--model_type MODEL_TYPE` | Model type of pre-quantized model. Currently gpt2, gptj, gpt_neox, falcon, llama, mpt, gpt_bigcode, dolly-v2, and replit are supported. |
+| `--model_type MODEL_TYPE` | Model type of pre-quantized model. Currently gpt2, gptj, gptneox, falcon, llama, mpt, starcoder (gptbigcode), dollyv2, and replit are supported. |
 
 #### AutoGPTQ
 

--- a/models/config.yaml
+++ b/models/config.yaml
@@ -5,7 +5,7 @@
 .*(gpt-j|gptj|gpt4all-j|malion-6b|pygway|pygmalion-6b|dolly-v1):
   model_type: 'gptj'
 .*(gpt-neox|koalpaca-polyglot|polyglot.*koalpaca|polyglot-ko|polyglot_ko|pythia|stablelm|incite|dolly-v2|polycoder|h2ogpt-oig|h2ogpt-oasst1|h2ogpt-gm):
-  model_type: 'gpt_neox'
+  model_type: 'gptneox'
 .*llama:
   model_type: 'llama'
 .*bloom:
@@ -17,9 +17,9 @@
 .*mpt:
   model_type: 'mpt'
 .*(starcoder|starchat):
-  model_type: 'gpt_bigcode'
+  model_type: 'starcoder'
 .*dolly-v2:
-  model_type: 'dolly-v2'
+  model_type: 'dollyv2'
 .*replit:
   model_type: 'replit'
 llama-65b-gptq-3bit:

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -289,6 +289,7 @@ loaders_model_types = {
         "dollyv2"
         "replit",
         "starcoder",
+        "gptbigcode",
         "falcon"
     ],
 }


### PR DESCRIPTION
Although the ctransformers backend will strip non-alphanumeric characters for the model_type comparison, for the sake of consistency, use the model_type as is as found in the LLM class found in ctransformers.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
