### PR TITLE
Bump AWQ to 0.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,4 +84,4 @@ https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.1/gptq_for_
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.1/gptq_for_llama-0.1.1+cu121-cp39-cp39-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.9"
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.1/gptq_for_llama-0.1.1+cu121-cp38-cp38-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.8"
 https://github.com/jllllll/ctransformers-cuBLAS-wheels/releases/download/AVX2/ctransformers-0.2.27+cu121-py3-none-any.whl
-autoawq==0.1.5; platform_system == "Linux" or platform_system == "Windows"
+autoawq==0.1.6; platform_system == "Linux" or platform_system == "Windows"

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -84,4 +84,4 @@ https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.1/gptq_for_
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.1/gptq_for_llama-0.1.1+cu121-cp39-cp39-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.9"
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.1/gptq_for_llama-0.1.1+cu121-cp38-cp38-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.8"
 https://github.com/jllllll/ctransformers-cuBLAS-wheels/releases/download/AVX/ctransformers-0.2.27+cu121-py3-none-any.whl
-autoawq==0.1.5; platform_system == "Linux" or platform_system == "Windows"
+autoawq==0.1.6; platform_system == "Linux" or platform_system == "Windows"


### PR DESCRIPTION
Changes:
- upgrades to transformers 4.35.0 (4.35.0 is not compatible with AutoAWQ 0.1.5)
- fix performance regression (25% speedup) from previous refactor
- upgrade to torch 2.1.0 and CUDA 12.1.1

NOTE: v0.1.6 is in the process of being released, currently building https://github.com/casper-hansen/AutoAWQ/releases/tag/v0.1.6. When it is available on PyPi, I will mark this PR ready, until then it is a draft.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
