### PR TITLE
llama.cpp: fix ban_eos_token

### DIFF
--- a/modules/llamacpp_model.py
+++ b/modules/llamacpp_model.py
@@ -120,7 +120,7 @@ class LlamaCppModel:
 
         logit_processors = LogitsProcessorList()
         if state['ban_eos_token']:
-            logit_processors.append(partial(ban_eos_logits_processor, self.model.tokenizer.eos_token_id))
+            logit_processors.append(partial(ban_eos_logits_processor, self.model.token_eos()))
 
         if state['custom_token_bans']:
             to_ban = [int(x) for x in state['custom_token_bans'].split(',')]


### PR DESCRIPTION
- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
***

Fixes this exception when attempting to ban the EOS token with llama.cpp:
```
Traceback (most recent call last):
  File "/home/cebtenzzre/src/forks/text-generation-webui/modules/text_generation.py", line 381, in generate_reply_custom
    reply = shared.model.generate(question, state)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cebtenzzre/src/forks/text-generation-webui/modules/llamacpp_model.py", line 135, in generate
    logit_processors.append(partial(ban_eos_logits_processor, self.model.tokenizer.eos_token_id))
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'function' object has no attribute 'eos_token_id'
```