### PR TITLE
Unescape last message

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -313,12 +313,12 @@ def remove_last_message(history):
     else:
         last = ['', '']
 
-    return last[0], history
+    return html.unescape(last[0]), history
 
 
 def send_last_reply_to_input(history):
     if len(history['visible']) > 0:
-        return history['visible'][-1][1]
+        return html.unescape(history['visible'][-1][1])
     else:
         return ''
 


### PR DESCRIPTION
## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/decb9aff-0459-4698-801b-b79014467afa)
The changes in a4e903e932c6b3b43b2ccb88f9e75049b2ac4b2e, f6724a1a01f48c70a0c00cc4b2f85501b1e4f9f1, and c4733000d715e422d76f3bf58c12f596df03fc0d cause HTML-escaped strings to be sent to the input box when clicking `Remove last` or `Copy last reply`. This fixes it by unescaping them.