### PR TITLE
fix: Add nvcc to runtime container image for exllamav2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,10 @@ LABEL maintainer="Your Name <your.email@example.com>"
 LABEL description="Docker image for GPTQ-for-LLaMa and Text Generation WebUI"
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,rw apt-get update && \
-    apt-get install --no-install-recommends -y python3-dev libportaudio2 libasound-dev git python3 python3-pip make g++ ffmpeg && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install --no-install-recommends -y python3-dev libportaudio2 libasound-dev git python3 python3-pip make \
+    g++ ffmpeg cuda-nvcc-11-8 && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/local/cuda/bin/nvcc /usr/local/bin/nvcc
 
 RUN --mount=type=cache,target=/root/.cache/pip,rw pip3 install virtualenv
 RUN mkdir /app


### PR DESCRIPTION
nvcc is required to run exllamav2 however the current runtime image is lacking the binary.

This PR adds the cuda-nvcc-11-8 package from apt which provides nvcc in the runtime image and symlinks it to /usr/local/bin so that it's available in the general PATH.

I suspect this will fix #3943.

```
dpkg -S nvcc
cuda-nvcc-11-8: /usr/share/doc/cuda-nvcc-11-8
cuda-nvcc-11-8: /usr/local/cuda-11.8/bin/nvcc.profile
cuda-nvcc-11-8: /usr/local/cuda-11.8/bin/__nvcc_device_query
cuda-nvcc-11-8: /usr/share/doc/cuda-nvcc-11-8/changelog.Debian.gz
cuda-nvcc-11-8: /usr/local/cuda-11.8/bin/nvcc
cuda-nvcc-11-8: /usr/share/doc/cuda-nvcc-11-8/copyright
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
