### PR TITLE
Clean shutdown on Ctrl+c

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -8,6 +8,17 @@ import site
 import subprocess
 import sys
 
+#### CAPTURE CTRL+C AND SHUTDOWN ######
+import signal
+from datetime import datetime
+current_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+def signal_handler(sig, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, signal_handler) 
+#### ALL THE NORMAL SCRIPT BELOW ######
+
 script_dir = os.getcwd()
 conda_env_path = os.path.join(script_dir, "installer_files", "env")
 

--- a/server.py
+++ b/server.py
@@ -53,6 +53,15 @@ from modules.models_settings import (
 )
 from modules.utils import gradio
 
+#### CAPTURE CTRL+C AND SHUTDOWN ######
+import signal
+def signal_handler(sig, frame):
+    logger.info(f"Received Ctrl+C. Shutting down Text-Generation-WebUI gracefully")
+    shared.gradio['interface'].close()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, signal_handler)
+#### ALL THE NORMAL SCRIPT BELOW ######
 
 def create_interface():
 


### PR DESCRIPTION
Have "imported signal" to both: 

**one_click.py** new lines are **11-20**
and 
**server.py** new lines are **56-64**

Server.py will output a logger message "**Received Ctrl+C. Shutting down Text-Generation-WebUI gracefully**" this will be shown on any OS.

This reduces the sprawl of text (mainly on Windows) when you Ctrl+C out of either the start_windows.bat or python server.py

Have updated the 2x files so it **now does this**:
![image](https://github.com/oobabooga/text-generation-webui/assets/35898566/43a5fefd-1f9f-410c-a6e6-7207eecec553)

Windows **normally** does this on Ctrl+C: 
![image](https://github.com/oobabooga/text-generation-webui/assets/35898566/203edb48-fe2c-47dc-9787-0484d4371da0)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
