### PR TITLE
Fix off-by-one error in exllama_hf caching logic

### DIFF
--- a/modules/exllama_hf.py
+++ b/modules/exllama_hf.py
@@ -94,6 +94,10 @@ class ExllamaHF(PreTrainedModel):
                     ex_cache.current_seq_len = longest_prefix
                     if len(seq_tensor) - longest_prefix > 1:
                         self.ex_model.forward(seq_tensor[longest_prefix:-1].view(1, -1), ex_cache, preprocess_only=True, lora=self.lora)
+                    elif len(seq_tensor) == longest_prefix:
+                        # Very tricky: if the prefix we are reusing *is* the input_ids, then we have to back up the cache pointer by one,
+                        # because we feed input_ids[-1] to forward() below, but that last token is already in the cache!
+                        ex_cache.current_seq_len -= 1
 
             if reset:
                 ex_cache.current_seq_len = 0

--- a/modules/exllamav2_hf.py
+++ b/modules/exllamav2_hf.py
@@ -98,6 +98,10 @@ class Exllamav2HF(PreTrainedModel):
                     ex_cache.current_seq_len = longest_prefix
                     if len(seq_tensor) - longest_prefix > 1:
                         self.ex_model.forward(seq_tensor[longest_prefix:-1].view(1, -1), ex_cache, preprocess_only=True)
+                    elif len(seq_tensor) == longest_prefix:
+                        # Very tricky: if the prefix we are reusing *is* the input_ids, then we have to back up the cache pointer by one,
+                        # because we feed input_ids[-1] to forward() below, but that last token is already in the cache!
+                        ex_cache.current_seq_len -= 1
 
             if reset:
                 ex_cache.current_seq_len = 0


### PR DESCRIPTION
This fixes a subtle caching bug introduced with 03dc69edc5436b9426238fa626212dcffd9d62a3. I was playing around with a custom lora that by chance happened to amplify the effect of this bug, which is how I noticed. This led me down a rabbit hole of debugging and I eventually figured out the issue.

## How to reproduce
1. Load any raw text completion model with exllama_hf. I used Llama-2-13B-GPTQ.
2. Set repetition_penalty to 1 (important! otherwise it masks the effect)
3. Go to default tab, type literally the letter "a" as a prompt
4. Generate some tokens, it should be some random text.
5. Generate again. It will always be "a a a a a..." repeating. This is because the off-by-one caching bug has the effect of "doubling up" the most recent token. So it is invisible, but the model is seeing "a a" as the prompt, not "a".
6. You can use the logit viewer to see how dramatically the probabilities change.

I added some explanatory comments because the logic confused me for a long time until I pieced everything together. Also, I did not test exllamav2_hf, since I don't have quants for it, but presumably it has exactly the same issue.

This caching / state management stuff is so tricky, I'm not even 100% sure this is a complete fix. Please double and triple check that what I'm doing is sensible before merging!

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
