### PR TITLE
token probs for non HF loaders

### DIFF
--- a/modules/exllama.py
+++ b/modules/exllama.py
@@ -192,3 +192,8 @@ class ExllamaModel:
 
     def decode(self, string, **kwargs):
         return self.tokenizer.decode(string)[0]
+
+    def get_logits(self, token_ids, **kwargs):
+        self.cache.current_seq_len = 0
+        self.model.forward(token_ids[:, :-1], self.cache, input_mask=None, preprocess_only=True)
+        return self.model.forward(token_ids[:, -1:], self.cache, **kwargs).float().cpu()

--- a/modules/exllamav2.py
+++ b/modules/exllamav2.py
@@ -108,3 +108,8 @@ class Exllamav2Model:
 
     def decode(self, string, **kwargs):
         return self.tokenizer.decode(string)[0]
+
+    def get_logits(self, token_ids, **kwargs):
+        self.cache.current_seq_len = 0
+        self.model.forward(token_ids[:, :-1], self.cache, input_mask=None, preprocess_only=True)
+        return self.model.forward(token_ids[:, -1:], self.cache, input_mask=None, **kwargs).float().cpu()

--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -1,6 +1,7 @@
 import re
 from functools import partial
 
+import numpy as np
 import torch
 
 from modules import RoPE, shared
@@ -99,6 +100,12 @@ class LlamaCppModel:
 
     def decode(self, tokens):
         return self.model.detokenize(tokens)
+
+    def get_logits(self, tokens):
+        self.model.eval(tokens)
+        logits = self.model._scores
+        logits = np.expand_dims(logits, 0)  # batch dim is expected
+        return torch.tensor(logits, dtype=torch.float32)
 
     def generate(self, prompt, state, callback=None):
 

--- a/modules/logits.py
+++ b/modules/logits.py
@@ -1,13 +1,25 @@
 import torch
 
 from modules import sampler_hijack, shared
+from modules.exllama import ExllamaModel
+from modules.exllamav2 import Exllamav2Model
+from modules.logging_colors import logger
 from modules.text_generation import generate_reply
 
 global_scores = None
 
 
 def get_next_logits(prompt, state, use_samplers, previous):
+    if shared.model is None:
+        logger.error("No model is loaded! Select one in the Model tab.")
+        return '', previous
+    is_non_hf_exllamav2 = isinstance(shared.model, Exllamav2Model)
+    is_non_hf_exllamav1 = isinstance(shared.model, ExllamaModel)
     if use_samplers:
+        if is_non_hf_exllamav2 or is_non_hf_exllamav1:
+            logger.error("Sampler hijacking is not supported non-Huggingface loaders.")
+            # sampling is all done in c for exllama, so it is really hard to hijack
+            return '', previous
         state['max_new_tokens'] = 1
         state['auto_max_new_tokens'] = False
         for _ in generate_reply(prompt, state):
@@ -15,13 +27,19 @@ def get_next_logits(prompt, state, use_samplers, previous):
 
         scores = sampler_hijack.global_scores[-1]
     else:
-        tokens = shared.tokenizer.encode(prompt, return_tensors='pt').cuda()
-        output = shared.model(input_ids=tokens)
-        scores = output['logits'][-1][-1]
+        if is_non_hf_exllamav2 or is_non_hf_exllamav1:
+            tokens = shared.tokenizer.encode(prompt).cuda()
+            scores = shared.model.get_logits(tokens)[-1][-1]
+        else:
+            tokens = shared.tokenizer.encode(prompt, return_tensors='pt').cuda()
+            output = shared.model(input_ids=tokens)
+            scores = output['logits'][-1][-1]
 
     probs = torch.softmax(scores, dim=-1, dtype=torch.float)
     topk_values, topk_indices = torch.topk(probs, k=25, largest=True, sorted=True)
     topk_values = [f"{float(i):.5f}" for i in topk_values]
+    if is_non_hf_exllamav1:
+        topk_indices = [i.expand((1, 1)) for i in topk_indices]
     tokens = [shared.tokenizer.decode(i) for i in topk_indices]
 
     output = ''

--- a/modules/logits.py
+++ b/modules/logits.py
@@ -3,6 +3,7 @@ import torch
 from modules import sampler_hijack, shared
 from modules.exllama import ExllamaModel
 from modules.exllamav2 import Exllamav2Model
+from modules.llamacpp_model import LlamaCppModel
 from modules.logging_colors import logger
 from modules.text_generation import generate_reply
 
@@ -12,14 +13,19 @@ global_scores = None
 def get_next_logits(prompt, state, use_samplers, previous):
     if shared.model is None:
         logger.error("No model is loaded! Select one in the Model tab.")
