### PR TITLE
Text Generation: Abort if EOS token is reached

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -355,6 +355,7 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
                 for output in generator:
                     if output[-1] in eos_token_ids:
                         break
+
                     yield get_reply_from_output_ids(output, input_ids, original_question, state, is_chat=is_chat)
 
     except Exception:

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -353,9 +353,9 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
 
             with generate_with_streaming(**generate_params) as generator:
                 for output in generator:
-                    yield get_reply_from_output_ids(output, input_ids, original_question, state, is_chat=is_chat)
                     if output[-1] in eos_token_ids:
                         break
+                    yield get_reply_from_output_ids(output, input_ids, original_question, state, is_chat=is_chat)
 
     except Exception:
         traceback.print_exc()


### PR DESCRIPTION
Please look at the commit message for more information about the commit itself. The rationale is explained below:

The exllamav2_HF loader was not working properly and outputting single character repeats whenever an EOS token was given within a streaming reply.

Here's an example of a response close to the end of streaming:

Before the EOS token was added:
` "Yeah, I'm a bit nervous. We're all going to be tested for our understanding of quantum concepts. You read the textbook, right?" She wonders if studying with User will help. Manami feels a little better after talking to a friend. "Thanks for coming over. I really need help understanding these topics." Taking a deep breath, she continues, "So, I'm pretty sure you know how hard quantum mechanics can be. If you'd be willing to help me out, I'd really appreciate it." Manami tries to hide her shyness with a playful smile.`

After EOS token addition:
`  "Yeah, I'm a bit nervous. We're all going to be tested for our understanding of quantum concepts. You read the textbook, right?" She wonders if studying with User will help. Manami feels a little better after talking to a friend. "Thanks for coming over. I really need help understanding these topics." Taking a deep breath, she continues, "So, I'm pretty sure you know how hard quantum mechanics can be. If you'd be willing to help me out, I'd really appreciate it." Manami tries to hide her shyness with a playful smile.</s>`

This causes the final API response to look like this:
`"Yeah, I'm a bit nervous. We're all going to be tested for our understanding of quantum concepts. You read the textbook, right?" She wonders if studying with User will help. Manami feels a little better after talking to a friend. "Thanks for coming over. I really need help understanding these topics." Taking a deep breath, she continues, "So, I'm pretty sure you know how hard quantum mechanics can be. If you'd be willing to help me out, I'd really appreciate it." Manami tries to hide her shyness with a playful smilee.`

The reason why the word `smilee` shows up is because of a shift in offset (due to adding another space at the beginning) when chunking the string for stream responses.

The final two chunks will look like this which are joined together:
1. `With a playful smile`
2. `e.</s>`

However, this occurrence led me to question why an added EOS token was parsed and sent in the first place. Therefore, to futureproof this error from ever happening again, just abort on the EOS token which ends the streaming without sending a message with mishandled whitespaces to the API response.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

