### PR TITLE
refactor the whole streaming/blocking API to a more unified code base

### DIFF
--- a/api-examples/api-example-chat-stream.py
+++ b/api-examples/api-example-chat-stream.py
@@ -81,11 +81,10 @@ async def run(user_input, history):
             incoming_data = await websocket.recv()
             incoming_data = json.loads(incoming_data)
 
-            match incoming_data['event']:
-                case 'text_stream':
-                    yield incoming_data['history']
-                case 'stream_end':
-                    return
+            if incoming_data['event'] == 'text_stream':
+                yield incoming_data['history']
+            elif incoming_data['event'] == 'stream_end':
+                return
 
 
 async def print_response_stream(user_input, history):

--- a/api-examples/api-example-chat.py
+++ b/api-examples/api-example-chat.py
@@ -71,10 +71,17 @@ def run(user_input, history):
     response = requests.post(URI, json=request)
 
     if response.status_code == 200:
-        result = response.json()['results'][0]['history']
-        print(json.dumps(result, indent=4))
-        print()
-        print(result['visible'][-1][1])
+        if response.json().get('event'):
+            print(response.json()['event'] + ": " + response.json()['message'])
+
+        if response.json().get('results'):
+            result = response.json()['results'][0]['history']
+            print(json.dumps(result, indent=4))
+            print()
+            print(result['visible'][-1][1])
+
+    else:
+        print("server responded with status code " + response.status_code)
 
 
 if __name__ == '__main__':

--- a/api-examples/api-example-stream.py
+++ b/api-examples/api-example-stream.py
@@ -15,6 +15,21 @@ URI = f'ws://{HOST}/api/v1/stream'
 # URI = 'wss://your-uri-here.trycloudflare.com/api/v1/stream'
 
 
+# token count can be requested from '/api/v1/token-count'
+# request = {
+#        'prompt': 'the prompt you want to know the token length of'
+# }
+#
+# the server responds with:
+# {
+#	'event': 'token-count', 
+#	'count': 42, 
+#	'prompt': 'a copy of your prompt' 
+# }
+
+
+
+
 async def run(context):
     # Note: the selected defaults change from time to time.
     request = {

--- a/api-examples/api-example.py
+++ b/api-examples/api-example.py
@@ -51,8 +51,15 @@ def run(prompt):
     response = requests.post(URI, json=request)
 
     if response.status_code == 200:
-        result = response.json()['results'][0]['text']
-        print(prompt + result)
+        if response.json().get('event'):
+            print(response.json()['event'] + ": " + response.json()['message'])
+
+        if response.json().get('results'):
+            result = response.json()['results'][0]['text']
+            print(prompt + result)
+
+    else:
+        print("server responded with status code " + response.status_code)
 
 
 if __name__ == '__main__':

--- a/extensions/api/shared_api.py
+++ b/extensions/api/shared_api.py
@@ -1,0 +1,107 @@
+from modules import shared
+from modules.text_generation import (
+    get_encoded_length,
+    stop_everything_event
+)
+from modules.utils import get_available_models
+from modules.models import load_model, unload_model
+from modules.models_settings import (
+    get_model_settings_from_yamls,
+    update_model_parameters
+)
+from modules.LoRA import add_lora_to_model
+from modules.logging_colors import logger
+
+
+# any method defined in this file can NOT be async since they are intended to be used by both, the HTTP and the websocket server
+
+
+def get_model_info():
+    return {
+        'model_name': shared.model_name,
+        'lora_names': shared.lora_names,
+        # dump
+        'shared.settings': shared.settings,
+        'shared.args': vars(shared.args),
+    }
+
+
+def ensureModelLoaded(context):
+    if shared.model_name is not None and shared.model_name != 'None':
+        return True
+    else:
+        logger.warning('api request not handled, no model is loaded')
+        context['responseHandler'](context, {
+            'event': 'warning',
+            'message': 'no model loaded'
+        })
+        return False
+
+
+def _handle_stop_streaming_request(context, message): #2nd argument is there for compatibility reasons...
+    stop_everything_event()
+    context['responseHandler'](context, { 'event': 'stop-stream', 'results': 'success' })
+
+
+def _handle_token_count_request(connectionContext, message):
+    if not ensureModelLoaded(connectionContext):
+        return
+
+    connectionContext['responseHandler'](connectionContext, {
+        'event': 'token-count',
+        'count': get_encoded_length(message['prompt']),
+        'prompt': message['prompt']
+    })
+
+
+def _handle_model_request(connectionContext, message):
+    # Actions: info, load, list, unload
+    action = message.get('action', '')
+
+    if action == 'load':
+        model_name = message['model_name']
+        args = message.get('args', {})
+
+
+        logger.info('model loading args: %s', args)
+
+        for k in args:
+            setattr(shared.args, k, args[k])
+
+        shared.model_name = model_name
+        unload_model()
+
+        model_settings = get_model_settings_from_yamls(shared.model_name)
+        shared.settings.update(model_settings)
+        update_model_parameters(model_settings, initial=True)
+
+        if shared.settings['mode'] != 'instruct':
+            shared.settings['instruction_template'] = None
+
+        try:
+            shared.model, shared.tokenizer = load_model(shared.model_name)
+            if shared.args.lora:
+                add_lora_to_model(shared.args.lora)  # list
+
+        except Exception as e:
+            connectionContext['responseHandler'](connectionContext, { 'event': 'error', 'message': repr(e) })
+            raise e
+
+        shared.args.model = shared.model_name
+
+        connectionContext['responseHandler'](connectionContext, { 'event': 'model-loaded', 'result': get_model_info() })
+
+    elif action == 'unload':
+        unload_model()
+        shared.args.model = None
+        connectionContext['responseHandler'](connectionContext, { 'event': 'model-unloaded', 'result': get_model_info() })
+
+    elif action == 'list':
+        connectionContext['responseHandler'](connectionContext, {'event': 'model-list', 'result': get_available_models() })
+
+    elif action == 'info':
+        connectionContext['responseHandler'](connectionContext, {'event': 'model-info', 'result': get_model_info() })
+
+    else:
+        # by default return the same as the GET interface
+        connectionContext['responseHandler'](connectionContext, { 'result': shared.model_name })


### PR DESCRIPTION
the idea is to pass the parsed JSON to methods together with a connectionContext which has a responseHandler the method then passes data back to the responseHandler which is responsible for sending json back to the client

another thing that was changed/added is the PATH_DICT which contains the path handlers for the websocket/http implementations, currently theres one for both, but it could also be merged into one if necessary

few other changes that have been made:
* more graceful handling of malformed json
* any action that requires a model now checks if a model is loaded and informs the user if none is loaded, instead of failing with a stacktrace output
* made use of the logger for most console print statements
* model/token-length/stop-streaming API methods are now available on the websocket API

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
