### PR TITLE
Fix bug with /internal/model/load API

### DIFF
--- a/extensions/openai/models.py
+++ b/extensions/openai/models.py
@@ -55,7 +55,8 @@ def _load_model(data):
                 setattr(shared.args, k, args[k])
 
     shared.model, shared.tokenizer = load_model(model_name)
-
+    shared.model_name = model_name
+    
     # Update shared.settings with custom generation defaults
     if settings:
         for k in settings:


### PR DESCRIPTION
/internal/model/load API calls would not update shared.model_name. Kept wondering why /internal/model/info would always show the previous model and I could not check to know if I was already running a specific model before asking to load it through the API.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
