### PR TITLE
Improved chat scrolling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -253,6 +253,10 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     .bigchat #chat {
         height: calc(100dvh - 180px) !important;
     }
+
+    .chat {
+        flex-direction: column-reverse !important;
+    }
 }
 
 .chat {

--- a/css/main.css
+++ b/css/main.css
@@ -263,10 +263,10 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     overflow-y: auto;
     padding-right: 20px;
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
     word-break: break-word;
     overflow-wrap: anywhere;
-    padding-top: 1px;
+    padding-top: 6px;
 }
 
 #chat {

--- a/js/main.js
+++ b/js/main.js
@@ -48,3 +48,46 @@ document.addEventListener("keydown", function(event) {
     }
   }
 });
+
+// Chat scrolling
+let globalScrollTop = 1e30;
+const targetElement = document.getElementById('chat').parentNode.parentNode.parentNode;
+let childElement = targetElement.childNodes[2].childNodes[0].childNodes[1];
+
+childElement.addEventListener('scroll', function() {
+  let diff = childElement.scrollHeight - childElement.clientHeight;
+  if(childElement.scrollTop == diff || diff == 0) {
+    globalScrollTop = 1e30;
+  } else {
+    globalScrollTop = childElement.scrollTop;
+  }
+});
+
+// Create a MutationObserver instance
+const observer = new MutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    childElement = targetElement.childNodes[2].childNodes[0].childNodes[1];
+    childElement.scrollTop = globalScrollTop; 
+
+    childElement.addEventListener('scroll', function() {
+      let diff = childElement.scrollHeight - childElement.clientHeight;
+      if(childElement.scrollTop == diff || diff == 0) {
+        globalScrollTop = 1e30;
+      } else {
+        globalScrollTop = childElement.scrollTop;
+      }
+    });
+  });
+});
+
+// Configure the observer to watch for changes in the subtree and attributes
+const config = {
+  childList: true,
+  subtree: true,
+  characterData: true,
+  attributeOldValue: true,
+  characterDataOldValue: true
+};
+
+// Start observing the target element
+observer.observe(targetElement, config);

--- a/js/main.js
+++ b/js/main.js
@@ -50,33 +50,13 @@ document.addEventListener("keydown", function(event) {
 });
 
 // Chat scrolling
-let globalScrollTop = 1e30;
 const targetElement = document.getElementById('chat').parentNode.parentNode.parentNode;
-let childElement = targetElement.childNodes[2].childNodes[0].childNodes[1];
-
-childElement.addEventListener('scroll', function() {
-  let diff = childElement.scrollHeight - childElement.clientHeight;
-  if(childElement.scrollTop == diff || diff == 0) {
-    globalScrollTop = 1e30;
-  } else {
-    globalScrollTop = childElement.scrollTop;
-  }
-});
 
 // Create a MutationObserver instance
 const observer = new MutationObserver(function(mutations) {
   mutations.forEach(function(mutation) {
-    childElement = targetElement.childNodes[2].childNodes[0].childNodes[1];
-    childElement.scrollTop = globalScrollTop; 
-
-    childElement.addEventListener('scroll', function() {
-      let diff = childElement.scrollHeight - childElement.clientHeight;
-      if(childElement.scrollTop == diff || diff == 0) {
-        globalScrollTop = 1e30;
-      } else {
-        globalScrollTop = childElement.scrollTop;
-      }
-    });
+    let childElement = targetElement.childNodes[2].childNodes[0].childNodes[1];
+    childElement.scrollTop = childElement.scrollHeight;
   });
 });
 


### PR DESCRIPTION
* On desktop devices, use javascript to scroll down instead of a flexbox with `flex-direction: column-reverse`.
* On mobile, keep the column-reverse as it's easier to read.
