### PR TITLE
Fix error "Attempting to unscale FP16 gradients" when training LoRA

### DIFF
--- a/modules/training.py
+++ b/modules/training.py
@@ -605,6 +605,11 @@ def do_train(lora_name: str, always_override: bool, q_proj_en: bool, v_proj_en: 
                     control.should_training_stop = True
                     print(f"\033[1;31;1mStop Loss {stop_at_loss} reached.\033[0;37;0m")
 
+    # Fix training for mixed precision models
+    for param in shared.model.parameters():
+        if param.requires_grad:
+            param.data = param.data.float()
+
     trainer = transformers.Trainer(
         model=lora_model,
         train_dataset=train_data,


### PR DESCRIPTION
I was trying to train [this model](https://huggingface.co/IlyaGusev/saiga_mistral_7b_merged) in webui, but got error `Attempting to unscale FP16 gradients`.

When I set flag `bf16`, I got message `Your setup doesn't support bf16/gpu. You need torch>=1.10, using Ampere GPU with cuda>=11.0`, I met all the requirements except `Ampere GPU` (I am using V100).

So, I found this patch here: https://github.com/huggingface/peft/pull/1336/files

It worked for me and I was finally able to train LoRA in webui.

But I have no idea how that will affect other code and performance.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
