### PR TITLE
Add initial BigDL loader support for Intel XPU.

### DIFF
--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 
 import gradio as gr
 
+from transformers import is_torch_xpu_available
+
 from modules import shared
 
 loaders_and_params = OrderedDict({
@@ -149,6 +151,15 @@ loaders_and_params = OrderedDict({
         'no_use_fast',
     ]
 })
+
+if is_torch_xpu_available():
+    print('XPU is available, adding BigDL loader')
+
+    loaders_and_params['BigDL'] = [
+        'quant_type_bigdl',
+        'compute_dtype',
+        'trust_remote_code'
+    ]
 
 
 def transformers_samplers():
@@ -321,6 +332,7 @@ loaders_samplers = {
         'repetition_penalty',
         'repetition_penalty_range',
     },
+    'BigDL': transformers_samplers(),
 }
 
 loaders_model_types = {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -261,6 +261,8 @@ def fix_loader_name(name):
         return 'QuIP#'
     elif name in ['hqq']:
         return 'HQQ'
+    elif name in ['bigdl', 'bigdl-llm']:
+        return 'BigDL'
 
 
 def add_extension(name, last=False):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -60,6 +60,7 @@ def list_model_elements():
         'load_in_4bit',
         'compute_dtype',
         'quant_type',
+        'quant_type_bigdl',
         'use_double_quant',
         'wbits',
         'groupsize',

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -52,6 +52,11 @@ def create_ui():
     else:
         default_cpu_mem = 0
 
+    # Supported types: https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/LLM/transformers.html#bigdl.llm.transformers.AutoModelForCausalLM.from_pretrained
+    # "None" means no quantization
+    # "Default" means load_in_4bit = True only, others are using load_in_low_bit = "sym_int4", etc
+    quant_types_bigdl = ["None", "Default", "sym_int4", "asym_int4", "sym_int5", "asym_int5", "sym_int8", "nf3", "nf4", "fp4", "fp8", "fp8_e4m3", "fp8_e5m2"]
+
     with gr.Tab("Model", elem_id="model-tab"):
         with gr.Row():
             with gr.Column():
@@ -84,6 +89,7 @@ def create_ui():
                             shared.gradio['transformers_info'] = gr.Markdown('load-in-4bit params:')
                             shared.gradio['compute_dtype'] = gr.Dropdown(label="compute_dtype", choices=["bfloat16", "float16", "float32"], value=shared.args.compute_dtype)
                             shared.gradio['quant_type'] = gr.Dropdown(label="quant_type", choices=["nf4", "fp4"], value=shared.args.quant_type)
+                            shared.gradio['quant_type_bigdl'] = gr.Dropdown(label="quant_type", choices=quant_types_bigdl, value=shared.args.quant_type)
                             shared.gradio['hqq_backend'] = gr.Dropdown(label="hqq_backend", choices=["PYTORCH", "PYTORCH_COMPILE", "ATEN"], value=shared.args.hqq_backend)
 
                             shared.gradio['n_gpu_layers'] = gr.Slider(label="n-gpu-layers", minimum=0, maximum=128, value=shared.args.n_gpu_layers)


### PR DESCRIPTION
This is an initial support for `intel-analytics/BigDL` loader (adapted from `huggingface_loader`), which supports `int4`, `int8` and more quantization types on Intel GPU.

To use this, you must install `bigdl-llm` first (referring to https://bigdl.readthedocs.io/en/latest/doc/LLM/Overview/install_gpu.html):

```bash
pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
```

then manually run the `update_linux.sh` to reinstall the `transformers` and `accelerate` package, because `bigdl-llm` will install lower versions of these two.

Tested on Intel A770 with Llama2-7b-chat, ChatGLM2-6B and Baichuan2-13B-Chat.

GPU Memory usage with default quantization method (`sym_int4`):

|Model|Usage after load (MB)|Usage during inference (MB)|
|---------|--------------------------------|------------------------------------------|
|Llama2-7b-chat|3997|4336|
|ChatGLM2-6B|3801|4552|
|Baichuan2-13B-Chat|8075|11189|

Note: your `bigdl_llm` version must use at least `2.5.0b20240110` for llama to work (see https://github.com/intel-analytics/BigDL/commit/6b339121bbfae271b6400fef249ff1f17597e0b7)

Known issues:

- The second model load may fail with `AssertionError: Torch not compiled with CUDA enabled`. I don't know why, maybe a BigDL or IPEX problem. You need to restart the server if it occurred.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
