### PR TITLE
llama.cpp: make Stop button work with streaming disabled

### DIFF
--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -125,6 +125,8 @@ class LlamaCppModel:
 
         output = ""
         for completion_chunk in completion_chunks:
+            if shared.stop_everything:
+                break
             text = completion_chunk['choices'][0]['text']
             output += text
             if callback:


### PR DESCRIPTION
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
***
I noticed that the 'Stop' button had no effect on llama.cpp when streaming was disabled. This simple fix makes it work as expected.