### PR TITLE
feat: add option to follow system theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ When you load this model in default or notebook modes, the "HTML" tab will show 
 
 Then browse to 
 
-`http://localhost:7860/?__theme=dark`
+`http://localhost:7860`
 
 Optionally, you can use the following command-line flags:
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -28,7 +28,7 @@ session_is_loading = False
 
 # UI defaults
 settings = {
-    'dark_theme': True,
+    'theme': 'system', # system, light, or dark
     'show_controls': True,
     'start_with': '',
     'mode': 'chat',

--- a/server.py
+++ b/server.py
@@ -126,9 +126,29 @@ def create_interface():
         ui_model_menu.create_event_handlers()
 
         # Interface launch events
-        if shared.settings['dark_theme']:
+        if shared.settings['theme'] == "light":
+            shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.remove('dark')")
+        elif shared.settings['theme'] == "dark":
             shared.gradio['interface'].load(lambda: None, None, None, _js="() => document.getElementsByTagName('body')[0].classList.add('dark')")
-
+        else: # default = system
+            shared.gradio['interface'].load(lambda: None, None, None, _js="""
+() => { 
+	const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)');
+	const bodyClassList = document.getElementsByTagName('body')[0].classList;
+	if (darkThemeMq.matches) { // first run
+		bodyClassList.add('dark');
+	} else {
+		bodyClassList.remove('dark');
+	};
+	darkThemeMq.addListener(e => { // on OS theme change
+		if (e.matches) {
+			bodyClassList.add('dark');
+		} else {
+			bodyClassList.remove('dark');
+		};
+	});
+}
+            """)
         shared.gradio['interface'].load(lambda: None, None, None, _js=f"() => {{{js}}}")
         shared.gradio['interface'].load(None, gradio('show_controls'), None, _js=f'(x) => {{{ui.show_controls_js}; toggle_controls(x)}}')
         shared.gradio['interface'].load(partial(ui.apply_interface_values, {}, use_persistent=True), None, gradio(ui.list_interface_input_elements()), show_progress=False)

--- a/settings-template.yaml
+++ b/settings-template.yaml
@@ -1,6 +1,6 @@
-dark_theme: true
+theme: "system" # system, light, or dark
 show_controls: true
-start_with: ''
+start_with: ""
 mode: chat
 chat_style: cai-chat
 character: None
@@ -11,11 +11,11 @@ max_new_tokens: 200
 max_new_tokens_min: 1
 max_new_tokens_max: 4096
 seed: -1
-negative_prompt: ''
+negative_prompt: ""
 truncation_length: 2048
 truncation_length_min: 0
 truncation_length_max: 16384
-custom_stopping_strings: ''
+custom_stopping_strings: ""
 auto_max_new_tokens: false
 max_tokens_second: 0
 ban_eos_token: false
@@ -25,7 +25,7 @@ stream: true
 name1: You
 name2: Assistant
 context: This is a conversation with your Assistant. It is a computer program designed to help you with various tasks such as answering questions, providing recommendations, and helping with decision making. You can ask it anything you want and it will do its best to give you accurate and relevant information.
-greeting: ''
+greeting: ""
 instruction_template: Alpaca
 chat-instruct_command: |-
   Continue the chat dialogue below. Write a single reply for the character "<|character|>".
@@ -33,4 +33,4 @@ chat-instruct_command: |-
   <|prompt|>
 autoload_model: false
 default_extensions:
-- gallery
+  - gallery


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

This PR adds a new setting `theme` that introduces the ability for WebUI to follow the system theme. So if the browser is dark, WebUI is dark, and if the browser is light, WebUI is light.

The valid values are **system** (default), **light**, and **dark**. 

Perhaps in the future we can introduce additional themes such as "high_contrast".

This also deprecates the old `dark_theme` setting.