### PR TITLE
Added checks for missing CFG state keys to fix issues when using openai extension

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -241,16 +241,17 @@ def apply_stopping_strings(reply, all_stop_strings):
 def generate_reply_HF(question, original_question, seed, state, stopping_strings=None, is_chat=False):
     generate_params = {}
     for k in ['max_new_tokens', 'do_sample', 'temperature', 'top_p', 'typical_p', 'repetition_penalty', 'repetition_penalty_range', 'encoder_repetition_penalty', 'top_k', 'min_length', 'no_repeat_ngram_size', 'num_beams', 'penalty_alpha', 'length_penalty', 'early_stopping', 'tfs', 'top_a', 'mirostat_mode', 'mirostat_tau', 'mirostat_eta', 'guidance_scale']:
-        generate_params[k] = state[k]
+        if k in state:
+            generate_params[k] = state[k]
 
-    if state['negative_prompt'] != '':
+    if 'negative_prompt' in state and state['negative_prompt'] != '':
         generate_params['negative_prompt_ids'] = encode(state['negative_prompt'])
 
     for k in ['epsilon_cutoff', 'eta_cutoff']:
-        if state[k] > 0:
+        if k in state and state[k] > 0:
             generate_params[k] = state[k] * 1e-4
 
-    if state['ban_eos_token']:
+    if 'ban_eos_token' in state and state['ban_eos_token']:
         generate_params['suppress_tokens'] = [shared.tokenizer.eos_token_id]
 
     if shared.args.no_cache:
@@ -263,7 +264,7 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
     input_ids = encode(question, add_bos_token=state['add_bos_token'], truncation_length=get_max_prompt_length(state))
     output = input_ids[0]
     cuda = not any((shared.args.cpu, shared.args.deepspeed))
-    if state['auto_max_new_tokens']:
+    if 'auto_max_new_tokens' in state and state['auto_max_new_tokens']:
         generate_params['max_new_tokens'] = state['truncation_length'] - input_ids.shape[-1]
 
     # Add the encoded tokens to generate_params


### PR DESCRIPTION
Today I updated my local codebase and the openai api extension kept returning errors on chat completions. The error is a `HTTP 500` and this is the payload:

```json
{
  "error": {
    "message": "KeyError('guidance_scale')",
    "code": 500,
    "type": "OpenAIError",
    "param": ""
  }
}
```

Traced the issue back to [modules/text_generation.py#L244](https://github.com/oobabooga/text-generation-webui/blob/main/modules/text_generation.py#L244) and in the process found a couple more similar issues on that same function. With these changes, the openai chat completions endpoint is now working again.

How to reproduce:
- launch webui in docker, model llama2 7b chat from HF. Here's my env `CLI_ARGS=--model meta-llama_Llama-2-7b-chat-hf --model_type llama --load-in-4bit --listen --no-stream --auto-devices --chat --extension openai --n_batch 512 --n_ctx 4096`
- call the chat completions endpoint:
  ```bash
  curl -X 'POST' \
    'http://localhost:5001/chat/completions' \
    -H 'accept: application/json' \
    -H 'Content-Type: application/json' \
    -d '{
      "frequency_penalty": 0,
      "logit_bias": null,
      "max_tokens": "inf",
      "messages": [
        {
          "content": "How to make a chocolate cake?",
          "role": "user"
        }
      ],
      "model": "llama-2-7b-chat-hf",
      "n": 1,
      "presence_penalty": 0,
      "stop": null,
      "stream": false,
      "temperature": 1,
      "top_p": 1,
      "user": "user-1234"
    }'
  ```

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

