### PR TITLE
hugginfce loader disable_exllama

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -182,6 +182,7 @@ def huggingface_loader(model_name):
                     'bnb_4bit_compute_dtype': eval("torch.{}".format(shared.args.compute_dtype)) if shared.args.compute_dtype in ["bfloat16", "float16", "float32"] else None,
                     'bnb_4bit_quant_type': shared.args.quant_type,
                     'bnb_4bit_use_double_quant': shared.args.use_double_quant,
+                    'disable_exllama' : True
                 }
 
                 logger.warning("Using the following 4-bit params: " + str(quantization_config_params))


### PR DESCRIPTION
We had discussion about it, I know, but I think that in all use cases, we should simply 'disable_exllama' : True in Transformers loader. 

It's supposed to be applicable only to quantized 4-bit and not unquantized but loaded as 4-bit using bnb but you know what if I:
- train lora on HF loaded as 4-bit bnb with disable_exllama' : False and
- interference HF loaded as 4-bit in bnb with that above LORA applied and disable_exllama' : False

I get a really bad results. 

If I disable exllama with
disable_exllama' : True
and do the same as above
all is good as it was before they sneaked exllama backend in. 
So call me paranoid. IDK. 

In worse case disable_exllama' : True will have no effect at all. So I suggest to simply put this in the Transformers loader - we have a few exllama loaders anyhow. I don't think we need Transformer loader that "may or may not" use exllama in some cases. Not to mention that even transformer docs suggest to disable_exllama in more than one place...

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
