### PR TITLE
Just kill the /s from Vicuna-v1.1.yaml elready

### DIFF
--- a/instruction-templates/Vicuna-v1.1.yaml
+++ b/instruction-templates/Vicuna-v1.1.yaml
@@ -1,4 +1,4 @@
 user: "USER:"
 bot: "ASSISTANT:"
-turn_template: "<|user|> <|user-message|>\n<|bot|> <|bot-message|></s>\n"
+turn_template: "<|user|> <|user-message|>\n<|bot|> <|bot-message|>\n"
 context: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n\n"


### PR DESCRIPTION
I know it has been here for donkey's years and I always marveled at the logic of adding /s in turn template, but seriously, in 99% of vicuna models used today adding /s in turn will make the chat talking to itself. And I'm not aware of the 1% that needs it.

If you have some conviction that /s should be there then ignore this, but I had to doctor this every single time I do pull, because /s makes things worse in everything that uses Vicuna USER/ASSISTANT.

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
