### PR TITLE
Ignoring custom changes to CMD_FLAGS.txt on update.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ models/config-user.yaml
 Thumbs.db
 .chroma
 installer_files
+/CMD_FLAGS.txt


### PR DESCRIPTION
This fixes a "bug" where users are unable to update if they have changed CMD_FLAGS.txt.

If we've moved on to storing all user settings in CMD_FLAGS.txt, we should add this file to the project (already done) and then add an ignore rule to prevent any update conflicts.


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
