### PR TITLE
Let model downloader download *.tiktoken as well

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -91,7 +91,8 @@ class ModelDownloader:
                 is_safetensors = re.match(r".*\.safetensors", fname)
                 is_pt = re.match(r".*\.pt", fname)
                 is_gguf = re.match(r'.*\.gguf', fname)
-                is_tokenizer = re.match(r"(tokenizer|ice|spiece).*\.model", fname)
+                is_tiktoken = re.match(r".*\.tiktoken", fname)
+                is_tokenizer = re.match(r"(tokenizer|ice|spiece).*\.model", fname) or is_tiktoken
                 is_text = re.match(r".*\.(txt|json|py|md)", fname) or is_tokenizer
                 if any((is_pytorch, is_safetensors, is_pt, is_gguf, is_tokenizer, is_text)):
                     if 'lfs' in dict[i]:


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

----

Some model uses tiktoken tokenizer but the downloader currently ignores this kind of file.  

Fix https://github.com/QwenLM/Qwen/issues/361