### PR TITLE
Fix double gap when chat-buttons is hidden

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -589,3 +589,7 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
 .old-ui #chat-buttons #clear-history-confirm {
     order: -1;
 }
+
+#chat-tab:not(.old-ui) #chat-buttons + div {
+    margin-top: calc(var(--layout-gap) * -1)
+}


### PR DESCRIPTION
## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

In hover menu mode, the hidden chat buttons leave a double-wide gap in their place.

Before:
![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/e16c3a17-02bd-40b7-ad96-ac2900b7847c)


After:
![image](https://github.com/oobabooga/text-generation-webui/assets/4073789/8937362d-1284-47d4-bdb8-e8cdf4be2032)
