### PR TITLE
Fix API arguments not applying

### DIFF
--- a/extensions/api/blocking_api.py
+++ b/extensions/api/blocking_api.py
@@ -124,9 +124,6 @@ class Handler(BaseHTTPRequestHandler):
             if action == 'load':
                 model_name = body['model_name']
                 args = body.get('args', {})
-                print('args', args)
-                for k in args:
-                    setattr(shared.args, k, args[k])
 
                 shared.model_name = model_name
                 unload_model()
@@ -134,6 +131,9 @@ class Handler(BaseHTTPRequestHandler):
                 model_settings = get_model_metadata(shared.model_name)
                 shared.settings.update({k: v for k, v in model_settings.items() if k in shared.settings})
                 update_model_parameters(model_settings, initial=True)
+                print('args', args)
+                for k in args:
+                    setattr(shared.args, k, args[k])
 
                 if shared.settings['mode'] != 'instruct':
                     shared.settings['instruction_template'] = None


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

The API parameters used to load the model get overwritten by the model's metadata. In particular, it breaks the use case when the model is loaded via API with `alpha_value`/`compress_pos_emb` specified and a different `max_seq_len`. Since `max_seq_len` is usually present in the model config it gets overwritten and the context size stays default. I moved the API arguments application after the model defaults and it now works as expected.