### PR TITLE
ChatML.yaml - Open-Orca/Mistral-7B-OpenOrca - Model answers to itself

### DIFF
--- a/instruction-templates/ChatML.yaml
+++ b/instruction-templates/ChatML.yaml
@@ -1,7 +1,7 @@
 user: "user"
 bot: "assistant"
 context: |
-  <|im_start|>system
+  <|im_start|><|system|>
   <|im_end|>
 turn_template: "<|im_start|><|user|>\n<|user-message|><|im_end|>\n<|im_start|><|bot|>\n<|bot-message|><|im_end|>\n"
 


### PR DESCRIPTION
Using:
```
  <|im_start|>system
  <|im_end|>
```
Open-Orca/Mistral-7B-OpenOrca answers to itself because the "system" tag is incomplete.

Replacing "system" by "<|system|>" fixes it.

## Checklist:

- [ x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
