### PR TITLE
[Fix] fix openai embedding_model loading as str

### DIFF
--- a/extensions/openai/embeddings.py
+++ b/extensions/openai/embeddings.py
@@ -26,23 +26,21 @@ def load_embedding_model(model: str) -> SentenceTransformer:
     initialize_embedding_params()
     global embeddings_device, embeddings_model
     try:
-        embeddings_model = 'loading...'  # flag
+        print(f"\Try embedding model: {model} on {embeddings_device}")
         # see: https://www.sbert.net/docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer
-        emb_model = SentenceTransformer(model, device=embeddings_device)
-        # ... emb_model.device doesn't seem to work, always cpu anyways? but specify cpu anyways to free more VRAM
-        print(f"\nLoaded embedding model: {model} on {emb_model.device} [always seems to say 'cpu', even if 'cuda'], max sequence length: {emb_model.max_seq_length}")
+        embeddings_model = SentenceTransformer(model, device=embeddings_device)
+        # ... embeddings_model.device doesn't seem to work, always cpu anyways? but specify cpu anyways to free more VRAM
+        print(f"\nLoaded embedding model: {model} on {embeddings_model.device} [always seems to say 'cpu', even if 'cuda'], max sequence length: {embeddings_model.max_seq_length}")
     except Exception as e:
         embeddings_model = None
         raise ServiceUnavailableError(f"Error: Failed to load embedding model: {model}", internal_message=repr(e))
-
-    return emb_model
 
 
 def get_embeddings_model() -> SentenceTransformer:
     initialize_embedding_params()
     global embeddings_model, st_model
     if st_model and not embeddings_model:
-        embeddings_model = load_embedding_model(st_model)  # lazy load the model
+        load_embedding_model(st_model)  # lazy load the model
     return embeddings_model
 
 
@@ -53,7 +51,11 @@ def get_embeddings_model_name() -> str:
 
 
 def get_embeddings(input: list) -> np.ndarray:
-    return get_embeddings_model().encode(input, convert_to_numpy=True, normalize_embeddings=True, convert_to_tensor=False, device=embeddings_device)
+    model = get_embeddings_model()
+    debug_msg(f"embedding model : {model}")
+    embedding = model.encode(input, convert_to_numpy=True, normalize_embeddings=True, convert_to_tensor=False)
+    debug_msg(f"embedding result : {embedding}") # might be too long even for debug, use at you own will
+    return embedding
 
 
 def embeddings(input: list, encoding_format: str) -> dict:


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

---

## Related issue  https://github.com/oobabooga/text-generation-webui/issues/4146

Logs and reprodution in the issue


This pr fix this line of code that leads to embeeding_model being assigned to str instead of intended an instance of SentenceTransformer https://github.com/oobabooga/text-generation-webui/issues/4146#issuecomment-1742457094

After the fix, the openai embedding begins working, here is the log after the fix with debug=1 in the openai extension.

