### PR TITLE
Allow symlinked folder within root directory

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -21,16 +21,17 @@ def save_file(fname, contents):
         return
 
     root_folder = Path(__file__).resolve().parent.parent
-    abs_path = Path(fname).resolve()
-    rel_path = abs_path.relative_to(root_folder)
+    abs_path_str = os.path.abspath(fname)
+    rel_path_str = os.path.relpath(abs_path_str, root_folder)
+    rel_path = Path(rel_path_str)
     if rel_path.parts[0] == '..':
         logger.error(f'Invalid file path: {fname}')
         return
 
-    with open(abs_path, 'w', encoding='utf-8') as f:
+    with open(abs_path_str, 'w', encoding='utf-8') as f:
         f.write(contents)
 
-    logger.info(f'Saved {abs_path}.')
+    logger.info(f'Saved {abs_path_str}.')
 
 
 def delete_file(fname):
@@ -39,8 +40,9 @@ def delete_file(fname):
         return
 
     root_folder = Path(__file__).resolve().parent.parent
-    abs_path = Path(fname).resolve()
-    rel_path = abs_path.relative_to(root_folder)
+    abs_path_str = os.path.abspath(fname)
+    rel_path_str = os.path.relpath(abs_path_str, root_folder)
+    rel_path = Path(rel_path_str)
     if rel_path.parts[0] == '..':
         logger.error(f'Invalid file path: {fname}')
         return


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

This change removes resolving folder paths such that symlinked folders will now function, while still maintaining the original checks to make sure that changes aren't being made outside the root folder.

So any folders that have a relative path containing ../ (such as ~/home/presets, ../presets, /presets) will fail, but if you create a folder within your root folder of the project and symlink it outside, that will be fine

Tested adding a file and deleting a file which still work properly, tested trying to save outside the root folder which still fails properly

Ideally I will also look at having it fail more gracefully, since in its current state it just causes an error output in CLI and breaks the UI until you reload if you pass in an invalid path (which is the current behaviour in master, not caused by my changes)