### PR TITLE
Fix print CSS

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -350,12 +350,10 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
         position: absolute;
         left: 0;
         top: 0;
-        max-width: none;
-        max-height: none;
+        max-width: unset;
+        max-height: unset;
         width: 100%;
-        height: fit-content;
-        display: flex;
-        flex-direction: column-reverse;
+        overflow-y: visible;
     }
     
     .message {
@@ -368,5 +366,9 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     
     .tab-nav {
         display: none !important;
+    }
+    
+    #chat-tab > :first-child {
+        max-width: unset;
     }
 }


### PR DESCRIPTION
## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

Fixes #3600

I'm not sure why it's so small, but that's easily adjusted with the print dialog's Scale setting.

Before
![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/50884da3-2998-4c6a-92af-c3535cd54aa0)

After
![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/b043e82b-5830-4791-84d3-b2ce57c6f495)
