### PR TITLE
do_sample false when temperature 0

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -97,6 +97,9 @@ async def openai_completions(request: Request, request_data: CompletionRequest):
     path = request.url.path
     is_legacy = "/generate" in path
 
+    if request_data.temperature == 0:
+        request_data.do_sample = False
+
     if request_data.stream:
         async def generator():
             async with streaming_semaphore:
@@ -119,6 +122,9 @@ async def openai_completions(request: Request, request_data: CompletionRequest):
 async def openai_chat_completions(request: Request, request_data: ChatCompletionRequest):
     path = request.url.path
     is_legacy = "/generate" in path
+
+    if request_data.temperature == 0:
+        request_data.do_sample = False
 
     if request_data.stream:
         async def generator():


### PR DESCRIPTION
If temperature is 0, set do_sample false to allow deterministic settings for OpenAI API-compatible clients that don't support do_sample. Prevents "ValueError: `temperature` (=0.0) has to be a strictly positive float, otherwise your next token scores will be invalid. If you're looking for greedy decoding strategies, set `do_sample=False`" and ensures h2oGPT compatibility (fixes https://github.com/h2oai/h2ogpt/issues/1217).

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
