### PR TITLE
Stops the generation immediately when using the "Maximum number of tokens/second" setting

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -88,7 +88,6 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False, escap
                     time.sleep(diff)
 
                 last_update = time.time()
-                # Avant de yield, vérifiez à nouveau.
                 if shared.stop_everything:
                     break
                 yield reply
@@ -97,7 +96,6 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False, escap
             else:
                 if cur_time - last_update > 0.041666666666666664:
                     last_update = cur_time
-                    # Avant de yield, vérifiez à nouveau.
                     if shared.stop_everything:
                         break
                     yield reply

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -88,19 +88,15 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False, escap
                     time.sleep(diff)
 
                 last_update = time.time()
-                if shared.stop_everything:
-                    break
                 yield reply
 
             # Limit updates to 24 per second to not stress low latency networks
             else:
                 if cur_time - last_update > 0.041666666666666664:
                     last_update = cur_time
-                    if shared.stop_everything:
-                        break
                     yield reply
-                    
-        if stop_found:
+
+        if stop_found or (state['max_tokens_second'] > 0 and shared.stop_everything):
             break
 
     if not is_chat:

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -88,13 +88,20 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False, escap
                     time.sleep(diff)
 
                 last_update = time.time()
+                # Avant de yield, vérifiez à nouveau.
+                if shared.stop_everything:
+                    break
                 yield reply
 
             # Limit updates to 24 per second to not stress low latency networks
             else:
                 if cur_time - last_update > 0.041666666666666664:
                     last_update = cur_time
+                    # Avant de yield, vérifiez à nouveau.
+                    if shared.stop_everything:
+                        break
                     yield reply
+                    
 
         if stop_found:
             break

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -100,7 +100,6 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False, escap
                         break
                     yield reply
                     
-
         if stop_found:
             break
 


### PR DESCRIPTION
Hello,

When using the "Maximum number of tokens/second" setting, if you start to generate and then press the "Stop" button, it doesn't really stop immediately, it's due to the fact that it's waiting for the whole generation (the one with the full speed) to display all its tokens.

This simple code fixes that and makes the Stop button an immediate stop in this situation.