### PR TITLE
USE_CUDA118 from ENV remains null one_click.py

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -174,7 +174,7 @@ def install_webui():
     use_cuda118 = "N"
     if any((is_windows(), is_linux())) and choice == "A":
         if "USE_CUDA118" in os.environ:
-            use_cuda118 = os.environ.get("USE_CUDA118", "").lower() in ("yes", "y", "trye", "1", "t", "on")
+            use_cuda118 = "Y" if os.environ.get("USE_CUDA118", "").lower() in ("yes", "y", "trye", "1", "t", "on") else "N"
         else:
             # Ask for CUDA version if using NVIDIA
             print("\nWould you like to use CUDA 11.8 instead of 12.1? This is only necessary for older GPUs like Kepler.\nIf unsure, say \"N\".\n")
@@ -182,10 +182,10 @@ def install_webui():
             while use_cuda118 not in 'YN':
                 print("Invalid choice. Please try again.")
                 use_cuda118 = input("Input> ").upper().strip('"\'').strip()
-            if use_cuda118 == 'Y':
-                print(f"CUDA: 11.8")
-            else:
-                print(f"CUDA: 12.1")
+        if use_cuda118 == 'Y':
+            print(f"CUDA: 11.8")
+        else:
+            print(f"CUDA: 12.1")
 
         install_pytorch = f"python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/{'cu121' if use_cuda118 == 'N' else 'cu118'}"
     elif not is_macos() and choice == "B":


### PR DESCRIPTION
If you set ENV var USE_CUDA118=N, when assigning value to it only when is true, it remains null and not going on the 12 path for pytorch.

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
