### PR TITLE
Various one-click-installer updates and fixes

### DIFF
--- a/cmd_linux.sh
+++ b/cmd_linux.sh
@@ -4,6 +4,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
+
 # config
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"

--- a/cmd_macos.sh
+++ b/cmd_macos.sh
@@ -4,8 +4,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
-# deactivate existing env if needed
-conda deactivate 2> /dev/null
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
 
 # config
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"

--- a/cmd_windows.bat
+++ b/cmd_windows.bat
@@ -10,6 +10,9 @@ echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which c
 set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
 
+@rem deactivate existing conda envs as needed to avoid conflicts
+(conda deactivate && conda deactivate && conda deactivate) 2>null
+
 @rem config
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
 set INSTALL_ENV_DIR=%cd%\installer_files\env

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -4,6 +4,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
+
 OS_ARCH=$(uname -m)
 case "${OS_ARCH}" in
     x86_64*)    OS_ARCH="x86_64";;

--- a/start_macos.sh
+++ b/start_macos.sh
@@ -4,6 +4,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
+
 # M Series or Intel
 OS_ARCH=$(uname -m)
 case "${OS_ARCH}" in

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -17,6 +17,9 @@ set SPCHARMESSAGE=
 set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
 
+@rem deactivate existing conda envs as needed to avoid conflicts
+(conda deactivate && conda deactivate && conda deactivate) 2>null
+
 @rem config
 set INSTALL_DIR=%cd%\installer_files
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda

--- a/update_linux.sh
+++ b/update_linux.sh
@@ -4,6 +4,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
+
 # config
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"

--- a/update_macos.sh
+++ b/update_macos.sh
@@ -4,6 +4,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
+
 # config
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"

--- a/update_windows.bat
+++ b/update_windows.bat
@@ -10,6 +10,9 @@ echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which c
 set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
 
+@rem deactivate existing conda envs as needed to avoid conflicts
+(conda deactivate && conda deactivate && conda deactivate) 2>null
+
 @rem config
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
 set INSTALL_ENV_DIR=%cd%\installer_files\env

--- a/webui.py
+++ b/webui.py
@@ -2,6 +2,7 @@ import argparse
 import glob
 import os
 import subprocess
+import site
 import sys
 
 script_dir = os.getcwd()
@@ -77,6 +78,16 @@ def clear_cache():
     run_cmd("conda clean -a -y", environment=True)
     run_cmd("python -m pip cache purge", environment=True)
 
+def is_installed():
+    for sitedir in site.getsitepackages():
+        if "site-packages" in sitedir and conda_env_path in sitedir:
+            site_packages_path = sitedir
+            break
+
+    if site_packages_path:
+        return os.path.isfile(os.path.join(site_packages_path, 'torch', '__init__.py'))
+    else:
+        return os.path.isdir(conda_env_path)
 
 def install_dependencies():
     # Select your GPU or, choose to run in CPU mode
@@ -235,8 +246,7 @@ if __name__ == "__main__":
         update_dependencies()
     else:
         # If webui has already been installed, skip and run
-        # if not os.path.exists("text-generation-webui/"):
-        if True:  # TODO implement a new installation check
+        if not is_installed():
             install_dependencies()
             os.chdir(script_dir)
 

--- a/webui.py
+++ b/webui.py
@@ -251,7 +251,7 @@ if __name__ == "__main__":
             os.chdir(script_dir)
 
         # Check if a model has been downloaded yet
-        if len([item for item in glob.glob('text-generation-webui/models/*') if not item.endswith(('.txt', '.yaml'))]) == 0:
+        if len([item for item in glob.glob('models/*') if not item.endswith(('.txt', '.yaml'))]) == 0:
             print_big_message("WARNING: You haven't downloaded any model yet.\nOnce the web UI launches, head over to the \"Model\" tab and download one.")
 
         # Workaround for llama-cpp-python loading paths in CUDA env vars even if they do not exist

