### PR TITLE
Correct field alias types for OpenAI extension

### DIFF
--- a/extensions/openai/typing.py
+++ b/extensions/openai/typing.py
@@ -99,8 +99,8 @@ class ChatCompletionRequestParams(BaseModel):
     instruction_template_str: str | None = Field(default=None, description="A Jinja2 instruction template. If set, will take precedence over everything else.")
 
     character: str | None = Field(default=None, description="A character defined under text-generation-webui/characters. If not set, the default \"Assistant\" character will be used.")
-    user_name: str | None = Field(default=None, description="Your name (the user). By default, it's \"You\".", alias=['name1'])
-    bot_name: str | None = Field(default=None, description="Overwrites the value set by character field.", alias=['name2'])
+    user_name: str | None = Field(default=None, description="Your name (the user). By default, it's \"You\".", alias="name1")
+    bot_name: str | None = Field(default=None, description="Overwrites the value set by character field.", alias="name2")
     context: str | None = Field(default=None, description="Overwrites the value set by character field.")
     greeting: str | None = Field(default=None, description="Overwrites the value set by character field.")
     chat_template_str: str | None = Field(default=None, description="Jinja2 template for chat.")


### PR DESCRIPTION
Fixes https://github.com/oobabooga/text-generation-webui/issues/5255

`alias` parameter only accepts `str | None`: https://docs.pydantic.dev/latest/api/fields/

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
