### PR TITLE
Load instruction_template from tokenizer_config.json

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -111,6 +111,11 @@ def get_model_metadata(model):
     path = Path(f'{shared.args.model_dir}/{model}') / 'tokenizer_config.json'
     if path.exists():
         metadata = json.loads(open(path, 'r', encoding='utf-8').read())
+        if 'instruction_template' in metadata:
+            model_settings['instruction_template'] = metadata['instruction_template']
+        if 'instruction_template_str' in metadata:
+            model_settings['instruction_template'] = 'Custom (obtained from model metadata)'
+            model_settings['instruction_template_str'] = metadata['instruction_template_str']
         if 'chat_template' in metadata:
             template = metadata['chat_template']
             for k in ['eos_token', 'bos_token']:


### PR DESCRIPTION
Currently, this is only possible when specifying a chat_template.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
