### PR TITLE
Fix use of functools decorators before Python 3.9

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -4,6 +4,7 @@ import functools
 import html
 import json
 import re
+import sys
 from pathlib import Path
 
 import gradio as gr
@@ -520,12 +521,18 @@ def load_character(character, name1, name2, instruct=False):
 
     return name1, name2, picture, greeting, context, turn_template.replace("\n", r"\n")
 
+# use appropriate functools decorator according to python version
+if sys.version_info < (3, 9, 0):
+    @functools.lru_cache(maxsize=None)
+    def load_character_memoized(character, name1, name2, instruct=False):
+        return load_character(character, name1, name2, instruct=instruct)
 
-@functools.cache
-def load_character_memoized(character, name1, name2, instruct=False):
-    return load_character(character, name1, name2, instruct=instruct)
+else:
+    @functools.cache
+    def load_character_memoized(character, name1, name2, instruct=False):
+        return load_character(character, name1, name2, instruct=instruct)
 
-
+   
 def upload_character(file, img, tavern=False):
     decoded_file = file if type(file) == str else file.decode('utf-8')
     try:

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -1,9 +1,11 @@
 import functools
 from collections import OrderedDict
+import sys
 
 import gradio as gr
 
 from modules import shared
+
 
 loaders_and_params = OrderedDict({
     'Transformers': [
@@ -308,15 +310,26 @@ loaders_model_types = {
     ],
 }
 
-
-@functools.cache
-def list_all_samplers():
-    all_samplers = set()
-    for k in loaders_samplers:
-        for sampler in loaders_samplers[k]:
-            all_samplers.add(sampler)
-
-    return sorted(all_samplers)
+# use appropriate functools decorator according to python version
+if sys.version_info < (3, 9, 0):
+    @functools.lru_cache(maxsize=None)
+    def list_all_samplers():
+        all_samplers = set()
+        for k in loaders_samplers:
+            for sampler in loaders_samplers[k]:
+                all_samplers.add(sampler)
+    
+        return sorted(all_samplers)
+    
+else:
+    @functools.cache
+    def list_all_samplers():
+        all_samplers = set()
+        for k in loaders_samplers:
+            for sampler in loaders_samplers[k]:
+                all_samplers.add(sampler)
+    
+        return sorted(all_samplers)
 
 
 def blacklist_samplers(loader):
@@ -337,20 +350,36 @@ def get_model_types(loader):
 def get_gpu_memory_keys():
     return [k for k in shared.gradio if k.startswith('gpu_memory')]
 
+# use appropriate functools decorator according to python version
+if sys.version_info < (3, 9, 0):
+    @functools.lru_cache(maxsize=None)
+    def get_all_params():
+        all_params = set()
+        for k in loaders_and_params:
+            for el in loaders_and_params[k]:
+                all_params.add(el)
 
-@functools.cache
-def get_all_params():
-    all_params = set()
-    for k in loaders_and_params:
-        for el in loaders_and_params[k]:
-            all_params.add(el)
+        if 'gpu_memory' in all_params:
+            all_params.remove('gpu_memory')
+            for k in get_gpu_memory_keys():
+                all_params.add(k)
 
-    if 'gpu_memory' in all_params:
-        all_params.remove('gpu_memory')
-        for k in get_gpu_memory_keys():
-            all_params.add(k)
+        return sorted(all_params)
 
-    return sorted(all_params)
+else:
+    @functools.cache
+    def get_all_params():
+        all_params = set()
+        for k in loaders_and_params:
+            for el in loaders_and_params[k]:
+                all_params.add(el)
+
+        if 'gpu_memory' in all_params:
+            all_params.remove('gpu_memory')
+            for k in get_gpu_memory_keys():
+                all_params.add(k)
+
+        return sorted(all_params)
 
 
 def make_loader_params_visible(loader):

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -1,5 +1,6 @@
 import functools
 from pathlib import Path
+import sys
 
 import yaml
 
@@ -47,10 +48,15 @@ def load_preset(name):
     generate_params['temperature'] = min(1.99, generate_params['temperature'])
     return generate_params
 
-
-@functools.cache
-def load_preset_memoized(name):
-    return load_preset(name)
+# use appropriate functools decorator according to python version
+if sys.version_info < (3, 9, 0):
+    @functools.lru_cache(maxsize=None)
+    def load_preset_memoized(name):
+        return load_preset(name)
+else:
+    @functools.cache
+    def load_preset_memoized(name):
+        return load_preset(name)
 
 
 def load_preset_for_ui(name, state):


### PR DESCRIPTION
Add check on python version prior to using functools cache decorators to provide compatability with Python versions earlier than 3.9.   
I tested successfully with Python 3.8 on Ubuntu 20.04.

Fixes #3808 

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
