### PR TITLE
Bump exllama to 0.0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,8 @@ https://github.com/PanQiWei/AutoGPTQ/releases/download/v0.4.2/auto_gptq-0.4.2+cu
 https://github.com/PanQiWei/AutoGPTQ/releases/download/v0.4.2/auto_gptq-0.4.2+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
 
 # ExLlama
-https://github.com/jllllll/exllama/releases/download/0.0.10/exllama-0.0.10+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"
-https://github.com/jllllll/exllama/releases/download/0.0.10/exllama-0.0.10+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
+https://github.com/jllllll/exllama/releases/download/0.0.14/exllama-0.0.14+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+https://github.com/jllllll/exllama/releases/download/0.0.14/exllama-0.0.14+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
 
 # llama-cpp-python without GPU support
 llama-cpp-python==0.1.83; platform_system != "Windows"


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
https://github.com/turboderp/exllama/compare/3dff8feee545734717cc61d5b1e2422f0a1085ca...69216d9d2a257cd2ccbc3aa14075fb178a64b541

---
Most of the commits since 0.0.10 haven't really been relevant to the webui's implementation.
The latest fix from turboderp may be relevant though: https://github.com/turboderp/exllama/commit/69216d9d2a257cd2ccbc3aa14075fb178a64b541