### PR TITLE
Bugfix: Updating the shared settings object when loading a model

### DIFF
--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -212,6 +212,9 @@ def load_model_wrapper(selected_model, loader, autoload=False):
                 if 'instruction_template' in settings:
                     output += '\n\nIt seems to be an instruction-following model with template "{}". In the chat tab, instruct or chat-instruct modes should be used.'.format(settings['instruction_template'])
 
+                # Applying the changes to the global shared settings (in-memory)
+                shared.settings.update({k: v for k, v in settings.items() if k in shared.settings})
+
                 yield output
             else:
                 yield f"Failed to load `{selected_model}`."


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).


I realized this bug when I was trying to use OpenAI API. In that scenario, the settings for the loaded model (which can be accessed through the `shared` module) is holding the default values while it's supposed to hold the settings for the loaded model.

For instance, the template for prompts that will be loaded when sending a chat request will always will "Alpaca" regardless of which model is loaded. Basically, the OpenAI API was broken.

This change will apply the settings from the the loaded model to the shared module so it can be picked up when responding to an API request.