### PR TITLE
fixes error when not specifying tunnel id

### DIFF
--- a/extensions/api/util.py
+++ b/extensions/api/util.py
@@ -99,7 +99,10 @@ def _start_cloudflared(port: int, tunnel_id: str, max_attempts: int = 3, on_star
 
     for _ in range(max_attempts):
         try:
-            public_url = _run_cloudflared(port, port + 1, tunnel_id=tunnel_id)
+            if tunnel_id is None:
+                public_url = _run_cloudflared(port, port + 1, tunnel_id=tunnel_id)
+            else:
+                public_url = _run_cloudflared(port, port + 1)
 
             if on_start:
                 on_start(public_url)

--- a/extensions/api/util.py
+++ b/extensions/api/util.py
@@ -99,7 +99,7 @@ def _start_cloudflared(port: int, tunnel_id: str, max_attempts: int = 3, on_star
 
     for _ in range(max_attempts):
         try:
-            if tunnel_id is None:
+            if tunnel_id is not None:
                 public_url = _run_cloudflared(port, port + 1, tunnel_id=tunnel_id)
             else:
                 public_url = _run_cloudflared(port, port + 1)


### PR DESCRIPTION
Added a simple if statement to not pass in the tunnel_id arg if it was not specified.

It addresses the error people get when using --public-api as seen in the error below. I was having the same problem and wanted to make a fix that will work with or without passing in the tunnel_id

https://github.com/oobabooga/text-generation-webui/issues/3570#issue-1849302813

## Checklist:

- [✅] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
