### PR TITLE
Make new browser reloads recognize current model (fixes #4843)

### DIFF
--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -58,7 +58,7 @@ def create_ui():
                 with gr.Row():
                     with gr.Column():
                         with gr.Row():
-                            shared.gradio['model_menu'] = gr.Dropdown(choices=utils.get_available_models(), value=shared.model_name, label='Model', elem_classes='slim-dropdown', interactive=not mu)
+                            shared.gradio['model_menu'] = gr.Dropdown(choices=utils.get_available_models(), value=lambda: shared.model_name, label='Model', elem_classes='slim-dropdown', interactive=not mu)
                             ui.create_refresh_button(shared.gradio['model_menu'], lambda: None, lambda: {'choices': utils.get_available_models()}, 'refresh-button', interactive=not mu)
                             shared.gradio['load_model'] = gr.Button("Load", visible=not shared.settings['autoload_model'], elem_classes='refresh-button', interactive=not mu)
                             shared.gradio['unload_model'] = gr.Button("Unload", elem_classes='refresh-button', interactive=not mu)


### PR DESCRIPTION
This fixes a long-standing UI bug #4843 the simplest way possible.

Essentially instead of just giving the model name as the value, which then gets cached and not replaced...ever, we give a `Callable` that returns the current model name so each time it generates the UI for a 'new' browser session, it updates the model name to be whatever's current.

Before this change, the displayed name would always be the default after a reload or when hit by another browser. I ran into it most often when switching between iPhone and desktop. With this change it shows the latest model loaded. And yes, the pull request is a hundred times longer than the change, but it took me hours to get here. 🤣

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
