### PR TITLE
fix:  minor error in _run_server defaults

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -197,7 +197,7 @@ class Handler(BaseHTTPRequestHandler):
         super().end_headers()
 
 
-def _run_server(port: int, share: bool = False, tunnel_id=str):
+def _run_server(port: int, share: bool, tunnel_id:str):
     address = '0.0.0.0' if shared.args.listen else '127.0.0.1'
 
     server = ThreadingHTTPServer((address, port), Handler)
@@ -217,5 +217,5 @@ def _run_server(port: int, share: bool = False, tunnel_id=str):
     server.serve_forever()
 
 
-def start_server(port: int, share: bool = False, tunnel_id=str):
+def start_server(port: int, *, share: bool, tunnel_id:str):
     Thread(target=_run_server, args=[port, share, tunnel_id], daemon=True).start()

--- a/extensions/api/streaming_api.py
+++ b/extensions/api/streaming_api.py
@@ -102,7 +102,7 @@ async def _run(host: str, port: int):
         await asyncio.Future()  # run forever
 
 
-def _run_server(port: int, share: bool = False, tunnel_id=str):
+def _run_server(port: int, share: bool , tunnel_id:str):
     address = '0.0.0.0' if shared.args.listen else '127.0.0.1'
 
     def on_start(public_url: str):
@@ -120,5 +120,5 @@ def _run_server(port: int, share: bool = False, tunnel_id=str):
     asyncio.run(_run(host=address, port=port))
 
 
-def start_server(port: int, share: bool = False, tunnel_id=str):
+def start_server(port: int, *, share: bool, tunnel_id:str):
     Thread(target=_run_server, args=[port, share, tunnel_id], daemon=True).start()


### PR DESCRIPTION
This fixes a minor error with the default values in `_run_server()` for both the streaming and non-streaming APIs.

I tested my changes and they do not interfere with anything else.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
