### PR TITLE
Fix bug with /internal/model/load

### DIFF
--- a/extensions/openai/models.py
+++ b/extensions/openai/models.py
@@ -55,7 +55,8 @@ def _load_model(data):
                 setattr(shared.args, k, args[k])
 
     shared.model, shared.tokenizer = load_model(model_name)
-
+    shared.model_name = model_name
+    
     # Update shared.settings with custom generation defaults
     if settings:
         for k in settings:


### PR DESCRIPTION
Update shared.model_name after loading model through API call. Kept wondering why /internal/model/info kept giving me the old model, and could not use /internal/model/load to check if a model was already loaded before sending the API call to load it.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
