### PR TITLE
OpenAI API: Don't strip leading space from completions

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -390,10 +390,6 @@ def completions_common(body: dict, is_legacy: bool = False, stream=False):
             for a in generator:
                 answer = a
 
-            # strip extra leading space off new generated content
-            if answer and answer[0] == ' ':
-                answer = answer[1:]
-
             completion_token_count = len(encode(answer)[0])
             total_completion_token_count += completion_token_count
             stop_reason = "stop"
@@ -474,10 +470,6 @@ def completions_common(body: dict, is_legacy: bool = False, stream=False):
                 continue
 
             seen_content = answer
-
-            # strip extra leading space off new generated content
-            if len_seen == 0 and new_content[0] == ' ':
-                new_content = new_content[1:]
 
             chunk = text_streaming_chunk(new_content)
 


### PR DESCRIPTION
The current OpenAI api has a section of code in completions that removes a leading whitespace if it is present. However, this block breaks features in frontends such as Sillytavern's "continue" option. This takes the current fragement and attempts to fill it in by asking the model in a prompt.

Here is an example with and without this change using adventure mode style prompting (which requires continuing the first message):

Prompt:
> Fiomar is an ancient world of myth and magic. The world has been locked in eternal winter since the arrival of the wicked fey called the Snow Queen and her army of Ice Giants. The few survivors hide in scattered villages, beset by the raiding parties of the Snow Queen's minions.
You are John, a

Response without this PR:
> Fiomar is an ancient world of myth and magic. The world has been locked in eternal winter since the arrival of the wicked fey called the Snow Queen and her army of Ice Giants. The few survivors hide in scattered villages, beset by the raiding parties of the Snow Queen's minions.
You are John, ayoung human from one such village. Your village has been struggling to survive under the oppressive rule of the Snow Queen. Food is scarce, and every day you must fight against the cold just to stay alive. One day, while hunting for food with your trusty bow and arrow, you stumble upon a hidden valley filled with lush vegetation. This place seems immune to the effects of winter! Curiosity gets the better of you, and you decide to investigate further…

Response with this PR:
> Fiomar is an ancient world of myth and magic. The world has been locked in eternal winter since the arrival of the wicked fey called the Snow Queen and her army of Ice Giants. The few survivors hide in scattered villages, beset by the raiding parties of the Snow Queen's minions.
You are John, a young human from one such village. Your village has been struggling to survive under the oppressive rule of the Snow Queen. Food is scarce, and every day you must fight against the cold just to stay alive. One day, while hunting for food with your trusty bow and arrow, you stumble upon a hidden valley filled with lush vegetation. This place seems immune to the effects of winter! Curiosity gets the better of you, and you decide to investigate further…

So, without this PR, continue results in removal of the leading whitespace leading to `ayoung` being produced instead of `a young` at the beginning of the response.

I kept the leading space removal in the chat completion endpoint because I'm not entirely sure why a leading space is removed in the first place. However, if it's not necessary, the pruning can be removed from there as well.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
