### PR TITLE
Relax numpy version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6; platform_system != "Darwin" and platform_machine != "x86_64"
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_amd_noavx2.txt
+++ b/requirements_amd_noavx2.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_apple_intel.txt
+++ b/requirements_apple_intel.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_apple_silicon.txt
+++ b/requirements_apple_silicon.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_cpu_only.txt
+++ b/requirements_cpu_only.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_cpu_only_noavx2.txt
+++ b/requirements_cpu_only_noavx2.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6; platform_system != "Darwin" and platform_machine != "x86_64"
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*

--- a/requirements_nowheels.txt
+++ b/requirements_nowheels.txt
@@ -5,7 +5,7 @@ einops
 exllamav2==0.0.6
 gradio==3.47.*
 markdown
-numpy==1.24
+numpy==1.24.*
 optimum==1.13.1
 pandas
 peft==0.5.*


### PR DESCRIPTION
If using torch from https://download.pytorch.org/whl/cu118 then numpy 1.24.1 also gets installed as a dependency,
and unless there there's any reason for requiring 1.24.0 I think it's unnecessary to downgrade it.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
