### PR TITLE
Use call for conda deactivate in Windows installer

### DIFF
--- a/cmd_windows.bat
+++ b/cmd_windows.bat
@@ -11,7 +11,7 @@ set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
 
 @rem deactivate existing conda envs as needed to avoid conflicts
-(conda deactivate && conda deactivate && conda deactivate) 2>nul
+(call conda deactivate && call conda deactivate && call conda deactivate) 2>nul
 
 @rem config
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -18,7 +18,7 @@ set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
 
 @rem deactivate existing conda envs as needed to avoid conflicts
-(conda deactivate && conda deactivate && conda deactivate) 2>nul
+(call conda deactivate && call conda deactivate && call conda deactivate) 2>nul
 
 @rem config
 set INSTALL_DIR=%cd%\installer_files

--- a/update_windows.bat
+++ b/update_windows.bat
@@ -11,7 +11,7 @@ set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
 
 @rem deactivate existing conda envs as needed to avoid conflicts
-(conda deactivate && conda deactivate && conda deactivate) 2>nul
+(call conda deactivate && call conda deactivate && call conda deactivate) 2>nul
 
 @rem config
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
Required for conda deactivate commands to work without breaking the Windows installer.

---
Fixes: #4041 