### PR TITLE
Fix whitespace formatting in perplexity_colors extension.

### DIFF
--- a/css/html_readable_style.css
+++ b/css/html_readable_style.css
@@ -27,3 +27,7 @@
 .container :not(pre) > code {
     white-space: normal !important;
 }
+
+.container .hoverable {
+    font-size: 14px;
+}


### PR DESCRIPTION
This is a somewhat opinionated change that fixes whitespace formatting in the perplexity_colors extension. Basically, we don't even attempt to interpret the text as markdown and render it into HTML. Instead we use a monkeypatch to just wrap the text in \<pre\> tags (with a bit of CSS to still wrap lines). This means all whitespace renders correctly, but things like italics, code blocks, or any other markdown formatting is just output as-is.

My reasoning for these larger formatting changes is that if you want to color tokens based on probability/perplexity, and especially if you're using the probability dropdown, you probably care more about seeing the actual tokens the model outputted than markdown rendered correctly. The changes also allowed me to simplify quite a few things in the code.

@SeanScripts Thoughts on bypassing the markdown rendering like this? To me it's better this way, but I want to see what others think.

![Screenshot from 2023-08-21 20-26-28](https://github.com/oobabooga/text-generation-webui/assets/6509934/c77b4f62-c08b-47cf-996c-77fba47f1003)


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
