### PR TITLE
Refine the checking branch name function of sanitize_model_and_branch…

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -40,7 +40,7 @@ class ModelDownloader:
         if branch is None:
             branch = "main"
         else:
-            pattern = re.compile(r"^[a-zA-Z0-9._-]+$")
+            pattern = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9._-]+$")
             if not pattern.match(branch):
                 raise ValueError(
                     "Invalid branch name. Only alphanumeric characters, period, underscore and dash are allowed.")


### PR DESCRIPTION
…_names in download-model.py

The branch name of git is only can begin with '0-9' or 'a-z' or 'A-Z' or '_', that can't begin with '.' or '-', for checking it precisely, I try to change the regex pattern from: ^[a-zA-Z0-9._-]+$ to ^[a-zA-Z0-9_][a-zA-Z0-9._-]+, that's restrict the first character of branch name by the partial expression: ^[a-zA-Z0-9_] to the correct character.

Hope to make text-generation-webui to be better, please review it.

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
