### PR TITLE
Fix ctransformers threads auto-detection

### DIFF
--- a/modules/ctransformers_model.py
+++ b/modules/ctransformers_model.py
@@ -15,7 +15,7 @@ class CtransformersModel:
 
         config = AutoConfig.from_pretrained(
             str(path),
-            threads=shared.args.threads,
+            threads=shared.args.threads if shared.args.threads != 0 else -1,
             gpu_layers=shared.args.n_gpu_layers,
             batch_size=shared.args.n_batch,
             context_length=shared.args.n_ctx,


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
ctransformers uses `-1` to auto-detect threads, unlike llama.cpp which uses `0`.

I was confused as to why ctransformers was so slow, until I noticed this difference.