### PR TITLE
Support LLaVA v1.5 7B

### DIFF
--- a/extensions/multimodal/README.md
+++ b/extensions/multimodal/README.md
@@ -14,8 +14,10 @@ To run this extension, download a LLM that supports multimodality, and then star
 
 ```
 # due to dimension mismatch, currently there are two versions of llava-v1.5 pipelines
-python server.py --model liuhaotian_llava-v1.5-7b --multimodal-pipeline llava-v1.5-7b --load-in-4bit
+# LLaVA 1.5 13B has the best performance
 python server.py --model liuhaotian_llava-v1.5-13b --multimodal-pipeline llava-v1.5-13b --load-in-4bit
+# LLaVA 1.5 7B is relavtively weaker, but requires less memory
+python server.py --model liuhaotian_llava-v1.5-7b --multimodal-pipeline llava-v1.5-7b --load-in-4bit
 python server.py --model TheBloke_llava-v1.5-13B-GPTQ_gptq-4bit-32g-actorder_True --multimodal-pipeline llava-v1.5-13b --disable_exllama --loader autogptq
 python server.py --model wojtab_llava-7b-v0-4bit-128g --multimodal-pipeline llava-7b
 python server.py --model wojtab_llava-13b-v0-4bit-128g --multimodal-pipeline llava-13b

--- a/extensions/multimodal/README.md
+++ b/extensions/multimodal/README.md
@@ -13,6 +13,8 @@ https://user-images.githubusercontent.com/3718215/233817203-69b57e77-0c55-4fd6-b
 To run this extension, download a LLM that supports multimodality, and then start server.py with the appropriate `--multimodal-pipeline` argument. Examples:
 
 ```
+# due to dimension mismatch, currently there are two versions of llava-v1.5 pipelines
+python server.py --model liuhaotian_llava-v1.5-7b --multimodal-pipeline llava-v1.5-7b --load-in-4bit
 python server.py --model liuhaotian_llava-v1.5-13b --multimodal-pipeline llava-v1.5-13b --load-in-4bit
 python server.py --model TheBloke_llava-v1.5-13B-GPTQ_gptq-4bit-32g-actorder_True --multimodal-pipeline llava-v1.5-13b --disable_exllama --loader autogptq
 python server.py --model wojtab_llava-7b-v0-4bit-128g --multimodal-pipeline llava-7b

