### PR TITLE
Better solution to chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Optionally, you can use the following command-line flags:
 | `--gradio-auth-path GRADIO_AUTH_PATH` | Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3" |
 | `--ssl-keyfile SSL_KEYFILE`           | The path to the SSL certificate key file. |
 | `--ssl-certfile SSL_CERTFILE`         | The path to the SSL certificate cert file. |
+| `--chat-buttons`                      | Show buttons on chat tab instead of hover menu. |
 
 #### API
 

--- a/css/main.css
+++ b/css/main.css
@@ -524,3 +524,7 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
 .transparent-substring {
   opacity: 0.333;
 }
+
+#chat-buttons:not(.old-ui) {
+    display: none !important;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -330,6 +330,14 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     overflow: auto !important;
 }
 
+.chat-parent.old-ui {
+    height: calc(100dvh - 290px);
+}
+
+.bigchat {
+    height: calc(100dvh - 181px) !important;
+}
+
 .chat > .messages {
     display: flex;
     flex-direction: column;

--- a/js/main.js
+++ b/js/main.js
@@ -250,6 +250,7 @@ for(i = 0; i < noBackgroundelements.length; i++) {
 // https://github.com/SillyTavern/SillyTavern/blob/6c8bd06308c69d51e2eb174541792a870a83d2d6/public/script.js
 //------------------------------------------------
 var buttonsInChat = document.querySelectorAll("#chat-tab #chat-buttons:not(.old-ui) button");
+console.log(buttonsInChat);
 var button = document.getElementById('hover-element-button');
 var menu = document.getElementById('hover-menu');
 
@@ -266,7 +267,7 @@ if (buttonsInChat.length > 0) {
         const thisButton = buttonsInChat[i];
         menu.appendChild(thisButton);
 
-        if(i != 10) {
+        if(i != 8) {
             thisButton.addEventListener("click", () => {
                 hideMenu();
             });

--- a/js/main.js
+++ b/js/main.js
@@ -249,7 +249,7 @@ for(i = 0; i < noBackgroundelements.length; i++) {
 // The show/hide events were adapted from:
 // https://github.com/SillyTavern/SillyTavern/blob/6c8bd06308c69d51e2eb174541792a870a83d2d6/public/script.js
 //------------------------------------------------
-const buttonsInChat = document.querySelectorAll("#chat-tab #chat-buttons:not(.old-ui) button");
+var buttonsInChat = document.querySelectorAll("#chat-tab #chat-buttons:not(.old-ui) button");
 var button = document.getElementById('hover-element-button');
 var menu = document.getElementById('hover-menu');
 
@@ -283,6 +283,11 @@ if (buttonsInChat.length > 0) {
         }
     }
 } else {
+    buttonsInChat = document.querySelectorAll("#chat-tab #chat-buttons.old-ui button");
+    console.log(buttonsInChat);
+    for (let i = 0; i < buttonsInChat.length; i++) {
+        buttonsInChat[i].textContent = buttonsInChat[i].textContent.replace(/ \(.*?\)/, '');
+    }
     document.getElementById('gr-hover').parentElement.style.display = 'none';
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -282,6 +282,8 @@ if (buttonsInChat.length > 0) {
             thisButton.innerHTML = newText;
         }
     }
+} else {
+    document.getElementById('gr-hover').parentElement.style.display = 'none';
 }
 
 function isMouseOverButtonOrMenu() {

--- a/js/main.js
+++ b/js/main.js
@@ -250,7 +250,6 @@ for(i = 0; i < noBackgroundelements.length; i++) {
 // https://github.com/SillyTavern/SillyTavern/blob/6c8bd06308c69d51e2eb174541792a870a83d2d6/public/script.js
 //------------------------------------------------
 var buttonsInChat = document.querySelectorAll("#chat-tab #chat-buttons:not(.old-ui) button");
-console.log(buttonsInChat);
 var button = document.getElementById('hover-element-button');
 var menu = document.getElementById('hover-menu');
 

--- a/js/main.js
+++ b/js/main.js
@@ -249,7 +249,7 @@ for(i = 0; i < noBackgroundelements.length; i++) {
 // The show/hide events were adapted from:
 // https://github.com/SillyTavern/SillyTavern/blob/6c8bd06308c69d51e2eb174541792a870a83d2d6/public/script.js
 //------------------------------------------------
-const buttonsInChat = document.getElementById("chat-tab").querySelectorAll("button");
+const buttonsInChat = document.querySelectorAll("#chat-tab #chat-buttons:not(.old-ui) button");
 var button = document.getElementById('hover-element-button');
 var menu = document.getElementById('hover-menu');
 
@@ -261,26 +261,27 @@ function hideMenu() {
     menu.style.display = 'none'; // Hide the menu
 }
 
-for (let i = 14; i >= 2; i--) {
-  const thisButton = buttonsInChat[i];
-  menu.appendChild(thisButton);
+if (buttonsInChat.length > 0) {
+    for (let i = buttonsInChat.length - 1; i >= 0; i--) {
+        const thisButton = buttonsInChat[i];
+        menu.appendChild(thisButton);
 
-  if(i != 10) {
-    thisButton.addEventListener("click", () => {
-      hideMenu();
-    });
-  }
+        if(i != 10) {
+            thisButton.addEventListener("click", () => {
+                hideMenu();
+            });
+        }
 
-  const buttonText = thisButton.textContent;
-  const matches = buttonText.match(/(\(.*?\))/);
+        const buttonText = thisButton.textContent;
+        const matches = buttonText.match(/(\(.*?\))/);
 
-  if (matches && matches.length > 1) {
-    // Apply the transparent-substring class to the matched substring
-    const substring = matches[1];
-    const newText = buttonText.replace(substring, `&nbsp;<span class="transparent-substring">${substring}</span>`);
-    thisButton.innerHTML = newText;
-  }
-
+        if (matches && matches.length > 1) {
+            // Apply the transparent-substring class to the matched substring
+            const substring = matches[1];
+            const newText = buttonText.replace(substring, `&nbsp;<span class="transparent-substring">${substring}</span>`);
+            thisButton.innerHTML = newText;
+        }
+    }
 }
 
 function isMouseOverButtonOrMenu() {

--- a/js/show_controls.js
+++ b/js/show_controls.js
@@ -1,5 +1,5 @@
 const belowChatInput = document.querySelectorAll("#chat-tab > div > :nth-child(n+2), #extensions");
-const chatParent = document.getElementById("chat").parentNode.parentNode.parentNode;
+const chatParent = document.querySelector(".chat-parent");
 
 function toggle_controls(value) {
     if (value) {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -91,7 +91,7 @@ parser.add_argument('--no-stream', action='store_true', help='DEPRECATED')
 parser.add_argument('--settings', type=str, help='Load the default interface settings from this yaml file. See settings-template.yaml for an example. If you create a file called settings.yaml, this file will be loaded by default without the need to use the --settings flag.')
 parser.add_argument('--extensions', type=str, nargs="+", help='The list of extensions to load. If you want to load more than one extension, write the names separated by spaces.')
 parser.add_argument('--verbose', action='store_true', help='Print the prompts to the terminal.')
-parser.add_argument('--old-chat-ui', action='store_true', help='Use the old chat UI.')
+parser.add_argument('--chat-tab-buttons', action='store_true', help='Show buttons on chat tab instead of hover menu.')
 
 # Model loader
 parser.add_argument('--loader', type=str, help='Choose the model loader manually, otherwise, it will get autodetected. Valid options: transformers, autogptq, gptq-for-llama, exllama, exllama_hf, llamacpp, rwkv')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -91,7 +91,7 @@ parser.add_argument('--no-stream', action='store_true', help='DEPRECATED')
 parser.add_argument('--settings', type=str, help='Load the default interface settings from this yaml file. See settings-template.yaml for an example. If you create a file called settings.yaml, this file will be loaded by default without the need to use the --settings flag.')
 parser.add_argument('--extensions', type=str, nargs="+", help='The list of extensions to load. If you want to load more than one extension, write the names separated by spaces.')
 parser.add_argument('--verbose', action='store_true', help='Print the prompts to the terminal.')
-parser.add_argument('--chat-tab-buttons', action='store_true', help='Show buttons on chat tab instead of hover menu.')
+parser.add_argument('--chat-buttons', action='store_true', help='Show buttons on chat tab instead of hover menu.')
 
 # Model loader
 parser.add_argument('--loader', type=str, help='Choose the model loader manually, otherwise, it will get autodetected. Valid options: transformers, autogptq, gptq-for-llama, exllama, exllama_hf, llamacpp, rwkv')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -91,6 +91,7 @@ parser.add_argument('--no-stream', action='store_true', help='DEPRECATED')
 parser.add_argument('--settings', type=str, help='Load the default interface settings from this yaml file. See settings-template.yaml for an example. If you create a file called settings.yaml, this file will be loaded by default without the need to use the --settings flag.')
 parser.add_argument('--extensions', type=str, nargs="+", help='The list of extensions to load. If you want to load more than one extension, write the names separated by spaces.')
 parser.add_argument('--verbose', action='store_true', help='Print the prompts to the terminal.')
+parser.add_argument('--old-chat-ui', action='store_true', help='Use the old chat UI.')
 
 # Model loader
 parser.add_argument('--loader', type=str, help='Choose the model loader manually, otherwise, it will get autodetected. Valid options: transformers, autogptq, gptq-for-llama, exllama, exllama_hf, llamacpp, rwkv')

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -23,7 +23,7 @@ def create_ui():
     with gr.Tab('Chat', elem_id='chat-tab'):
         with gr.Row():
             with gr.Column():
-                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'), elem_classes=("old-ui" if shared.args.old_chat_ui else None))
+                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'), elem_classes=("old-ui" if shared.args.chat_tab_buttons else None))
 
                 with gr.Row():
                     with gr.Column(scale=1):
@@ -40,7 +40,7 @@ def create_ui():
                             shared.gradio['Generate'] = gr.Button('Generate', elem_id='Generate', variant='primary')
 
         # Hover menu buttons
-        with gr.Column(elem_id='chat-buttons', elem_classes=("old-ui" if shared.args.old_chat_ui else None)):
+        with gr.Column(elem_id='chat-buttons', elem_classes=("old-ui" if shared.args.chat_tab_buttons else None)):
             with gr.Row():
                 shared.gradio['Regenerate'] = gr.Button('Regenerate (Ctrl + Enter)', elem_id='Regenerate')
                 shared.gradio['Continue'] = gr.Button('Continue (Alt + Enter)', elem_id='Continue')

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -40,19 +40,25 @@ def create_ui():
                             shared.gradio['Generate'] = gr.Button('Generate', elem_id='Generate', variant='primary')
 
         # Hover menu buttons
-        shared.gradio['Regenerate'] = gr.Button('Regenerate (Ctrl + Enter)', elem_id='Regenerate')
-        shared.gradio['Continue'] = gr.Button('Continue (Alt + Enter)', elem_id='Continue')
-        shared.gradio['Remove last'] = gr.Button('Remove last reply (Ctrl + Shift + Backspace)', elem_id='Remove-last')
-        shared.gradio['Replace last reply'] = gr.Button('Replace last reply (Ctrl + Shift + L)', elem_id='Replace-last')
-        shared.gradio['Copy last reply'] = gr.Button('Copy last reply (Ctrl + Shift + K)', elem_id='Copy-last')
-        shared.gradio['Impersonate'] = gr.Button('Impersonate (Ctrl + Shift + M)', elem_id='Impersonate')
-        shared.gradio['Send dummy message'] = gr.Button('Send dummy message')
-        shared.gradio['Send dummy reply'] = gr.Button('Send dummy reply')
-        shared.gradio['Clear history'] = gr.Button('Clear history')
-        shared.gradio['Clear history-cancel'] = gr.Button('Cancel', visible=False)
-        shared.gradio['Clear history-confirm'] = gr.Button('Confirm', variant='stop', visible=False, elem_id='clear-history-confirm')
-        shared.gradio['send-chat-to-default'] = gr.Button('Send to default')
-        shared.gradio['send-chat-to-notebook'] = gr.Button('Send to notebook')
+        with gr.Column(elem_id='chat-buttons', elem_classes=("old-ui" if shared.args.old_chat_ui else None)):
+            with gr.Row():
+                shared.gradio['Regenerate'] = gr.Button('Regenerate (Ctrl + Enter)', elem_id='Regenerate')
+                shared.gradio['Continue'] = gr.Button('Continue (Alt + Enter)', elem_id='Continue')
+                shared.gradio['Remove last'] = gr.Button('Remove last reply (Ctrl + Shift + Backspace)', elem_id='Remove-last')
+            with gr.Row():
+                shared.gradio['Replace last reply'] = gr.Button('Replace last reply (Ctrl + Shift + L)', elem_id='Replace-last')
+                shared.gradio['Copy last reply'] = gr.Button('Copy last reply (Ctrl + Shift + K)', elem_id='Copy-last')
+                shared.gradio['Impersonate'] = gr.Button('Impersonate (Ctrl + Shift + M)', elem_id='Impersonate')
+            with gr.Row():
+                shared.gradio['Send dummy message'] = gr.Button('Send dummy message')
+                shared.gradio['Send dummy reply'] = gr.Button('Send dummy reply')
+            with gr.Row():
+                shared.gradio['Clear history'] = gr.Button('Clear history')
+                shared.gradio['Clear history-cancel'] = gr.Button('Cancel', visible=False)
+                shared.gradio['Clear history-confirm'] = gr.Button('Confirm', variant='stop', visible=False, elem_id='clear-history-confirm')
+            with gr.Row():
+                shared.gradio['send-chat-to-default'] = gr.Button('Send to default')
+                shared.gradio['send-chat-to-notebook'] = gr.Button('Send to notebook')
 
         with gr.Row():
             shared.gradio['start_with'] = gr.Textbox(label='Start reply with', placeholder='Sure thing!', value=shared.settings['start_with'])

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -23,7 +23,7 @@ def create_ui():
     with gr.Tab('Chat', elem_id='chat-tab'):
         with gr.Row():
             with gr.Column():
-                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'), elem_classes=("old-ui" if shared.args.chat_tab_buttons else None))
+                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'), elem_classes=("old-ui" if shared.args.chat_buttons else None))
 
                 with gr.Row():
                     with gr.Column(scale=1):
@@ -40,7 +40,7 @@ def create_ui():
                             shared.gradio['Generate'] = gr.Button('Generate', elem_id='Generate', variant='primary')
 
         # Hover menu buttons
-        with gr.Column(elem_id='chat-buttons', elem_classes=("old-ui" if shared.args.chat_tab_buttons else None)):
+        with gr.Column(elem_id='chat-buttons', elem_classes=("old-ui" if shared.args.chat_buttons else None)):
             with gr.Row():
                 shared.gradio['Regenerate'] = gr.Button('Regenerate (Ctrl + Enter)', elem_id='Regenerate')
                 shared.gradio['Continue'] = gr.Button('Continue (Alt + Enter)', elem_id='Continue')

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -23,7 +23,7 @@ def create_ui():
     with gr.Tab('Chat', elem_id='chat-tab'):
         with gr.Row():
             with gr.Column():
-                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'))
+                shared.gradio['display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, shared.settings['name1'], shared.settings['name2'], 'chat', 'cai-chat'), elem_classes=("old-ui" if shared.args.old_chat_ui else None))
 
                 with gr.Row():
                     with gr.Column(scale=1):


### PR DESCRIPTION
## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

A more elegant method of making the hover menu optional.

- Existing buttons are arranged (similar to) how they were before. If `--chat-buttons` is set, hover menu creation is skipped and its button is hidden.
- Doesn't duplicate code like my previous attempt. 
- Buttons are aligned like they were before and `Show Controls` functions as expected.
- Generate/Stop remains where it is in both modes.

![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/c0b4727b-390e-411f-a64d-a3d94bb32bb8)

