### PR TITLE
Bump llama-cpp-python to 0.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ https://github.com/abetlen/llama-cpp-python/releases/download/v0.2.6/llama_cpp_p
 
 # llama-cpp-python with CUDA support
 https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.2.6+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"
-https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.2.6+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
+https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.2.6+cu117-cp310-cp310-manylinux_2_31_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
 
 # GPTQ-for-LLaMa
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.0/gptq_for_llama-0.1.0+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,12 +38,12 @@ https://github.com/jllllll/exllama/releases/download/0.0.17/exllama-0.0.17+cu117
 https://github.com/jllllll/exllama/releases/download/0.0.17/exllama-0.0.17+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
 
 # llama-cpp-python without GPU support
-llama-cpp-python==0.1.85; platform_system != "Windows"
-https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.85/llama_cpp_python-0.1.85-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+llama-cpp-python==0.2.6; platform_system != "Windows"
+https://github.com/abetlen/llama-cpp-python/releases/download/v0.2.6/llama_cpp_python-0.2.6-cp310-cp310-win_amd64.whl; platform_system == "Windows"
 
 # llama-cpp-python with CUDA support
-https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.1.85+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"
-https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.1.85+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
+https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.2.6+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"
+https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/textgen-webui/llama_cpp_python_cuda-0.2.6+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
 
 # GPTQ-for-LLaMa
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.0/gptq_for_llama-0.1.0+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
Held off on making a PR for this due to believing that there was a version conflict with pydantic that prevented installation.
I now believe that this was actually a separate issue and was fixed here: #3927

I haven't had any issues with it that I've noticed since, but this may require more thorough testing.

---
Written changelog: https://github.com/abetlen/llama-cpp-python/blob/v0.2.6/CHANGELOG.md
- 0.2.0
  - https://github.com/abetlen/llama-cpp-python/compare/v0.1.85...v0.2.0
- 0.2.1
  - https://github.com/abetlen/llama-cpp-python/compare/v0.2.0...v0.2.1
- 0.2.2
  - https://github.com/abetlen/llama-cpp-python/compare/v0.2.1...v0.2.2
- 0.2.3
  - https://github.com/abetlen/llama-cpp-python/compare/v0.2.2...v0.2.3
  - https://github.com/ggerganov/llama.cpp/compare/89e89599fd095172f8d67903b5e227467420f036...71ca2fad7d6c0ef95ef9944fb3a1a843e481f314
- 0.2.4
  - https://github.com/abetlen/llama-cpp-python/compare/v0.2.3...v0.2.4
- 0.2.5
  - https://github.com/abetlen/llama-cpp-python/compare/v0.2.4...v0.2.5
- 0.2.6
  - https://github.com/abetlen/llama-cpp-python/compare/v0.2.5...v0.2.6
  - https://github.com/ggerganov/llama.cpp/compare/71ca2fad7d6c0ef95ef9944fb3a1a843e481f314...80291a1d02a07f7f66666fb576c5b1e75aa48b46
- All changes
  - https://github.com/abetlen/llama-cpp-python/compare/v0.1.85...v0.2.6
  - https://github.com/ggerganov/llama.cpp/compare/89e89599fd095172f8d67903b5e227467420f036...80291a1d02a07f7f66666fb576c5b1e75aa48b46