### PR TITLE
openai: fix wrong models list on query present in /v1/models

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -127,7 +127,7 @@ class Handler(BaseHTTPRequestHandler):
 
         if self.path.startswith('/v1/engines') or self.path.startswith('/v1/models'):
             is_legacy = 'engines' in self.path
-            is_list = self.path in ['/v1/engines', '/v1/models']
+            is_list = self.path.split('?')[0].split('#')[0] in ['/v1/engines', '/v1/models']
             if is_legacy and not is_list:
                 model_name = self.path[self.path.find('/v1/engines/') + len('/v1/engines/'):]
                 resp = OAImodels.load_model(model_name)


### PR DESCRIPTION
When request to models list contains query in url like 
```
/v1/models?query=val
```
response contains wrong data:
```json
{"id": "query=val", "object": "model", "owned_by": "user", "permission": []}
```
against list
```json
{ "object": "list","data": [{"id": "all-mpnet-base-v2","object": "model","owned_by": "user","permission": []},{"id": "gpt-3.5-turbo", "object": "model","owned_by": "user","permission": []},]}
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
