### PR TITLE
Fix logits bias in API [completions.py]

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -104,7 +104,7 @@ def process_parameters(body, is_legacy=False):
         # XXX convert tokens from tiktoken based on requested model
         # Ex.: 'logit_bias': {'1129': 100, '11442': 100, '16243': 100}
         try:
-            encoder = tiktoken.encoding_for_model(generate_params['model'])
+            encoder = tiktoken.encoding_for_model(generate_params['model'] if generate_params['model'] else "llama")
             new_logit_bias = {}
             for logit, bias in logit_bias.items():
                 for x in encode(encoder.decode([int(logit)]), add_special_tokens=False)[0]:

--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -104,7 +104,9 @@ def process_parameters(body, is_legacy=False):
         # XXX convert tokens from tiktoken based on requested model
         # Ex.: 'logit_bias': {'1129': 100, '11442': 100, '16243': 100}
         try:
-            encoder = tiktoken.encoding_for_model(generate_params['model'] if generate_params['model'] else "llama")
+            if not generate_params['model']:
+                raise KeyError # not openAI model.
+            encoder = tiktoken.encoding_for_model(generate_params['model'])
             new_logit_bias = {}
             for logit, bias in logit_bias.items():
                 for x in encode(encoder.decode([int(logit)]), add_special_tokens=False)[0]:


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

When loading a model from the UI, generate_params['model'] is nonsense or empty and this cases tiktoken to fail like in this issue. After fixing it, I find that the bias is working well again. https://github.com/oobabooga/text-generation-webui/issues/5232

I have no clue about the other case where it's used so I can't test it, but if there is a model generate_param it should pass it.
