### PR TITLE
Replace hashlib.sha256 with hashlib.file_digest, so we don't need to load entire files into ram before hashing them.

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -236,8 +236,7 @@ class ModelDownloader:
                 continue
 
             with open(output_folder / sha256[i][0], "rb") as f:
-                bytes = f.read()
-                file_hash = hashlib.sha256(bytes).hexdigest()
+                file_hash = hashlib.file_digest(f, "sha256").hexdigest()
                 if file_hash != sha256[i][1]:
                     print(f'Checksum failed: {sha256[i][0]}  {sha256[i][1]}')
                     validated = False


### PR DESCRIPTION
Replace hashlib.sha256 with hashlib.file_digest, so we don't need to load entire files into ram before hashing them.

I was running into an issue with running out of ram when it was hashing some 10GB+ pytorch model files, so I swapped out f.read() for hashlib's built-in file_digest(f, "sha256").

## Checklist:

- [✔ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
