### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ colorama
 datasets
 einops
 markdown
-numpy
+numpy==1.24
 pandas
 Pillow>=9.5.0
 pyyaml


### PR DESCRIPTION
The whisper extension needs numpy 1.24 to work properly. This version doesn't seem to break anything.

Fixes #3599

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
