### PR TITLE
Fix stopping immediately when stop at loss is 0

### DIFF
--- a/modules/training.py
+++ b/modules/training.py
@@ -598,7 +598,7 @@ def do_train(lora_name: str, always_override: bool, q_proj_en: bool, v_proj_en: 
             print(f"\033[1;30;40mStep: {tracked.current_steps} \033[0;37;0m", end='')
             if 'loss' in logs:
                 loss = float(logs['loss'])
-                if loss <= stop_at_loss:
+                if stop_at_loss > 0 and loss <= stop_at_loss:
                     control.should_epoch_stop = True
                     control.should_training_stop = True
                     print(f"\033[1;31;1mStop Loss {stop_at_loss} reached.\033[0;37;0m")


### PR DESCRIPTION
This will prevent stopping when stop_at_loss is 0 (which is assumed as OFF)

I noticed on my copy that if eval_dataset exists then the training log *may* report 0 loss and 0 learning_rate. However I had not seen anybody else reporting this issue so I assume it is on my system only (i was messing with something). 

Regardless, when stop_at_loss is 0 this should not mess with training as it's assumed to be OFF.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
