### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ fastapi==0.95.2
 gradio_client==0.2.5
 gradio==3.33.1
 
-accelerate==0.21.*
+accelerate==0.22.*
 colorama
 datasets
 einops


### PR DESCRIPTION
Updating accelerate to 0.22 solves error: ImportError: cannot import name 'is_npu_available' from 'accelerate.utils'

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
