### PR TITLE
Fix ctransformers model unload

### DIFF
--- a/modules/ctransformers_model.py
+++ b/modules/ctransformers_model.py
@@ -10,8 +10,8 @@ class CtransformersModel:
         pass
 
     @classmethod
-    def from_pretrained(self, path):
-        result = self()
+    def from_pretrained(cls, path):
+        result = cls()
 
         config = AutoConfig.from_pretrained(
             str(path),
@@ -24,13 +24,13 @@ class CtransformersModel:
             mlock=shared.args.mlock
         )
 
-        self.model = AutoModelForCausalLM.from_pretrained(
+        result.model = AutoModelForCausalLM.from_pretrained(
             str(result.model_dir(path) if result.model_type_is_auto() else path),
             model_type=(None if result.model_type_is_auto() else shared.args.model_type),
             config=config
         )
 
-        logger.info(f'Using ctransformers model_type: {self.model.model_type} for {self.model.model_path}')
+        logger.info(f'Using ctransformers model_type: {result.model.model_type} for {result.model.model_path}')
         return result, result
 
     def model_type_is_auto(self):

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -304,7 +304,7 @@ loaders_model_types = {
         "gptneox",
         "llama",
         "mpt",
-        "dollyv2"
+        "dollyv2",
         "replit",
         "starcoder",
         "gptbigcode",


### PR DESCRIPTION
Closes marella/ctransformers#111

Currently `model` is added to `self` (points to class as it is a `classmethod`) instead of `result` which prevents it from being deleted in `unload_model()`.

Also add missing comma in model types list.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
