### PR TITLE
Use shared chat-instruct_command with api

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -203,6 +203,7 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False) -
     turn_template = body['turn_template'] or turn_template
     context_instruct = body['context_instruct'] or context_instruct
     system_message = body['system_message'] or system_message
+    chat_instruct_command = body['chat_instruct_command'] or shared.settings['chat-instruct_command']
 
     # Chat character
     character = body['character'] or shared.settings['character']
@@ -228,7 +229,7 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False) -
         'system_message': system_message,
         'custom_system_message': custom_system_message,
         'turn_template': turn_template,
-        'chat-instruct_command': body['chat_instruct_command'],
+        'chat-instruct_command': chat_instruct_command,
         'history': history,
         'stream': stream
     })


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

This PR sets `chat-instruct_command` to the shared UI setting when called from the API, making the corresponding `chat_instruct_command` API parameter optional when using chat-instruct mode.

Without this PR, when calling the API with chat-instruct mode, the following error is thrown when no `chat_instruct_command` parameter is provided.

```
  File "text-generation-webui\modules\chat.py", line 93, in generate_chat_prompt
    command = state['chat-instruct_command'].replace('<|character|>', state['name2'] if not impersonate else state['name1'])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```

With this PR, the API call succeeds when the `chat_instruct_command` parameter is not provided since it defaults to the UI setting.