### PR TITLE
Exllama new rope settings

### DIFF
--- a/modules/exllama.py
+++ b/modules/exllama.py
@@ -56,9 +56,11 @@ class ExllamaModel:
             config.set_auto_map(shared.args.gpu_split)
             config.gpu_peer_fix = True
 
-        if shared.args.alpha_value > 1 or shared.args.rope_freq_base > 0:
-            config.alpha_value = RoPE.get_alpha_value(shared.args.alpha_value, shared.args.rope_freq_base)
+        if shared.args.alpha_value > 1 and shared.args.rope_freq_base == 0:
+            config.alpha_value = shared.args.alpha_value
             config.calculate_rotary_embedding_base()
+        elif shared.args.rope_freq_base > 0:
+            config.rotary_embedding_base = shared.args.rope_freq_base
 
         if torch_version.hip:
             config.rmsnorm_no_half2 = True

--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -134,9 +134,11 @@ class ExllamaHF(PreTrainedModel):
             config.set_auto_map(shared.args.gpu_split)
             config.gpu_peer_fix = True
 
-        if shared.args.alpha_value > 1 or shared.args.rope_freq_base > 0:
-            config.alpha_value = RoPE.get_alpha_value(shared.args.alpha_value, shared.args.rope_freq_base)
+        if shared.args.alpha_value > 1 and shared.args.rope_freq_base == 0:
+            config.alpha_value = shared.args.alpha_value
             config.calculate_rotary_embedding_base()
+        elif shared.args.rope_freq_base > 0:
+            config.rotary_embedding_base = shared.args.rope_freq_base
 
         if torch.version.hip:
             config.rmsnorm_no_half2 = True


### PR DESCRIPTION
The latest builds of exllama read the rope base from the model config file. They will now apply alpha value to the inferred base. This means that the current settings will produce 200k context since base is converted to an alpha value.

This PR makes alpha value apply to the read base and writing the actual theta value to use that value as an override. It helps since some tunes were not run at 1e6 and produce better perplexity with different values. The other alternative would be to allow alpha below 1 but I think that is more trouble.

code:

```
        if shared.args.alpha_value > 1 and shared.args.rope_freq_base == 0:
            config.alpha_value = shared.args.alpha_value
            config.calculate_rotary_embedding_base()
        elif shared.args.rope_freq_base > 0:
            config.rotary_embedding_base = shared.args.rope_freq_base
```