### PR TITLE
Wrong vicuna-format.json ?

### DIFF
--- a/training/formats/vicuna-format.json
+++ b/training/formats/vicuna-format.json
@@ -1,3 +1,3 @@
 {
-  "instruction,output": "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n\nUSER: %instruction%\n\nASSISTANT: %output%"
+  "instruction,output": "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n\nUSER: %instruction%\nASSISTANT: %output%"
 }


### PR DESCRIPTION
I don't want to be that guy again, but I'm pretty sure the Vicuna-format is wrong one way or another. Your instruct template for vicuna says:
'<|user|> <|user-message|>\n<|bot|> <|bot-message|></s>\n'

and it does indeed create
USER: blahblah
ASSISTANT: yeah

So keeping in mind that that is how Vicuna likes it yet, when training we force two lines in vicuna-format.json

USER: I am Groot

ASSISTANT: Sure you are

It is a tiny thing, but LLM does care about tiny things.

So check why there are \n\n between USER/ASSISTANT in the template - IMHO there should be only one. And since there isn't /s at the end either then everything trained with that template is slightly off unless you actually use instruct: <|user|> <|user-message|>\n\n<|bot|> <|bot-message|>\n

(added 2\n and removed /s) which isn't Vicuna, but more like webui-cuna - but that's how everyone who uses vicuna-format to this very day trains then uses Vicuna instruct and it is slightly off.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
