### PR TITLE
Fix 'train only after' not working

### DIFF
--- a/extensions/Training_PRO/script.py
+++ b/extensions/Training_PRO/script.py
@@ -387,7 +387,7 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
                 before_tokens = [shared.tokenizer.pad_token_id] * (cutoff_len - full_length) + before_tokens
 
             input_ids = before_tokens + after_tokens
-            labels = [-100] * len(before_tokens) + [1] * len(after_tokens)
+            labels = [shared.tokenizer.pad_token_id] * len(before_tokens) + [1] * len(after_tokens)
 
         input_ids = torch.tensor(input_ids)
         return {

--- a/modules/training.py
+++ b/modules/training.py
@@ -353,7 +353,7 @@ def do_train(lora_name: str, always_override: bool, save_steps: int, micro_batch
                 before_tokens = [shared.tokenizer.pad_token_id] * (cutoff_len - full_length) + before_tokens
 
             input_ids = before_tokens + after_tokens
-            labels = [-100] * len(before_tokens) + [1] * len(after_tokens)
+            labels = [shared.tokenizer.pad_token_id] * len(before_tokens) + [1] * len(after_tokens)
 
         input_ids = torch.tensor(input_ids)
         return {


### PR DESCRIPTION
closes #4031

The goal of this PR is to fix the overwriting of all the labels including -100s by input_ids in the process of collating the batches with Transformers's DataCollatorForLanguageModeling

See https://github.com/oobabooga/text-generation-webui/issues/4031 for more details

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
