### PR TITLE
Update one_click.py to initialize site_packages_path variable

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -55,6 +55,7 @@ def cpu_has_avx2():
 
 
 def torch_version():
+    site_packages_path = None
     for sitedir in site.getsitepackages():
         if "site-packages" in sitedir and conda_env_path in sitedir:
             site_packages_path = sitedir
@@ -69,6 +70,7 @@ def torch_version():
 
 
 def is_installed():
+    site_packages_path = None
     for sitedir in site.getsitepackages():
         if "site-packages" in sitedir and conda_env_path in sitedir:
             site_packages_path = sitedir


### PR DESCRIPTION
Fixes issue:
https://github.com/oobabooga/text-generation-webui/issues/4078
For Task:
https://github.com/oobabooga/text-generation-webui/issues/4084

This actually affects macos as well and I suspect all other types of start scripts.

The Fix:
Added site_packages_path = None

Reasoning:
The reason for this is on new installs this variable won't be initialized by the time we hit the if block trying to access the variable. With this cod if this is a brand new install the code will fail the if check instead of throwing an exception, and if the project has already been installed it will pass the if check appropriately.

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
