### PR TITLE
Move Regenerate, Remove Last, and Continue out of hover menu.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -306,7 +306,7 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     }
 
     .chat-parent {
-        height: calc(100dvh - 179px) !important;
+        height: calc(100dvh - 238px) !important;
     }
 }
 
@@ -324,7 +324,7 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
 }
 
 .chat-parent {
-    height: calc(100dvh - 181px);
+    height: calc(100dvh - 240px);
     overflow: auto !important;
 }
 
@@ -500,7 +500,7 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
   width: 100%;
   background: transparent !important;
   border-radius: 0px !important;
-  justify-content: left;
+  justify-content: space-between;
   margin: 0 !important;
 }
 
@@ -514,6 +514,31 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
 
 .hover-menu button:hover {
   background: var(--button-secondary-background-fill-hover) !important;
+}
+
+#gr-hover-container {
+  min-width: 0 !important;
+  display: flex;
+  flex-direction: column-reverse;
+  padding-right: 20px;
+  padding-bottom: 3px;
+  flex-grow: 0 !important;
+}
+
+#generate-stop-container {
+  min-width: 0 !important;
+  display: flex;
+  flex-direction: column-reverse;
+  padding-bottom: 3px;
+}
+
+#chat-input-container {
+  min-width: 0 !important;
+}
+
+#chat-input-container > .form {
+  background: transparent;
+  border: none;
 }
 
 .transparent-substring {

--- a/js/main.js
+++ b/js/main.js
@@ -214,28 +214,6 @@ for(i = 0; i < textareaElements.length; i++) {
 }
 
 //------------------------------------------------
-// Improve the looks of the chat input field
-//------------------------------------------------
-document.getElementById('chat-input').parentNode.style.background = 'transparent';
-document.getElementById('chat-input').parentNode.style.border = 'none';
-document.getElementById('chat-input').parentElement.parentElement.style.minWidth = 0;
-
-document.getElementById('stop').parentElement.parentElement.style.minWidth = 0;
-document.getElementById('stop').parentElement.parentElement.style.display = 'flex';
-document.getElementById('stop').parentElement.parentElement.style.flexDirection = 'column-reverse';
-document.getElementById('stop').parentElement.parentElement.style.paddingBottom = '3px';
-document.getElementById('stop').parentElement.parentElement.parentElement.style.paddingBottom = '20px';
-
-document.getElementById('stop').parentElement.parentElement.style.flex = '0 0 auto';
-
-document.getElementById('gr-hover').parentElement.style.minWidth = 0;
-document.getElementById('gr-hover').parentElement.style.display = 'flex';
-document.getElementById('gr-hover').parentElement.style.flexDirection = 'column-reverse';
-document.getElementById('gr-hover').parentElement.style.flex = '0';
-document.getElementById('gr-hover').parentElement.style.paddingRight = '20px';
-document.getElementById('gr-hover').parentElement.style.paddingBottom = '3px';
-
-//------------------------------------------------
 // Remove some backgrounds
 //------------------------------------------------
 const noBackgroundelements = document.querySelectorAll('.no-background');
@@ -261,7 +239,7 @@ function hideMenu() {
     menu.style.display = 'none'; // Hide the menu
 }
 
-for (let i = 14; i >= 2; i--) {
+for (let i = 14; i >= 5; i--) {
   const thisButton = buttonsInChat[i];
   menu.appendChild(thisButton);
 
@@ -277,7 +255,7 @@ for (let i = 14; i >= 2; i--) {
   if (matches && matches.length > 1) {
     // Apply the transparent-substring class to the matched substring
     const substring = matches[1];
-    const newText = buttonText.replace(substring, `&nbsp;<span class="transparent-substring">${substring}</span>`);
+    const newText = buttonText.replace(substring, `&nbsp;<span class="transparent-substring">${substring.slice(1, -1)}</span>`);
     thisButton.innerHTML = newText;
   }
 

--- a/js/show_controls.js
+++ b/js/show_controls.js
@@ -8,15 +8,15 @@ function toggle_controls(value) {
         });
 
         chatParent.classList.remove("bigchat");
-        document.getElementById('stop').parentElement.parentElement.parentElement.style.paddingBottom = '20px';
         document.getElementById('show-controls').parentNode.parentNode.style.paddingBottom = '115px';
+        document.querySelector('.chat-parent').style.height = 'calc(100dvh - 240px)';
     } else {
         belowChatInput.forEach(element => {
           element.style.display = "none";
         });
 
         chatParent.classList.add("bigchat");
-        document.getElementById('stop').parentElement.parentElement.parentElement.style.paddingBottom = '0px';
         document.getElementById('show-controls').parentNode.parentNode.style.paddingBottom = '95px';
+        document.querySelector('.chat-parent').style.height = 'calc(100dvh - 181px)';
     }
 }

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -24,25 +24,26 @@ def create_ui():
         with gr.Row():
             with gr.Column():
                 shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'))
-
                 with gr.Row():
-                    with gr.Column(scale=1):
+                    with gr.Column(scale=1, elem_id='gr-hover-container'):
                         gr.HTML(value='<div class="hover-element" onclick="void(0)"><span style="width: 100px; display: block" id="hover-element-button">&#9776;</span><div class="hover-menu" id="hover-menu"></div>', elem_id='gr-hover')
 
-                    with gr.Column(scale=10):
+                    with gr.Column(scale=10, elem_id='chat-input-container'):
                         shared.gradio['textbox'] = gr.Textbox(label='', placeholder='Send a message', elem_id='chat-input', elem_classes=['add_scrollbar'])
                         shared.gradio['show_controls'] = gr.Checkbox(value=shared.settings['show_controls'], label='Show controls (Ctrl+S)', elem_id='show-controls')
                         shared.gradio['typing-dots'] = gr.HTML(value='<div class="typing"><span></span><span class="dot1"></span><span class="dot2"></span></div>', label='typing', elem_id='typing-container')
 
-                    with gr.Column(scale=1):
+                    with gr.Column(scale=1, elem_id='generate-stop-container'):
                         with gr.Row():
                             shared.gradio['Stop'] = gr.Button('Stop', elem_id='stop', visible=False)
                             shared.gradio['Generate'] = gr.Button('Generate', elem_id='Generate', variant='primary')
 
+        with gr.Row():
+            shared.gradio['Regenerate'] = gr.Button('Regenerate', elem_id='Regenerate')
+            shared.gradio['Continue'] = gr.Button('Continue', elem_id='Continue')
+            shared.gradio['Remove last'] = gr.Button('Remove last reply', elem_id='Remove-last')
+
         # Hover menu buttons
-        shared.gradio['Regenerate'] = gr.Button('Regenerate (Ctrl + Enter)', elem_id='Regenerate')
-        shared.gradio['Continue'] = gr.Button('Continue (Alt + Enter)', elem_id='Continue')
-        shared.gradio['Remove last'] = gr.Button('Remove last reply (Ctrl + Shift + Backspace)', elem_id='Remove-last')
         shared.gradio['Replace last reply'] = gr.Button('Replace last reply (Ctrl + Shift + L)', elem_id='Replace-last')
         shared.gradio['Copy last reply'] = gr.Button('Copy last reply (Ctrl + Shift + K)', elem_id='Copy-last')
         shared.gradio['Impersonate'] = gr.Button('Impersonate (Ctrl + Shift + M)', elem_id='Impersonate')


### PR DESCRIPTION
## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

Since I already have it working...

It also moves some styles from JS to CSS, and adjusts the hover menu shortcut text.
![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/9ae05630-2ac7-459f-903a-acc46732b8ed)
These could probably be moved and restyled to fit the way you want them.

Personally, I prefer the old UI. Moving everything to a menu is just too big of a change.