### PR TITLE
superboogaV2 requirements adjustment for issue #4307

### DIFF
--- a/extensions/superboogav2/requirements.txt
+++ b/extensions/superboogav2/requirements.txt
@@ -8,3 +8,4 @@ sentence_transformers==2.2.2
 spacy
 pytextrank
 num2words
+pydantic==1.10.12


### PR DESCRIPTION
- [x] _I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines)._

# Workaround for issue loading superboogav2 extension

## Issue

When activating the superboogav2 extension, after installing the needed packages via _extensions/requirements.txt_, the following error message and stack trace occurs in the console when launching ooba with the extension enabled:

<details>
<summary>(expand) Failed to load the extension "superboogav2" due to error in chromadb --> pydantic</summary>

```
06:43:27-618399 INFO     Loading the extension "superboogav2"
06:43:27-623398 ERROR    Failed to load the extension "superboogav2".
Traceback (most recent call last):
  File "G:\AI\LLMs\text-generation-webui\modules\extensions.py", line 37, in load_extensions
    exec(f"import extensions.{name}.script")
  File "<string>", line 1, in <module>
  File "G:\AI\LLMs\text-generation-webui\extensions\superboogav2\script.py", line 20, in <module>
    from .chromadb import make_collector
  File "G:\AI\LLMs\text-generation-webui\extensions\superboogav2\chromadb.py", line 2, in <module>
    import chromadb
  File "G:\AI\LLMs\text-generation-webui\installer_files\env\Lib\site-packages\chromadb\__init__.py", line 1, in <module>
    import chromadb.config
  File "G:\AI\LLMs\text-generation-webui\installer_files\env\Lib\site-packages\chromadb\config.py", line 1, in <module>
    from pydantic import BaseSettings
  File "G:\AI\LLMs\text-generation-webui\installer_files\env\Lib\site-packages\pydantic\__init__.py", line 363, in __getattr__
    return _getattr_migration(attr_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\AI\LLMs\text-generation-webui\installer_files\env\Lib\site-packages\pydantic\_migration.py", line 296, in wrapper
    raise PydanticImportError(
pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package. See https://docs.pydantic.dev/2.5/migration/#basesettings-has-moved-to-pydantic-settings for more details.

For further information visit https://errors.pydantic.dev/2.5/u/import-error
```

</details>

### Root cause:

The package `pydantic` updated a while back as can be seen here.  However it's the dependency `chromadb` that is causing the thrown error.  The version set to be installed (`chromadb==0.3.18`) is incompatible with more recent versions of pydantic, as discussed in their associated issue below.

### Separate incidents:

- The open issue mentioned: https://github.com/oobabooga/text-generation-webui/issues/4307

- Recent comment on the original PR discussion for superboogav2:  https://github.com/oobabooga/text-generation-webui/pull/3272#issuecomment-1835312636


## Contained solution

This [comment on #4307](https://github.com/oobabooga/text-generation-webui/issues/4307#issuecomment-1858686179) suggests locking pydantic to version 1.10.12, which works to get the extension to load.  Others' comments and reactions and my personal testing (launching the extension and minimal use) seem to resolve the issue.

This PR simply locks the package requirement to 1.10.12.  Note that this is the same version that the base _requirements.txt_ for ooba was locked to (see next note).

## Notes

### Context within this repo, text-generation-webui

- Previously, the base _requirements.txt_ for ooba was locked to this same version ever since https://github.com/oobabooga/text-generation-webui/commit/66d5caba1b79b060ca1a5626d9c958711ba1e3b6
  - This was the case until https://github.com/oobabooga/text-generation-webui/pull/4258 when [requirements changed a lot](https://github.com/oobabooga/text-generation-webui/blob/fae8062d393edb84f74ec3ad5a1192dd83eb6875/requirements.txt) and `pydantic` was removed.
  - It seems to not have been mentioned or modified since that time.
  - Note, a small file from the openai extension is also using the same deprecated functionality that raises the exception in the `chromadb` package: 
  https://github.com/oobabooga/text-generation-webui/blob/4b25acf58f78ee8821fc5bf325f602583bfa513f/extensions/openai/typing.py#L5

### Thoughts

Not sure why `chromadb` is locked to 0.3.18 in the original commit.  Any idea @HideLord ?  Is it [just because superbooga 1 did so](https://github.com/oobabooga/text-generation-webui/blob/main/extensions/superbooga/requirements.txt)?
- `chromadb` did eventually [patch to work with pydantic v2](https://github.com/chroma-core/chroma/pull/1174) - closing out their similar [bug report](https://github.com/chroma-core/chroma/issues/774) which is what led me to #4307.
  - So if `chromadb` is just locked there because it was what was used at the time, it would be worth fully testing the current version with the extension, then removing this separate and possibly conflicting dependency from this file altogether.

But wait!  The latest `gradio` dependency [does use a 2.0+ version of chromadb in their requirements.txt](https://github.com/gradio-app/gradio/blob/main/requirements.txt)!  However, I'm not sure about this repo's current dependency (`gradio==3.50.*`) or any repercussions - there are no issues so far in _my_ testing, but it is certainly worth noting.  
  - This makes this **better as a _temporary_ patch for users of the extension** - there seems to be good reason to update the extensions to not use outdated `chromadb`, and to follow whatever `gradio` uses.  Therefore I will not be disappointed if this PR is rejected - instead this will hopefully serve as a good reference for now.

