### PR TITLE
Fix pydantic version conflict in elevenlabs extension

### DIFF
--- a/extensions/elevenlabs_tts/requirements.txt
+++ b/extensions/elevenlabs_tts/requirements.txt
@@ -1,1 +1,1 @@
-elevenlabs==0.2.*
+elevenlabs==0.2.24


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
It seems that the `elevenlabs` package updated to using `pydantic` 2.0 in [0.2.25](https://github.com/elevenlabs/elevenlabs-python/releases/tag/v0.2.25), which would require `gradio` 3.37.0 and `gradio_client` 0.2.10 to work.

Tried updating the webui with those versions and it just breaks the UI layout.

Fixes: #3905