When debug=1 [[here](https://github.com/oobabooga/text-generation-webui/blob/0197fdddf106270ccf77fc2757d7bc53cc9729d4/extensions/openai/script.py#L35)], it now prints out embedding models and embedding results



```
OpenAI compatible API ready at: OPENAI_API_BASE=http://127.0.0.1:5051/v1
Running on local URL:  http://127.0.0.1:7860

To create a public link, set `share=True` in `launch()`.
POST /v1/embeddings HTTP/1.1
Accept: application/json, text/plain, */*
Content-Type: application/json
User-Agent: OpenAI/NodeJS/3.3.0
Authorization: Bearer sk-111111111111111111111111111111111111111111111111
auth: 
Content-Length: 2759
Host: host.docker.internal:5051
Connection: keep-alive


{'model': 'text-embedding-ada-002', 'input': ['第2章方舟编译器的构建第1步,安装 64 位版本的 Ubuntu 16.04,并且安装如下依赖库：\nsudo apt– get – y install openjdk – 8 – jdk git– core build– essential zlib1g–dev\nlibc6- de v - i386 g++ - multilib gcc - multilib linux- libc - dev:i386\nsudo apt-get - y install gcc - 5 - aarch64 - linux- gnu g++ - 5- aarch64-linux-gnu 上述代码中安装这些库的个别版本可能会有差异，有的时候这并不会影响源码的编译，不用在这个环节过分纠结个别库的具体小版本号，如果后面真的影响编译结果也可以再调整。 第2步,安装 Clang 工具链,并完成配置。 在 http://releases. llvm.org/download.html #8.0.0下载clang+llvm-8.0.0-x86 64-linux-gnu-ubuntu-16.04,并将其放到 openarkcompiler/tools目录,打开 build/config 目录的 BUILDCONFIG. gn,将 GN C COMPILER、GN CXX COMPILER 和 GN AR COMPILER三个变量配置为 Clang 编译器所在路径，代码如下：\n//第2章/BUILDCONFIG. gn\nGN_C_COMPILER = "$ {MAPLE_ROOT}/tools/clang_llvm-8.0.0- x86_64-linux-gnu-ubuntu-16.04/bin/clang"\nGN_CXX_COMPILER = "${MAPLE_ROOT}/tools/clang_llvm-8.0.0 - x86_64-linux-gnu-ubuntu-16.04/bin/clang++"\nGN_AR_COMPILER = "${MAPLE_ROOT}/tools/clang_llvm-8.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/llvm-ar" 第3步,安装 gn 和 Ninja 并完成配置。 在 https://gitee.com/ xlnb/gn binary下载gn,在 https://github.com/ninja-build/ninja/\n011\n华为方舟编译器之美——基于开源代码的架构分析与实现\nreleases下载Ninja(V1.9.0),将它们放到openarkcompiler/tools目录，然后使用如下命令修改它们的文件权限：\ncd openarkcompiler/tools\nchmo d 775 gn\nchmo d 775 ninja 在完成文件权限的修改之后,将 openarkcompiler/Makefile 文件中的 gn 和 Ninja 两个变量配置为 gn 和 Ninja 可执行程序的所在路径。 这里需要提醒大家注意：第一，目前方舟编译器的默认构建系统是 64 位的 Ubuntu 16.04，所以在这里推荐按照官方的默认版本选择系统，避免在更高版本的系统上出现问题；第二，根据配置文件的要求完成相关配置的时候，需要修改 gn 和 Ninja的权限。 在完成环境配置之后，可以开始进行方舟编译器源码的编译。方舟编译器源码编译需要执行以下命令：\nsource build/envsetup. sh\nmake 其中, source build/envsetup. sh 是初始化环境, make 是直接进行编译。 也可以通过 make BUILD TYPE= DEBUG 编译 Debug 版本。编译完成后的输出信息如图2.1所示。 方舟编译器编译完成之后，会在 out/bin目录下生成如图2.2所示的可执行文件。至此，已经完成了方舟编译器的源码编译。\n']}
\Try embedding model: /root/CodeSpace/text-generation-webui/models/all-MiniLM-L6-v2 on cuda

Loaded embedding model: /root/CodeSpace/text-generation-webui/models/all-MiniLM-L6-v2 on cpu [always seems to say 'cpu', even if 'cuda'], max sequence length: 256
embedding model : SentenceTransformer(
  (0): Transformer({'max_seq_length': 256, 'do_lower_case': False}) with Transformer model: BertModel 
  (1): Pooling({'word_embedding_dimension': 384, 'pooling_mode_cls_token': False, 'pooling_mode_mean_tokens': True, 'pooling_mode_max_tokens': False, 'pooling_mode_mean_sqrt_len_tokens': False})
  (2): Normalize()
)
embedding result : [[-7.73551837e-02 -4.49015247e-03 -1.37750925e-02 -4.06129323e-02
  -1.76254585e-02 -5.74141853e-02 -2.43103504e-02  7.62139112e-02
  -1.67401985e-03 -1.49013568e-02  1.52447820e-01 -6.88280910e-02
  -2.25216243e-02 -1.62662882e-02 -6.48290617e-03  7.70601183e-02
  -7.23275840e-02  6.77352399e-02 -3.11460476e-02 -1.44165494e-02
  -5.14036417e-02  1.43107940e-02 -2.61855572e-02  1.49411727e-02
   5.73237166e-02 -2.64910311e-02 -7.58715346e-02  6.41647354e-02
   1.95311364e-02 -5.00875674e-02  3.40607800e-02  3.68064903e-02
   7.71081522e-02  2.93252943e-03  6.87031075e-02  1.23014469e-02
   3.57129611e-02 -7.28593096e-02 -3.62314694e-02  3.38021712e-03
  -7.63785318e-02  5.77552915e-02  1.98374353e-02  7.03101791e-03
  -3.62285450e-02  1.77916121e-02  1.32814907e-02 -2.26710159e-02
  -6.94823563e-02 -2.68289782e-02 -4.19104472e-02 -3.07748932e-02
   2.70276293e-02 -2.22963542e-02  5.19119836e-02  3.49110551e-02
  -2.19750106e-02  3.39216143e-02  1.96903106e-02  6.33902848e-02
  -4.84866202e-02  5.30954003e-02 -9.71858669e-03  3.29348654e-03
  -1.09462216e-01 -2.99146608e-03  8.17073435e-02 -6.02517556e-03
  -2.28624232e-02  3.36869247e-02 -2.45417114e-02 -9.21822265e-02
  -3.70859448e-03 -6.14741556e-02 -6.40160739e-02  1.03998436e-02
  -7.20601482e-03 -4.79989499e-02  3.13787535e-03 -1.08420305e-01
  -6.80314749e-02  7.84037262e-02  5.91285378e-02 -1.17274011e-02
  -2.99199708e-02  4.74572703e-02 -3.89515050e-02 -2.03105621e-02
   8.67481977e-02 -2.98567992e-02  1.05657689e-01 -1.00484723e-02
  -1.23602465e-01  5.81072867e-02  1.50992107e-02 -3.01691070e-02
   1.03546724e-01  2.59340331e-02 -4.80931029e-02  4.76764739e-02
  -7.37414835e-03 -6.74728528e-02  3.58778276e-02  1.91183146e-02
  -5.11428490e-02 -1.80337706e-03  1.32296002e-02  5.28568253e-02
  -1.17008258e-02 -4.01357822e-02 -2.87797898e-02 -2.22412795e-02
  -2.85961684e-02 -1.03704460e-01 -1.63116567e-02  6.17303774e-02
   4.74313907e-02 -2.85994168e-02 -2.46980805e-02  8.50278698e-03
   6.09157840e-03 -6.87084645e-02 -2.85674650e-02 -1.77706052e-02
  -1.32933304e-01 -2.00064015e-02  7.03219250e-02  2.22578368e-33
   3.19878794e-02 -1.28955180e-02 -8.22935104e-02 -1.73490308e-02
   2.19667964e-02 -4.16968763e-02  2.47599911e-02 -5.16075492e-02
  -8.70462582e-02  3.47439758e-02 -3.55731510e-02 -6.76240623e-02
  -9.36331823e-02  1.10595331e-01 -2.79234499e-02 -9.07896608e-02
   2.26877537e-02 -7.10977539e-02 -5.49337715e-02 -2.74367202e-02
   3.76307890e-02  9.04490575e-02 -1.48685202e-02 -2.10698247e-02
   3.24965604e-02  3.35260518e-02  1.23463437e-01 -4.73652743e-02
  -3.51501140e-03  2.15102751e-02  3.34883481e-02 -1.83574334e-02
  -5.01681678e-02 -3.16468850e-02  1.01345340e-02 -1.29650896e-02
  -7.05672726e-02 -6.46711385e-04 -2.13745851e-02  9.67806950e-03
   4.20357212e-02  6.38863370e-02 -3.52392741e-03  2.02985443e-02
   1.46300748e-01  5.85777536e-02 -3.79043519e-02  1.72833782e-02
   5.61943874e-02 -8.44008010e-03 -2.05860734e-02  7.49958977e-02
  -4.94771674e-02  5.91273308e-02  4.82208841e-03  1.65860243e-02
  -6.22552335e-02  2.00071204e-02 -2.23891139e-02 -1.58700962e-02
  -1.71059929e-02  5.47203161e-02  2.79330052e-02 -5.67290485e-02
   6.04981091e-03 -8.31547752e-03 -1.57787621e-01 -3.71512733e-02
   2.24836264e-02  7.77909672e-03 -8.77234712e-02 -2.39890553e-02
   6.89949095e-02  4.96190488e-02 -1.82514023e-02 -1.62165817e-02
  -6.32598847e-02  1.91538353e-02  3.60515192e-02 -7.21074715e-02
  -1.27703711e-01  1.11876912e-02 -3.53546138e-03 -5.73722310e-02
   8.59149639e-03  4.85059917e-02  3.11578978e-02  2.05059275e-02
  -6.62137344e-02  3.82064506e-02 -5.28791025e-02  7.85760358e-02
   1.27363633e-02  1.52990194e-02 -3.33702266e-02 -7.07686684e-33
  -2.39212774e-02  4.81331022e-04 -1.05202217e-02 -2.26346757e-02
  -8.59904010e-03  3.71355540e-03 -4.70335111e-02 -4.74472679e-02
   2.11755205e-02  1.61159807e-03  2.00308068e-03  4.50106598e-02
   3.90736870e-02 -2.78290082e-03  5.23546524e-02 -3.12262606e-02
  -1.85526744e-03  9.02571678e-02  1.78343561e-02  3.75544950e-02
  -2.15449091e-02 -1.13141234e-03 -2.34095603e-02 -1.95527803e-02
   6.70978427e-02 -5.79657964e-04  8.28515068e-02 -4.63999361e-02
   5.53244203e-02  4.89909053e-02  5.16600423e-02  4.35454119e-03
  -5.00057153e-02  6.48569912e-02  2.97496491e-03 -1.70473028e-02
   1.80558842e-02 -3.80261429e-02 -1.17075182e-01 -1.80693157e-02
   3.47771160e-02  2.24420242e-02  3.49925682e-02 -3.74595113e-02
  -3.91616449e-02  9.27998945e-02  4.79445234e-02 -6.97311992e-03
  -5.63121326e-02 -9.96041745e-02  7.50989616e-02 -8.81292373e-02
   9.88455955e-03 -2.36559217e-03  2.14047544e-02 -2.79979743e-02
  -4.22274868e-04  1.46928979e-02 -6.90358281e-02 -7.85692707e-02
  -3.15919258e-02  5.64816892e-02 -3.30376700e-02 -1.21314138e-01
   5.28284572e-02  1.37003465e-02  3.58291119e-02 -2.56193168e-02
  -1.63359325e-02 -9.86789465e-02 -9.27376002e-03  2.81915199e-02
   3.15508693e-02 -4.06228006e-02 -9.17183328e-03  3.36324610e-02
  -1.00245446e-01  5.25364317e-02 -1.53757418e-02 -1.57609563e-02
   1.80217512e-02 -2.37421482e-03  2.88792495e-02  1.49688929e-01
  -1.81696459e-03 -7.26313516e-02  7.33599823e-04  7.05813393e-02
   5.36494069e-02 -4.18078527e-02  3.35578658e-02  7.68654570e-02
   3.75392437e-02  8.05261359e-02  8.66937041e-02 -5.11734761e-08
   7.61519969e-02 -9.07370672e-02 -1.29374325e-01 -6.72198758e-02
   1.74987447e-02 -9.04674530e-02  7.91769475e-03 -4.52668853e-02
  -4.97827567e-02  1.40569750e-02  2.95274761e-02  7.35418200e-02
  -7.93776065e-02  3.82881938e-03 -6.29189759e-02 -5.40899411e-02
  -1.14736840e-01  3.73732182e-03 -1.39747991e-03 -1.36895850e-02
  -2.51839664e-02 -1.52626047e-02  4.75721732e-02 -6.22038543e-02
  -8.82700905e-02 -2.71580722e-02  8.60630348e-03 -1.54054174e-02
   1.87255871e-02 -9.98146087e-03  7.99676031e-02  9.49650537e-03
  -3.05355191e-02 -3.09522860e-02  1.13429807e-01  8.10767431e-03
  -8.43283348e-03 -3.21736652e-03  8.30494836e-02  3.38251777e-02
  -1.14089865e-02 -4.44450416e-02  9.52894613e-02  3.30453068e-02
   6.28809556e-02 -4.85706665e-02  2.53688190e-02  3.18152495e-02
  -2.91586462e-02  1.11031048e-02  4.13766131e-03 -1.99301615e-02
  -3.34963240e-02  3.11049987e-02 -7.96408858e-03 -1.79780032e-02
  -5.55891320e-02 -1.51144248e-03  2.79609263e-02 -6.08653612e-02
   3.15718465e-02 -7.57255703e-02 -1.37890866e-02 -4.59958595e-04]]
Embeddings return size: 384, number: 1
```
