### PR TITLE
fix: add missing superboogav2 dep

### DIFF
--- a/extensions/superboogav2/requirements.txt
+++ b/extensions/superboogav2/requirements.txt
@@ -6,3 +6,4 @@ pandas==2.0.3
 posthog==2.4.2
 sentence_transformers==2.2.2
 spacy
+pytextrank


### PR DESCRIPTION
Add missing dependency for superboogav2

fixes:

```
2023-09-27 01:47:47 ERROR:Failed to load the extension "superboogav2".
Traceback (most recent call last):
  File "/app/modules/extensions.py", line 36, in load_extensions
    exec(f"import extensions.{name}.script")
  File "<string>", line 1, in <module>
  File "/app/extensions/superboogav2/script.py", line 21, in <module>
    from .download_urls import feed_url_into_collector
  File "/app/extensions/superboogav2/download_urls.py", line 9, in <module>
    from .data_processor import process_and_add_to_collector
  File "/app/extensions/superboogav2/data_processor.py", line 12, in <module>
    from .data_preprocessor import TextPreprocessorBuilder, TextSummarizer
  File "/app/extensions/superboogav2/data_preprocessor.py", line 14, in <module>
    import pytextrank
ModuleNotFoundError: No module named 'pytextrank'
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
