### PR TITLE
Reduce the number of built-in presets

### DIFF
--- a/docs/03 - Parameters Tab.md
+++ b/docs/03 - Parameters Tab.md
@@ -21,7 +21,7 @@ These were obtained after a blind contest called "Preset Arena" where hundreds o
 
 A key takeaway is that the best presets are:
 
-* **For Instruct**: Divine Intellect, Big O, simple-1, Space Alien, StarChat, Titanic, tfs-with-top-a, Asterism, Contrastive Search (only works for the Transformers loader at the moment).
+* **For Instruct**: Divine Intellect, Big O, simple-1.
 * **For Chat**: Midnight Enigma, Yara, Shortwave.
 
 The other presets are:

--- a/presets/Asterism.yaml
+++ b/presets/Asterism.yaml
@@ -1,4 +1,0 @@
-temperature: 1.68
-top_p: 0.17
-repetition_penalty: 1.02
-top_k: 77

--- a/presets/Mirostat.yaml
+++ b/presets/Mirostat.yaml
@@ -1,2 +1,0 @@
-mirostat_mode: 2
-mirostat_tau: 8

--- a/presets/Null preset.yaml
+++ b/presets/Null preset.yaml
@@ -1,0 +1,1 @@
+temperature: 1

--- a/presets/Space Alien.yaml
+++ b/presets/Space Alien.yaml
@@ -1,4 +1,0 @@
-temperature: 1.31
-top_p: 0.29
-repetition_penalty: 1.09
-top_k: 72

--- a/presets/StarChat.yaml
+++ b/presets/StarChat.yaml
@@ -1,3 +1,0 @@
-temperature: 0.2
-top_p: 0.95
-top_k: 50

--- a/presets/Titanic.yaml
+++ b/presets/Titanic.yaml
@@ -1,5 +1,0 @@
-temperature: 1.01
-top_p: 0.21
-repetition_penalty: 1.21
-encoder_repetition_penalty: 1.07
-top_k: 91

--- a/presets/tfs-with-top-a.yaml
+++ b/presets/tfs-with-top-a.yaml
@@ -1,4 +1,0 @@
-temperature: 0.7
-tfs: 0.95
-top_a: 0.2
-repetition_penalty: 1.15


### PR DESCRIPTION
* Keep only the top 3 presets for chat/instruct according to Preset Arena
* Remove Mirostat (apparently it doesn't do anything with its `tau = 8`)
* Add a null preset