### PR TITLE
Import accelerate very early to make Intel GPU happy

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,5 @@
+import accelerate;
+
 import os
 import warnings
 


### PR DESCRIPTION
 Import `accelerate` first in `server.py`, or the `accelerate.utils.is_xpu_available()` will return `False` if imported later.

Note: this is only a workaround. At least it works for now. Needs more testing. 

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
