### PR TITLE
Fix NTK (alpha) and RoPE scaling for exllamav2 and exllamav2_HF

### DIFF
--- a/modules/exllamav2.py
+++ b/modules/exllamav2.py
@@ -28,9 +28,9 @@ class Exllamav2Model:
         config.prepare()
 
         config.max_seq_len = shared.args.max_seq_len
-        config.rope_scale = shared.args.compress_pos_emb
-        config.rope_alpha = shared.args.alpha_value
-
+        config.scale_pos_emb = shared.args.compress_pos_emb
+        config.scale_alpha_value = shared.args.alpha_value
+        
         model = ExLlamaV2(config)
 
         split = None

--- a/modules/exllamav2_hf.py
+++ b/modules/exllamav2_hf.py
@@ -116,7 +116,7 @@ class Exllamav2HF(PreTrainedModel):
         config.prepare()
 
         config.max_seq_len = shared.args.max_seq_len
-        config.rope_scale = shared.args.compress_pos_emb
-        config.rope_alpha = shared.args.alpha_value
+        config.scale_pos_emb = shared.args.compress_pos_emb
+        config.scale_alpha_value = shared.args.alpha_value
 
         return Exllamav2HF(config)


### PR DESCRIPTION
## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

Small fix discussed with @turboderp, since it uses different config.names for both alpha for NTK scaling and RoPE scaling. (Now they're on config.py)

Fixes gibberish >4096 ctx and alpha values greater than 1 for llama2 based models. >2048 respectively for llama1 based models.

Fixes gibberish for 4k/8k/16k/etc ctx and their respective embedding compression.