### PR TITLE
install xformers too

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,6 +60,7 @@ RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd ex
 RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/whisper_stt && pip3 install -r requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/superbooga && pip3 install -r requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/openai && pip3 install -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip . /app/venv/bin/activate && cd extensions/xformers && pip3 install -r requirements.txt
 
 COPY requirements.txt /app/requirements.txt
 RUN . /app/venv/bin/activate && \

--- a/extensions/xformers/requirements.txt
+++ b/extensions/xformers/requirements.txt
@@ -1,0 +1,1 @@
+xformers


### PR DESCRIPTION
So i have try to use --xformers, but seems it is not in the requirement.
```
Traceback (most recent call last):
  File "/xxx/text-generation-webui/modules/llama_attn_hijack.py", line 14, in <module>
    import xformers.ops
ModuleNotFoundError: No module named 'xformers'
```

I have add a requirement.txt in extensions, and now the xformers should installed when initial_installation. 

Tested with start_windows.bat. `--listen --api --verbose --auto-devices --xformers`
```
Starting API at http://0.0.0.0:5000/api
Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`.
..
2023-08-29 10:56:19 INFO:Replaced attention with xformers_attention
2023-08-29 10:56:19 INFO:Loaded the model in 11.18 seconds.
```

## Checklist:

- [Y] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
