### PR TITLE
Avoid importing torch in one-click-installer

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -53,7 +53,16 @@ def cpu_has_avx2():
 
 
 def torch_version():
-    from torch import __version__ as torver
+    for sitedir in site.getsitepackages():
+        if "site-packages" in sitedir and conda_env_path in sitedir:
+            site_packages_path = sitedir
+            break
+
+    if site_packages_path:
+        torch_version_file = open(os.path.join(site_packages_path, 'torch', 'version.py')).read().splitlines()
+        torver = [line for line in torch_version_file if '__version__' in line][0].split('__version__ = ')[1].strip("'")
+    else:
+        from torch import __version__ as torver
     return torver
 
 


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
---
`__version__` in `torch` is derived from `version.py`. So, to avoid issues with Windows not uninstalling torch dependencies, this will just read that value directly from `version.py` if possible.

---
Fixes: #4063 