### PR TITLE
replace IdToPiece function to  id_to_piece for new exllamav2 tokenizer class and support for deepseek models

### DIFF
--- a/modules/exllamav2.py
+++ b/modules/exllamav2.py
@@ -131,7 +131,7 @@ class Exllamav2Model:
             token, _, _ = ExLlamaV2Sampler.sample(logits, settings, ids, random.random(), self.tokenizer)
             ids = torch.cat([ids, token], dim=1)
 
-            if i == 0 and self.tokenizer.tokenizer.IdToPiece(int(token)).startswith('▁'):
+            if i == 0 and self.tokenizer.tokenizer.id_to_piece(int(token)).startswith('▁'):
                 has_leading_space = True
 
             decoded_text = self.tokenizer.decode(ids[:, initial_len:], decode_special_tokens=not state['skip_special_tokens'])[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate==0.24.*
 colorama
 datasets
 einops
-exllamav2==0.0.8; platform_system != "Darwin" and platform_machine != "x86_64"
+exllamav2==0.0.10; platform_system != "Darwin" and platform_machine != "x86_64"
 gradio==3.50.*
 markdown
 numpy==1.24.*


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
The exllamaV2 adding HF tokenizer support which abstract the original `sentence piece` function `IdToPiece` into `id_to_piece`
1. update exllamaV2 loader to using version `0.0.10` to support deepseek model family
2. Test the fixed for model using both `tokenizer.model`  and `tokenizer.json`