--- a/extensions/multimodal/README.md
+++ b/extensions/multimodal/README.md
@@ -13,10 +13,9 @@ https://user-images.githubusercontent.com/3718215/233817203-69b57e77-0c55-4fd6-b
 To run this extension, download a LLM that supports multimodality, and then start server.py with the appropriate `--multimodal-pipeline` argument. Examples:
 
 ```
-# due to dimension mismatch, currently there are two versions of llava-v1.5 pipelines
 # LLaVA 1.5 13B has the best performance
 python server.py --model liuhaotian_llava-v1.5-13b --multimodal-pipeline llava-v1.5-13b --load-in-4bit
-# LLaVA 1.5 7B is relavtively weaker, but requires less memory
+# LLaVA 1.5 7B is relatively weaker, but requires less memory
 python server.py --model liuhaotian_llava-v1.5-7b --multimodal-pipeline llava-v1.5-7b --load-in-4bit
 python server.py --model TheBloke_llava-v1.5-13B-GPTQ_gptq-4bit-32g-actorder_True --multimodal-pipeline llava-v1.5-13b --disable_exllama --loader autogptq
 python server.py --model wojtab_llava-7b-v0-4bit-128g --multimodal-pipeline llava-7b

--- a/extensions/multimodal/pipelines/llava/llava.py
+++ b/extensions/multimodal/pipelines/llava/llava.py
@@ -203,53 +203,6 @@ class LLaVA_LLaMA_2_13B_Pipeline(LLaVA_v0_13B_Pipeline):
         return LLaVA_v0_Pipeline.embed_tokens(encode("<unk>"*256, add_bos_token=False)[0])
 
 
-class LLaVA_v1_5_7B_Pipeline(LLaVA_v0_13B_Pipeline):
-    CLIP_REPO = "openai/clip-vit-large-patch14-336"
-
-    def __init__(self, params: dict) -> None:
-        super().__init__(params)
-
-    @staticmethod
-    def name() -> str:
-        return "llava-v1.5-7b"
-
-    @staticmethod
-    def llava_projector_shape() -> Tuple[int, int]:
-        return (1024, 4096, 4096)
-
-    @staticmethod
-    def placeholder_token_id() -> int:
-        return 0
-
-    @staticmethod
-    def llava_projector_repo() -> str:
-        return "cnut1648/llava-v1.5-7b"
-
-    @staticmethod
-    def image_start() -> str:
-        return ""
-
-    @staticmethod
-    def image_end() -> str:
-        return ""
-
-    @staticmethod
-    def num_image_embeds() -> int:
-        return 576
-
-    def embed_images(self, images: List[Image.Image]) -> torch.Tensor:
-        # pad it to square first
-        images = [
-            expand2square(image, tuple(int(x*255) for x in self.image_processor.image_mean))
-            for image in images
-        ]
-        return super().embed_images(images)
-
-    @staticmethod
-    def placeholder_embeddings() -> torch.Tensor:
-        return LLaVA_v0_Pipeline.embed_tokens(encode("<unk>"*576, add_bos_token=False)[0])
-
-
 class LLaVA_v1_5_13B_Pipeline(LLaVA_v0_13B_Pipeline):
     CLIP_REPO = "openai/clip-vit-large-patch14-336"
 
@@ -295,3 +248,15 @@ class LLaVA_v1_5_13B_Pipeline(LLaVA_v0_13B_Pipeline):
     @staticmethod
     def placeholder_embeddings() -> torch.Tensor:
         return LLaVA_v0_Pipeline.embed_tokens(encode("<unk>"*576, add_bos_token=False)[0])
+
+class LLaVA_v1_5_7B_Pipeline(LLaVA_v1_5_13B_Pipeline):
+    @staticmethod
+    def name() -> str:
+        return "llava-v1.5-7b"
+
+    @staticmethod
+    def llava_projector_shape() -> Tuple[int, int]:
+        return (1024, 4096, 4096)
+    @staticmethod
+    def llava_projector_repo() -> str:
+        return "cnut1648/llava-v1.5-7b"

--- a/extensions/multimodal/pipelines/llava/llava.py
+++ b/extensions/multimodal/pipelines/llava/llava.py
@@ -259,4 +259,4 @@ class LLaVA_v1_5_7B_Pipeline(LLaVA_v1_5_13B_Pipeline):
         return (1024, 4096, 4096)
     @staticmethod
     def llava_projector_repo() -> str:
-        return "cnut1648/llava-v1.5-7b"
+        return "liuhaotian/llava-v1.5-7b"

--- a/extensions/multimodal/pipelines/llava/llava.py
+++ b/extensions/multimodal/pipelines/llava/llava.py
@@ -203,6 +203,53 @@ class LLaVA_LLaMA_2_13B_Pipeline(LLaVA_v0_13B_Pipeline):
         return LLaVA_v0_Pipeline.embed_tokens(encode("<unk>"*256, add_bos_token=False)[0])
 
 
+class LLaVA_v1_5_7B_Pipeline(LLaVA_v0_13B_Pipeline):
+    CLIP_REPO = "openai/clip-vit-large-patch14-336"
+
+    def __init__(self, params: dict) -> None:
+        super().__init__(params)
+
+    @staticmethod
+    def name() -> str:
+        return "llava-v1.5-7b"
+
+    @staticmethod
+    def llava_projector_shape() -> Tuple[int, int]:
+        return (1024, 4096, 4096)
+
+    @staticmethod
+    def placeholder_token_id() -> int:
+        return 0
+
+    @staticmethod
+    def llava_projector_repo() -> str:
+        return "cnut1648/llava-v1.5-7b"
+
+    @staticmethod
+    def image_start() -> str:
+        return ""
+
+    @staticmethod
+    def image_end() -> str:
+        return ""
+
+    @staticmethod
+    def num_image_embeds() -> int:
+        return 576
+
+    def embed_images(self, images: List[Image.Image]) -> torch.Tensor:
+        # pad it to square first
+        images = [
+            expand2square(image, tuple(int(x*255) for x in self.image_processor.image_mean))
+            for image in images
+        ]
+        return super().embed_images(images)
+
+    @staticmethod
+    def placeholder_embeddings() -> torch.Tensor:
+        return LLaVA_v0_Pipeline.embed_tokens(encode("<unk>"*576, add_bos_token=False)[0])
+
+
 class LLaVA_v1_5_13B_Pipeline(LLaVA_v0_13B_Pipeline):
     CLIP_REPO = "openai/clip-vit-large-patch14-336"
 

--- a/extensions/multimodal/pipelines/llava/pipelines.py
+++ b/extensions/multimodal/pipelines/llava/pipelines.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from extensions.multimodal.abstract_pipeline import AbstractMultimodalPipeline
 
-available_pipelines = ['llava-7b', 'llava-13b', 'llava-llama-2-13b', 'llava-v1.5-13b']
+available_pipelines = ['llava-7b', 'llava-13b', 'llava-llama-2-13b', 'llava-v1.5-13b', 'llava-v1.5-7b']
 
 
 def get_pipeline(name: str, params: dict) -> Optional[AbstractMultimodalPipeline]:
@@ -15,6 +15,9 @@ def get_pipeline(name: str, params: dict) -> Optional[AbstractMultimodalPipeline
     if name == 'llava-llama-2-13b':
         from .llava import LLaVA_LLaMA_2_13B_Pipeline
         return LLaVA_LLaMA_2_13B_Pipeline(params)
+    if name == 'llava-v1.5-7b':
+        from .llava import LLaVA_v1_5_7B_Pipeline
+        return LLaVA_v1_5_7B_Pipeline(params)
     if name == 'llava-v1.5-13b':
         from .llava import LLaVA_v1_5_13B_Pipeline
         return LLaVA_v1_5_13B_Pipeline(params)
@@ -32,6 +35,9 @@ def get_pipeline_from_model_name(model_name: str, params: dict) -> Optional[Abst
         if '13b' in model_name.lower():
             from .llava import LLaVA_v1_5_13B_Pipeline
             return LLaVA_v1_5_13B_Pipeline(params)
+        if '7b' in model_name.lower():
+            from .llava import LLaVA_v1_5_7B_Pipeline
+            return LLaVA_v1_5_7B_Pipeline(params)
     else:
         if '7b' in model_name.lower():
             from .llava import LLaVA_v0_7B_Pipeline


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

## This PR supports LLaVA v1.5 7B.

The author @haotian-liu  has submitted the (already merged) PR https://github.com/oobabooga/text-generation-webui/pull/4305 that enables LLaVA v1.5 13B. However the current code does not work out of the box for v1.5 7B due to dimension mismatch. This PR supports the smaller 7B version so that LLaVA would be more accessible for people having less GPU memory like me.

- Add new `multimodal-pipeline` pipeline called `llava-v1.5-7b`

## Run LLaVA v1.5 7B

First download the model from offical [llava v1.5 7b repo](https://huggingface.co/liuhaotian/llava-v1.5-7b/tree/main).
```shell
python download-model.py liuhaotian/llava-v1.5-7b
```
Then in `models/` folder, change `config.json`'s "model_type" to be `llama` instead of `llava`, as suggested by @oobabooga in https://github.com/oobabooga/text-generation-webui/pull/4305. If you have `jq` installed you can do
```
jq '.model_type |= if . == "llava" then "llama" else . end' config.json > tmp.json && mv tmp.json config.json
```


Lastly simply run
```shell
python server.py \
    --model liuhaotian_llava-v1.5-7b \
    --load_in_4bit \
    --multimodal-pipeline llava-v1.5-7b
```
The result seems to be pretty good. The following is run using 3070, taking about 5638MiB memory.
<img width="656" alt="image" src="https://github.com/oobabooga/text-generation-webui/assets/37067883/97e7f46a-7b02-4a88-82c3-83f033822d61">


## Caveat
 
`mm_projector` reads from [my version of llava v1.5 7b repo](https://huggingface.co/cnut1648/llava-v1.5-7b/tree/main) since [author's official one](https://huggingface.co/liuhaotian/llava-v1.5-7b) does not have projector weights.