### PR TITLE
[Fix] OpenOrca-Platypus2 models should use correct instruction_template when matching against models/config.yaml

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -45,9 +45,6 @@
 .*starchat-beta:
   instruction_template: 'Starchat-Beta'
   custom_stopping_strings: '"<|end|>"'
-.*(openorca-platypus2):
-  instruction_template: 'OpenOrca-Platypus2'
-  custom_stopping_strings: '"### Instruction:", "### Response:"'
 (?!.*v0)(?!.*1.1)(?!.*1_1)(?!.*stable)(?!.*chinese).*vicuna:
   instruction_template: 'Vicuna-v0'
 .*vicuna.*v0:
@@ -152,6 +149,9 @@
   instruction_template: 'Orca Mini'
 .*(platypus|gplatty|superplatty):
   instruction_template: 'Alpaca'
+.*(openorca-platypus2):
+  instruction_template: 'OpenOrca-Platypus2'
+  custom_stopping_strings: '"### Instruction:", "### Response:"'
 .*longchat:
   instruction_template: 'Vicuna-v1.1'
 .*vicuna-33b:


### PR DESCRIPTION
`models/config.yaml` applies ALL MATCHES sequentially as it compares model names with the supplied regexp keys.

This PR moves the `.*(openorca-platypus2)` entry to occur _after_ the `.*(platypus|gplatty|superplatty)` entry, thus allowing the more specific (and correct) match to occur afterwards.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
