### PR TITLE
Add HTTPS Support to openai extension

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -1,4 +1,5 @@
 import json
+import ssl
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 
@@ -14,6 +15,7 @@ from modules.text_generation import (
     stop_everything_event
 )
 from modules.utils import get_available_models
+from modules.logging_colors import logger
 
 
 def get_model_info():
@@ -199,11 +201,18 @@ class Handler(BaseHTTPRequestHandler):
 
 def _run_server(port: int, share: bool = False, tunnel_id=str):
     address = '0.0.0.0' if shared.args.listen else '127.0.0.1'
-
     server = ThreadingHTTPServer((address, port), Handler)
 
+    ssl_certfile = shared.args.ssl_certfile
+    ssl_keyfile = shared.args.ssl_keyfile
+    ssl_verify = True if (ssl_keyfile and ssl_certfile) else False
+    if ssl_verify:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(ssl_certfile, ssl_keyfile)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+
     def on_start(public_url: str):
-        print(f'Starting non-streaming server at public url {public_url}/api')
+        logger.info(f'Starting non-streaming server at public url {public_url}/api')
 
     if share:
         try:
@@ -211,8 +220,10 @@ def _run_server(port: int, share: bool = False, tunnel_id=str):
         except Exception:
             pass
     else:
-        print(
-            f'Starting API at http://{address}:{port}/api')
+        if ssl_verify:
+            logger.info(f'Starting API at https://{address}:{port}/api')
+        else:
+            logger.info(f'Starting API at http://{address}:{port}/api')
 
     server.serve_forever()
 

--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -1,5 +1,6 @@
 import json
 import os
+import ssl
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
@@ -322,6 +323,15 @@ def run_server():
     port = int(os.environ.get('OPENEDAI_PORT', params.get('port', 5001)))
     server_addr = ('0.0.0.0' if shared.args.listen else '127.0.0.1', port)
     server = ThreadingHTTPServer(server_addr, Handler)
+    
+    ssl_certfile=os.environ.get('OPENEDAI_CERT_PATH', shared.args.ssl_certfile)
+    ssl_keyfile=os.environ.get('OPENEDAI_KEY_PATH', shared.args.ssl_keyfile)
+    ssl_verify=True if (ssl_keyfile and ssl_certfile) else False
+    if ssl_verify:        
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(ssl_certfile, ssl_keyfile)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        
     if shared.args.share:
         try:
             from flask_cloudflared import _run_cloudflared
@@ -330,8 +340,11 @@ def run_server():
         except ImportError:
             print('You should install flask_cloudflared manually')
     else:
-        print(f'OpenAI compatible API ready at: OPENAI_API_BASE=http://{server_addr[0]}:{server_addr[1]}/v1')
-
+        if ssl_verify:
+            print(f'OpenAI compatible API ready at: OPENAI_API_BASE=https://{server_addr[0]}:{server_addr[1]}/v1')
+        else:
+            print(f'OpenAI compatible API ready at: OPENAI_API_BASE=http://{server_addr[0]}:{server_addr[1]}/v1')
+    
     server.serve_forever()
 
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

## Related Issue: https://github.com/oobabooga/text-generation-webui/issues/4254

This PR passes the ssl-certfile and ssl-keyfile from the CLI to the OpenAI extension. 

**Test with no cert params**
```
2023-10-12 09:08:15 INFO:Loading the extension "gallery"...
Running on local URL:  http://playground.internal:7860

To create a public link, set `share=True` in `launch()`.
OpenAI compatible API ready at: OPENAI_API_BASE=http://0.0.0.0:5001/v1
```

**Test with cli args**
```
# Same arguments from text-gen now get pushed down to the extension
...
--ssl-certfile=/devcerts/certificate.pem \
--ssl-keyfile=/devcerts/private_key.pem \
...

To create a public link, set `share=True` in `launch()`.
OpenAI compatible API ready at: OPENAI_API_BASE=https://0.0.0.0:5001/v1
```

**Test with Env Variables**
```
# Same naming convention OPENEDAI* as existing extension
export OPENEDAI_CERT_PATH=/devcerts/certificate.pem
export OPENEDAI_KEY_PATH=/devcerts/private_key.pem 
...
To create a public link, set `share=True` in `launch()`.
OpenAI compatible API ready at: OPENAI_API_BASE=https://0.0.0.0:5001/v1
```