### PR TITLE
Fix: support loading absolute path of model

### DIFF
--- a/server.py
+++ b/server.py
@@ -207,9 +207,9 @@ if __name__ == "__main__":
     if shared.model_name != 'None':
         p = Path(shared.model_name)
         if p.exists():
-            model_name = p.parts[-1]
-        else:
             model_name = shared.model_name
+        else:
+            model_name = p.parts[-1]
 
         model_settings = get_model_metadata(model_name)
         shared.settings.update({k: v for k, v in model_settings.items() if k in shared.settings})  # hijacking the interface defaults


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).



## Explanation:

Previously:
When if there's no any model inside relative path `./models/`
It's expected to be able to run `--model` for a absolute path as below
`python3 server.py --listen-host 0.0.0.0 --listen --model /data/models/Llama-2-13b-chat-hf `
but it will fail:
```
ERROR:The path to the model does not exist. Exiting.
```

So this PR helps to fix it.

