### PR TITLE
Update download-model.py (Allow single file download)

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -131,9 +131,13 @@ class ModelDownloader:
 
         return links, sha256, is_lora
 
-    def get_output_folder(self, model, branch, is_lora, base_folder=None):
+    def get_output_folder(self, model, branch, is_lora, base_folder=None, is_gguf=False, is_ggml=False):
         if base_folder is None:
             base_folder = 'models' if not is_lora else 'loras'
+
+        # If the model is of type GGUF or GGML, save directly in the base_folder
+        if is_gguf or is_ggml:
+            return Path(base_folder)
 
         output_folder = f"{'_'.join(model.split('/')[-2:])}"
         if branch != 'main':
@@ -254,9 +258,13 @@ if __name__ == '__main__':
 
     # Getting the download links from Hugging Face
     links, sha256, is_lora = downloader.get_download_links_from_huggingface(model, branch, text_only=args.text_only, specific_bin=specific_bin)
-
+    
+    # Check if the model is of type GGUF or GGML
+    is_gguf = any(re.search(r'.*\.gguf$', link) for link in links)
+    is_ggml = any(re.search(r'.*ggml.*\.bin$', link) for link in links)    
+    
     # Getting the output folder
-    output_folder = downloader.get_output_folder(model, branch, is_lora, base_folder=args.output)
+    output_folder = downloader.get_output_folder(model, branch, is_lora, base_folder=args.output, is_gguf=is_gguf, is_ggml=is_ggml)
 
     if args.check:
         # Check previously downloaded files

--- a/download-model.py
+++ b/download-model.py
@@ -176,7 +176,7 @@ class ModelDownloader:
     def start_download_threads(self, file_list, output_folder, start_from_scratch=False, threads=1):
         thread_map(lambda url: self.get_single_file(url, output_folder, start_from_scratch=start_from_scratch), file_list, max_workers=threads, disable=True)
 
-    def download_model_files(self, model, branch, links, sha256, output_folder, progress_bar=None, start_from_scratch=False, threads=1):
+    def download_model_files(self, model, branch, links, sha256, output_folder, progress_bar=None, start_from_scratch=False, threads=1, specific_bin=None):
         self.progress_bar = progress_bar
 
         # Creating the folder and writing the metadata
@@ -192,8 +192,10 @@ class ModelDownloader:
         metadata += '\n'
         (output_folder / 'huggingface-metadata.txt').write_text(metadata)
 
-        # Downloading the files
-        print(f"Downloading the model to {output_folder}")
+        if specific_bin:
+            print(f"Downloading {specific_bin} to {output_folder}")
+        else:
+            print(f"Downloading the model to {output_folder}")        
         self.start_download_threads(links, output_folder, start_from_scratch=start_from_scratch, threads=threads)
 
     def check_model_files(self, model, branch, links, sha256, output_folder):
@@ -261,4 +263,4 @@ if __name__ == '__main__':
         downloader.check_model_files(model, branch, links, sha256, output_folder)
     else:
         # Download files
-        downloader.download_model_files(model, branch, links, sha256, output_folder, threads=args.threads)
+        downloader.download_model_files(model, branch, links, sha256, output_folder, specific_bin=specific_bin, threads=args.threads)

--- a/download-model.py
+++ b/download-model.py
@@ -73,7 +73,7 @@ class ModelDownloader:
 
             for i in range(len(dict)):
                 fname = dict[i]['path']
-                if isinstance(specific_file, str) and fname != specific_file:
+                if specific_file is not None and fname != specific_file:
                     continue
                 
                 if not is_lora and fname.endswith(('adapter_config.json', 'adapter_model.bin')):
@@ -129,7 +129,7 @@ class ModelDownloader:
                 if classifications[i] == 'ggml':
                     links.pop(i)
 
-        return links, sha256, is_lora, (has_ggml or has_gguf)
+        return links, sha256, is_lora, ((has_ggml or has_gguf) and specific_file is not None)
 
     def get_output_folder(self, model, branch, is_lora, is_llamacpp=False, base_folder=None):
         if base_folder is None:

--- a/download-model.py
+++ b/download-model.py
@@ -75,7 +75,7 @@ class ModelDownloader:
                 fname = dict[i]['path']
                 if specific_file is not None and fname != specific_file:
                     continue
-                
+
                 if not is_lora and fname.endswith(('adapter_config.json', 'adapter_model.bin')):
                     is_lora = True
 
@@ -199,7 +199,7 @@ class ModelDownloader:
         if specific_file:
             print(f"Downloading {specific_file} to {output_folder}")
         else:
-            print(f"Downloading the model to {output_folder}")        
+            print(f"Downloading the model to {output_folder}")
 
         self.start_download_threads(links, output_folder, start_from_scratch=start_from_scratch, threads=threads)
 
@@ -261,7 +261,7 @@ if __name__ == '__main__':
 
     # Get the download links from Hugging Face
     links, sha256, is_lora, is_llamacpp = downloader.get_download_links_from_huggingface(model, branch, text_only=args.text_only, specific_file=specific_file)
-    
+
     # Get the output folder
     output_folder = downloader.get_output_folder(model, branch, is_lora, is_llamacpp=is_llamacpp, base_folder=args.output)
 


### PR DESCRIPTION
## Checklist:

- [ X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

With this change, we can download a single file, and this should fix #3717 and not download the entire repo:

```
bet0x@dell:~/text-generation-webui$ python download-model.py TheBloke/Griffin-3B-GGML --specific-bin=griffin-3b.ggmlv3.q4_0.bin
Downloading griffin-3b.ggmlv3.q4_0.bin to models/TheBloke_Griffin-3B-GGML
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.93G /1.93G  4.15MiB/s
bet0x@dell:~/text-generation-webui$ ll models/TheBloke_Griffin-3B-GGML/
total 1883252
drwxrwxr-x 2 bet0x bet0x       4096 Aug 28 13:36 ./
drwxrwxr-x 4 bet0x bet0x       4096 Aug 28 13:36 ../
-rw-rw-r-- 1 bet0x bet0x 1928429856 Aug 28 13:43 griffin-3b.ggmlv3.q4_0.bin
-rw-rw-r-- 1 bet0x bet0x        208 Aug 28 13:36 huggingface-metadata.txt
bet0x@dell:~/text-generation-webui$
```