-        return '', previous
+        return 'Error: No model is loaded1 Select one in the Model tab.', previous
+
     is_non_hf_exllamav2 = isinstance(shared.model, Exllamav2Model)
     is_non_hf_exllamav1 = isinstance(shared.model, ExllamaModel)
+    is_non_hf_llamacpp = isinstance(shared.model, LlamaCppModel)
+
     if use_samplers:
-        if is_non_hf_exllamav2 or is_non_hf_exllamav1:
+        if any([is_non_hf_exllamav2, is_non_hf_exllamav1, is_non_hf_llamacpp]):
             logger.error("Sampler hijacking is not supported non-Huggingface loaders.")
             # sampling is all done in c for exllama, so it is really hard to hijack
-            return '', previous
+            # it should be possible to hijack llamacpp sampler by hijacking all their sampling methods,
+            # but it is not implemented yet
+            return 'Error: Sampler hijacking is not supported non-Huggingface loaders', previous
         state['max_new_tokens'] = 1
         state['auto_max_new_tokens'] = False
         for _ in generate_reply(prompt, state):
@@ -30,6 +36,9 @@ def get_next_logits(prompt, state, use_samplers, previous):
         if is_non_hf_exllamav2 or is_non_hf_exllamav1:
             tokens = shared.tokenizer.encode(prompt).cuda()
             scores = shared.model.get_logits(tokens)[-1][-1]
+        elif is_non_hf_llamacpp:
+            tokens = shared.tokenizer.encode(prompt)
+            scores = shared.model.get_logits(tokens)[-1][-1]
         else:
             tokens = shared.tokenizer.encode(prompt, return_tensors='pt').cuda()
             output = shared.model(input_ids=tokens)
@@ -38,9 +47,11 @@ def get_next_logits(prompt, state, use_samplers, previous):
     probs = torch.softmax(scores, dim=-1, dtype=torch.float)
     topk_values, topk_indices = torch.topk(probs, k=25, largest=True, sorted=True)
     topk_values = [f"{float(i):.5f}" for i in topk_values]
-    if is_non_hf_exllamav1:
+    if is_non_hf_exllamav1 or is_non_hf_llamacpp:
         topk_indices = [i.expand((1, 1)) for i in topk_indices]
     tokens = [shared.tokenizer.decode(i) for i in topk_indices]
+    if is_non_hf_llamacpp:
+        tokens = [i.decode('utf-8') for i in tokens] # llamacpp returns bytes, not str
 
     output = ''
     for row in list(zip(topk_values, tokens)):

--- a/modules/logits.py
+++ b/modules/logits.py
@@ -25,7 +25,8 @@ def get_next_logits(prompt, state, use_samplers, previous):
             # sampling is all done in c for exllama, so it is really hard to hijack
             # it should be possible to hijack llamacpp sampler by hijacking all their sampling methods,
             # but it is not implemented yet
-            return 'Error: Sampler hijacking is not supported non-Huggingface loaders', previous
+            return 'Error: Sampler hijacking is not supported non-Huggingface loaders. Please disable the "Use samplers" option.', previous
+
         state['max_new_tokens'] = 1
         state['auto_max_new_tokens'] = False
         for _ in generate_reply(prompt, state):
@@ -49,12 +50,13 @@ def get_next_logits(prompt, state, use_samplers, previous):
     topk_values = [f"{float(i):.5f}" for i in topk_values]
     if is_non_hf_exllamav1 or is_non_hf_llamacpp:
         topk_indices = [i.expand((1, 1)) for i in topk_indices]
+
     tokens = [shared.tokenizer.decode(i) for i in topk_indices]
     if is_non_hf_llamacpp:
-        tokens = [i.decode('utf-8') for i in tokens] # llamacpp returns bytes, not str
+        tokens = [i.decode('utf-8') for i in tokens]  # llamacpp returns bytes, not str
 
     output = ''
     for row in list(zip(topk_values, tokens)):
-        output += f"{row[0]}  -  {row[1]}\n"
+        output += f"{row[0]}  -  {repr(row[1])[1:-1]}\n"
 
     return output, previous

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -150,7 +150,7 @@ def get_token_ids(prompt):
 
     output = ''
     for row in list(zip(tokens, decoded_tokens)):
-        output += f"{str(int(row[0])).ljust(5)}  -  {row[1]}\n"
+        output += f"{str(int(row[0])).ljust(5)}  -  {repr(row[1])[1:-1]}\n"
 
     return output
 


### PR DESCRIPTION
Right now, your console gets flooded with errors if you try to use the new Logits tab with non-HF model loaders. It doesn't seem to be (at least easily) possible to hijack the exllama samplers as they are written in C, so I was only able to implement for without the "use samplers" checkbox

I think the bigger part of this PR is that it adds proper error handling with messages telling the user what went wrong (etc they tried to use logits + sampler on a non HF loader), along with an error message telling the user they don't have a model loaded