### PR TITLE
Add gpt-fast loader (pure PyTorch)

### DIFF
--- a/modules/gpt_fast_hf.py
+++ b/modules/gpt_fast_hf.py
@@ -18,7 +18,6 @@ from modules.logging_colors import logger
 from transformers import LogitsProcessorList, is_torch_xpu_available
 
 
-
 class GptFastHF(PreTrainedModel):
     def __init__(self, model, device):
         super().__init__(PretrainedConfig())
@@ -52,7 +51,6 @@ class GptFastHF(PreTrainedModel):
         seq = input_ids[0]
         reset = True
 
-        a = torch.tensor([[0]], device=self.torch_device, dtype=torch.int32)
         if labels is None:
             if past_seq is not None:
                 min_length = min(past_seq.shape[0], seq.shape[0])

--- a/modules/gpt_fast_hf.py
+++ b/modules/gpt_fast_hf.py
@@ -1,0 +1,125 @@
+from modules.relative_imports import RelativeImport
+
+with RelativeImport("repositories/gpt-fast"):
+    from generate import _load_model
+    from tp import maybe_init_dist
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import torch
+from torch.nn import CrossEntropyLoss
+from transformers import GenerationConfig, PretrainedConfig, PreTrainedModel
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+from modules import shared
+from modules.logging_colors import logger
+
+
+class GptFastHF(PreTrainedModel):
+    def __init__(self, model):
+        super().__init__(PretrainedConfig())
+        self.model = model
+        self.generation_config = GenerationConfig()
+        self.past_seq = None
+        self.n_tokens = 0
+
+    def _validate_model_class(self):
+        pass
+
+    def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
+        pass
+
+    def prepare_inputs_for_generation(self, input_ids, **kwargs):
+        return {'input_ids': input_ids, **kwargs}
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(0)
+
+    def __call__(self, *args, **kwargs):
+        use_cache = kwargs.get('use_cache', True)
+        labels = kwargs.get('labels', None)
+        past_key_values = kwargs.get('past_key_values', None)
+
+        input_ids = kwargs['input_ids']
+        past_seq = self.past_seq
+
+        seq = input_ids[0].tolist()
+        seq_tensor = torch.tensor(seq)
+        reset = True
+
+        if labels is None:
+            if past_seq is not None:
+                min_length = min(past_seq.shape[0], seq_tensor.shape[0])
+                indices = torch.nonzero(~torch.eq(past_seq[:min_length], seq_tensor[:min_length]))
+                if len(indices) > 0:
+                    longest_prefix = indices[0].item()
+                else:
+                    longest_prefix = min_length
+
+                if longest_prefix > 0:
+                    reset = False
+                    self.n_tokens = longest_prefix
+                    if len(seq_tensor) - longest_prefix > 0:
+                        for token in seq[longest_prefix:]:
+                            a = torch.tensor([[token]], device='cuda:0', dtype=torch.int32)
+                            b = torch.tensor([self.n_tokens], device='cuda:0', dtype=torch.int32)
+                            logits = self.model(a, b)
+                            self.n_tokens += 1
+
+            if reset:
+                self.n_tokens = 0
+                for token in seq:
+                    a = torch.tensor([[token]], device='cuda:0', dtype=torch.int32)
+                    b = torch.tensor([self.n_tokens], device='cuda:0', dtype=torch.int32)
+                    logits = self.model(a, b)
+                    self.n_tokens += 1
+
+            logits = logits.to(input_ids.device)
+        # else:
+        #     logits = self.model(input_ids).to(input_ids.device)
+
+        self.past_seq = seq_tensor
+
+        loss = None
+        # if labels is not None:
+        #     # Shift so that tokens < n predict n
+        #     shift_logits = logits[..., :-1, :].contiguous()
+        #     shift_labels = labels[..., 1:].contiguous()
+        #     # Flatten the tokens
+        #     loss_fct = CrossEntropyLoss()
+        #     shift_logits = shift_logits.view(-1, logits.shape[-1])
+        #     shift_labels = shift_labels.view(-1)
+        #     # Enable model parallelism
+        #     shift_labels = shift_labels.to(shift_logits.device)
+        #     loss = loss_fct(shift_logits, shift_labels)
+
+        return CausalLMOutputWithPast(logits=logits, past_key_values=None, loss=loss)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], *model_args, **kwargs):
+        assert len(model_args) == 0 and len(kwargs) == 0, "extra args is currently not supported"
+
+        if isinstance(pretrained_model_name_or_path, str):
+            pretrained_model_name_or_path = Path(pretrained_model_name_or_path)
+
+        path = Path(f'{shared.args.model_dir}') / Path(pretrained_model_name_or_path)
+        model_file = list(path.glob('*.pth'))[0]
+        logger.info(f"Model weights detected: {model_file}\n")
+
+        # From here on the code has been copied from
+        # https://github.com/pytorch-labs/gpt-fast/blob/main/generate.py
+        rank = maybe_init_dist()
+        use_tp = rank is not None
+        device = 'cuda'
+        precision = torch.bfloat16
+
+        model = _load_model(model_file, device, precision, use_tp)
+        torch.cuda.synchronize()
+
+        with torch.device(device):
+            model.setup_caches(max_batch_size=1, max_seq_length=2048)
+
+        return GptFastHF(model)

