### PR TITLE
Use system message in chat instruct

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -91,7 +91,12 @@ def generate_chat_prompt(user_input, state, **kwargs):
     if state['mode'] == 'chat-instruct':
         wrapper = ''
         command = state['chat-instruct_command'].replace('<|character|>', state['name2'] if not impersonate else state['name1'])
-        wrapper += state['context_instruct']
+        context_instruct = state['context_instruct']
+        if state['custom_system_message'].strip() != '':
+            context_instruct = context_instruct.replace('<|system-message|>', state['custom_system_message'])
+        else:
+            context_instruct = context_instruct.replace('<|system-message|>', state['system_message'])
+        wrapper += context_instruct
         wrapper += all_substrings['instruct']['user_turn'].replace('<|user-message|>', command)
         wrapper += all_substrings['instruct']['bot_turn_stripped']
         if impersonate:


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

This PR allows instruction templates to insert their system message into the context of the prompt in chat-instruct mode.

As an example, before this change, the constructed prompt with the Llama-v2 instruction template in chat-instruct mode would look like this:

```
[INST] <<SYS>>
<|system-message|>
<</SYS>>

Continue the chat dialogue below. Write a single reply for the character "AI".

The following is a conversation with an AI Large Language Model. The AI has been trained to answer questions, provide recommendations, and help with decision making. The AI follows user requests. The AI thinks outside the box.
AI: How can I help you today?
You: Write a hello world program in Python.
 [/INST] AI:
```

Note that verbatim string `<|system-message|>` is provided to the tokenizer instead of the system message itself.

With this change, the constructed prompt with Llama-v2 instruction template in chat-instruct mode looks like this:

```
[INST] <<SYS>>
Answer the questions.
<</SYS>>

Continue the chat dialogue below. Write a single reply for the character "AI".

The following is a conversation with an AI Large Language Model. The AI has been trained to answer questions, provide recommendations, and help with decision making. The AI follows user requests. The AI thinks outside the box.
AI: How can I help you today?
You: Write a hello world program in Python.
 [/INST] AI:
```

The system message in the Llama-v2 instruction template is "Answer the questions." and it is now correctly included in the prompt.

These examples use the Llama-v2 instruction template, but the changes apply to any instruction template that has the string `<|system-message|>` in its **Context** field. If the **Custom system message** field is not empty, its contents will be used instead of the **System message** field.