### PR TITLE
fix api custom_stopping_strings

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -85,7 +85,7 @@ def process_parameters(body, is_legacy=False):
         preset = load_preset_memoized(body['preset'])
         generate_params.update(preset)
 
-    generate_params['custom_stopping_strings'] = []
+    generate_params['custom_stopping_strings'] = shared.settings['custom_stopping_strings']
     if 'stop' in body:  # str or array, max len 4 (ignored)
         if isinstance(body['stop'], str):
             generate_params['custom_stopping_strings'] = [body['stop']]


### PR DESCRIPTION
Get default custom_stopping_strings from shared.setting['custom_stopping_strings']

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
