### PR TITLE
Allow for changing shared.settings during model load via API

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -125,7 +125,10 @@ class Handler(BaseHTTPRequestHandler):
             if action == 'load':
                 model_name = body['model_name']
                 args = body.get('args', {})
+                settings = body.get('settings', {})
                 print('args', args)
+                print('settings', settings)
+
                 for k in args:
                     setattr(shared.args, k, args[k])
 
@@ -138,6 +141,8 @@ class Handler(BaseHTTPRequestHandler):
 
                 if shared.settings['mode'] != 'instruct':
                     shared.settings['instruction_template'] = None
+
+                shared.settings.update(settings)
 
                 try:
                     shared.model, shared.tokenizer = load_model(shared.model_name)


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

## Reasoning

Sometimes, when you load a certain lora, you need to be able to change the `instruction_template` on the fly.

Rather than focus on that specific use case, allow for updating the `shared.settings` as a whole at the time of model load via the api.