### PR TITLE
Fix deleting chat logs

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -47,8 +47,8 @@ def delete_file(fname):
         logger.error(f'Invalid file path: {fname}')
         return
 
-    if abs_path.exists():
-        abs_path.unlink()
+    if rel_path.exists():
+        rel_path.unlink()
         logger.info(f'Deleted {fname}.')
 
 


### PR DESCRIPTION
Fixes bug introduced by https://github.com/oobabooga/text-generation-webui/commit/f51156705d0b801226b6e431376dea5091870410.
Tested and working on normal, symlinked and junction `logs` directory.
```bash
  File "...\modules\chat.py", line 545, in delete_history
    delete_file(p)
  File "...\modules\utils.py", line 50, in delete_file
    if abs_path.exists():
       ^^^^^^^^
NameError: name 'abs_path' is not defined
```

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