--- a/webui.py
+++ b/webui.py
@@ -117,7 +117,12 @@ def install_dependencies():
 
 
 def update_dependencies(initial_installation=False):
-    # run_cmd("git pull", assert_success=True, environment=True)  # TODO uncomment before merging (is there a better way?)
+    # Create .git directory if missing
+    if not os.path.isdir(os.path.join(script_dir, ".git")):
+        git_creation_cmd = 'git init -b main && git remote add origin https://github.com/oobabooga/text-generation-webui && git fetch && git remote set-head origin -a && git reset origin/HEAD && git branch --set-upstream-to=origin/HEAD'
+        run_cmd(git_creation_cmd, environment=True, assert_success=True)
+    
+    run_cmd("git pull", assert_success=True, environment=True)  # TODO is there a better way?
 
     # Install the extensions dependencies (only on the first install)
     if initial_installation:

--- a/webui.py
+++ b/webui.py
@@ -133,7 +133,7 @@ def update_dependencies(initial_installation=False):
         git_creation_cmd = 'git init -b main && git remote add origin https://github.com/oobabooga/text-generation-webui && git fetch && git remote set-head origin -a && git reset origin/HEAD && git branch --set-upstream-to=origin/HEAD'
         run_cmd(git_creation_cmd, environment=True, assert_success=True)
     
-    run_cmd("git pull", assert_success=True, environment=True)  # TODO is there a better way?
+    run_cmd("git pull --autostash", assert_success=True, environment=True)  # TODO is there a better way?
 
     # Install the extensions dependencies (only on the first install)
     if initial_installation:

--- a/wsl.sh
+++ b/wsl.sh
@@ -15,8 +15,8 @@ read -n1 -p "Continue the installer anyway? [y,n]" EXIT_PROMPT
 if ! [[ $EXIT_PROMPT == "Y" || $EXIT_PROMPT == "y" ]]; then exit; fi
 fi
 
-# deactivate any currently active conda env
-conda deactivate 2> /dev/null
+# deactivate existing conda envs as needed to avoid conflicts
+{ conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
 
 # config   unlike other scripts, can't use current directory due to file IO bug in WSL, needs to be in virtual drive
 INSTALL_DIR="$HOME/text-gen-install"


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
- [Add .git creation to installer](https://github.com/oobabooga/text-generation-webui/commit/6bbfc40d10a7d2e671558a2f928285b6744c4a3c)
  - Ensures that the installer will function as intended even if the webui is downloaded from the [repo zip](https://github.com/oobabooga/text-generation-webui/archive/refs/heads/main.zip).
- [Add Conda env deactivation to installer scripts](https://github.com/oobabooga/text-generation-webui/commit/cd1049ededa4dc694c360b53801d12fdcaa0bb3d)
  - Avoids conflicts with existing Conda installations
- [More robust installation check for installer](https://github.com/oobabooga/text-generation-webui/commit/498552a92bf9b40eaea0fdae028ce1c940a157cc)
  - Checks if torch is installed under the installer's Conda env.
  Will fallback to checking if the installer's env location exists if the torch check fails to find `site-packages` for some reason.
- [Use --autostash on git pull](https://github.com/oobabooga/text-generation-webui/pull/4029/commits/9054c98ecac8c7b2d40c84262e92cfe6cd6a1e5a)
  - This will attempt to save any changes made before git pull and restore them after.
  This is necessary due to the need to modify `CMD_FLAGS.txt`, which will block pulling updates until changes are reverted.
  It is possible that this isn't needed so long as `CMD_FLAGS.txt` is never touched in a commit. Not sure.
- [Update WSL installer](https://github.com/oobabooga/text-generation-webui/pull/4029/commits/060bb76aa077fc03c0278eb9b77005239f12be19)
  - WSL installer was updated to account for installation within the webui repo directory.
  WSL's file I/O bug made this more complicated than it otherwise would be.