### PR TITLE
Docker: Remove explicit CUDA 11.8 Reference

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,rw \
 
 COPY . /app/
 
-RUN cp /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda118.so /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so
+RUN cp /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda121.so /app/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so
 
 # Install extension requirements
 RUN --mount=type=cache,target=/root/.cache/pip,rw \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,rw \
     python3 -m venv /build/venv && \
     . /build/venv/bin/activate && \
     pip3 install --upgrade pip setuptools wheel ninja && \
-    pip3 install torch torchvision torchaudio && \
+    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 && \
     pip3 install -r requirements.txt
 
 # https://developer.nvidia.com/cuda-gpus
@@ -44,7 +44,7 @@ RUN virtualenv /app/venv
 RUN --mount=type=cache,target=/root/.cache/pip,rw \
     . /app/venv/bin/activate && \
     pip3 install --upgrade pip setuptools wheel ninja && \
-    pip3 install torch && \
+    pip3 install torch --index-url https://download.pytorch.org/whl/cu121 && \
     pip3 install torchvision torchaudio sentence_transformers xformers
 
 # Copy and install GPTQ-for-LLaMa

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,rw \
     python3 -m venv /build/venv && \
     . /build/venv/bin/activate && \
     pip3 install --upgrade pip setuptools wheel ninja && \
-    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 && \
+    pip3 install torch torchvision torchaudio && \
     pip3 install -r requirements.txt
 
 # https://developer.nvidia.com/cuda-gpus
@@ -44,7 +44,7 @@ RUN virtualenv /app/venv
 RUN --mount=type=cache,target=/root/.cache/pip,rw \
     . /app/venv/bin/activate && \
     pip3 install --upgrade pip setuptools wheel ninja && \
-    pip3 install torch --index-url https://download.pytorch.org/whl/cu118 && \
+    pip3 install torch && \
     pip3 install torchvision torchaudio sentence_transformers xformers
 
 # Copy and install GPTQ-for-LLaMa


### PR DESCRIPTION
Since @bdashore3 added CUDA 12.1 images, the explicit CUDA 11.8 ref for Torch set by @sammcj is no longer needed.

I tested this build locally with RTX 3060 and found no issues (other than a DEPRECATION NOTICE! from NVIDIA on 12.1).

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