--- a/modules/gpt_fast_hf.py
+++ b/modules/gpt_fast_hf.py
@@ -72,7 +72,7 @@ class GptFastHF(PreTrainedModel):
                     elif len(seq) == longest_prefix:
                         # Very tricky: if the prefix we are reusing *is* the input_ids, then we have to back up the cache pointer by one,
                         # because we feed input_ids[-1] to forward() below, but that last token is already in the cache!
-                        ex_cache.current_seq_len -= 1
+                        self.n_tokens -= 1
 
             if reset:
                 self.n_tokens = 0
@@ -132,7 +132,7 @@ class GptFastHF(PreTrainedModel):
 
         logger.info(f"Device: {device}")
         model = _load_model(model_file, device, precision, use_tp)
-        torch.cuda.synchronize()
+        # torch.cuda.synchronize()
 
         with torch.device(device):
             model.setup_caches(max_batch_size=1, max_seq_length=shared.args.max_seq_len)

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -147,7 +147,11 @@ loaders_and_params = OrderedDict({
         'hqq_backend',
         'trust_remote_code',
         'no_use_fast',
-    ]
+    ],
+    'gpt-fast': [
+        'trust_remote_code',
+        'no_use_fast',
+    ],
 })
 
 
@@ -308,6 +312,37 @@ loaders_samplers = {
         'top_k',
         'repetition_penalty',
         'repetition_penalty_range',
+    },
+    'gpt-fast': {
+        'temperature',
+        'temperature_last',
+        'top_p',
+        'min_p',
+        'top_k',
+        'typical_p',
+        'epsilon_cutoff',
+        'eta_cutoff',
+        'tfs',
+        'top_a',
+        'repetition_penalty',
+        'presence_penalty',
+        'frequency_penalty',
+        'repetition_penalty_range',
+        'encoder_repetition_penalty',
+        'no_repeat_ngram_size',
+        'min_length',
+        'seed',
+        'do_sample',
+        'mirostat_mode',
+        'mirostat_tau',
+        'mirostat_eta',
+        'grammar_file_row',
+        'grammar_string',
+        'ban_eos_token',
+        'custom_token_bans',
+        'add_bos_token',
+        'skip_special_tokens',
+        'auto_max_new_tokens',
     },
 }
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -71,6 +71,7 @@ def load_model(model_name, loader=None):
         'AutoAWQ': AutoAWQ_loader,
         'QuIP#': QuipSharp_loader,
         'HQQ': HQQ_loader,
+        'gpt-fast': gpt_fast_loader,
     }
 
     metadata = get_model_metadata(model_name)
@@ -399,6 +400,12 @@ def HQQ_loader(model_name):
     model = HQQModelForCausalLM.from_quantized(str(model_dir))
     HQQLinear.set_backend(getattr(HQQBackend, shared.args.hqq_backend))
     return model
+
+
+def gpt_fast_loader(model_name):
+    from modules.gpt_fast_hf import GptFastHF
+
+    return GptFastHF.from_pretrained(model_name)
 
 
 def get_max_memory_dict():

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -259,6 +259,8 @@ def fix_loader_name(name):
         return 'QuIP#'
     elif name in ['hqq']:
         return 'HQQ'
+    elif name in ['gptfast', 'gpt-fast', 'gpt_fast']:
+        return 'gpt-fast'
 
 
 def add_extension(name, last=False):


### PR DESCRIPTION
Reference: https://github.com/pytorch-labs/gpt-fast

The advantage of this backend is that it requires no wheels or compiled extensions. It is 100% PyTorch, so it should in principle work on any GPU (including AMD, Intel Arc, and Metal).

Feedback is welcome.

### Installation

It is necessary to upgrade to the latest PyTorch (Nightly) and clone the repository:

```
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121 --upgrade
git clone https://github.com/pytorch-labs/gpt-fast repositories
```

The first command changes for each hardware and can be found here: https://pytorch.org/get-started/locally/

### Model conversion

```
python scripts/convert_hf_checkpoint.py --checkpoint_dir models/llama-2-7b-hf
python quantize.py --checkpoint_path models/llama-2-7b-hf/model.pth --mode int4
```

### Load a model

```
python server.py --model llama-2-7b-hf --loader "gpt-fast"
```

### TODO

It is possible to use `torch.compile()` with this backend, which improves performance by a factor of around 2. I haven't added the option yet.