### PR TITLE
Add speechrecognition dependency for OpenAI extension 

### DIFF
--- a/extensions/openai/requirements.txt
+++ b/extensions/openai/requirements.txt
@@ -1,3 +1,4 @@
+SpeechRecognition==3.10.0
 flask_cloudflared==0.0.12
 sentence-transformers
 tiktoken


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

The openai extension broke after https://github.com/oobabooga/text-generation-webui/pull/3958, a forgotten dependency was added to fix it.