### PR TITLE
Allow content arrays for multimodal OpenAI requests

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -144,24 +144,25 @@ def convert_history(history):
     user_input = ""
     system_message = ""
 
-    new_history = []
-    for entry in history:
-        if isinstance(entry['content'], list):
-            image_url = None
-            content = None
-            for item in entry['content']:
-                if not isinstance(item, dict):
-                    continue
-                if item['type'] == 'image_url' and isinstance(item['image_url'], dict):
-                    image_url = item['image_url']['url']
-                elif item['type'] == 'text' and isinstance(item['text'], str):
-                    content = item['text']
-            if image_url and content:
-                new_history.append({"image_url": image_url, "role": "user"})
-                new_history.append({"content": content, "role": "user"})
-        else:
-            new_history.append(entry)
-    history = new_history
+    if any(isinstance(entry['content'], list) for entry in history):
+        new_history = []
+        for entry in history:
+            if isinstance(entry['content'], list):
+                image_url = None
+                content = None
+                for item in entry['content']:
+                    if not isinstance(item, dict):
+                        continue
+                    if item['type'] == 'image_url' and isinstance(item['image_url'], dict):
+                        image_url = item['image_url']['url']
+                    elif item['type'] == 'text' and isinstance(item['text'], str):
+                        content = item['text']
+                if image_url and content:
+                    new_history.append({"image_url": image_url, "role": "user"})
+                    new_history.append({"content": content, "role": "user"})
+            else:
+                new_history.append(entry)
+        history = new_history
 
     for entry in history:
         if "image_url" in entry:

--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -144,6 +144,25 @@ def convert_history(history):
     user_input = ""
     system_message = ""
 
+    new_history = []
+    for entry in history:
+        if isinstance(entry['content'], list):
+            image_url = None
+            content = None
+            for item in entry['content']:
+                if not isinstance(item, dict):
+                    continue
+                if item['type'] == 'image_url' and isinstance(item['image_url'], dict):
+                    image_url = item['image_url']['url']
+                elif item['type'] == 'text' and isinstance(item['text'], str):
+                    content = item['text']
+            if image_url and content:
+                new_history.append({"image_url": image_url, "role": "user"})
+                new_history.append({"content": content, "role": "user"})
+        else:
+            new_history.append(entry)
+    history = new_history
+
     for entry in history:
         if "image_url" in entry:
             image_url = entry['image_url']


### PR DESCRIPTION
This patch will allow sending prompts to chat completions endpoint formatted according to [OpenAI vision guide](https://platform.openai.com/docs/guides/vision/quick-start). If message content contains a list with text and image parts, it will be converted to the format expected by the multimodal extension (two user messages).

Without this change, the following exception will be thrown if the message contents include a list:

![image](https://github.com/oobabooga/text-generation-webui/assets/18619528/0f122399-5159-4c0f-b1da-8cb4a9e918ad)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
