### PR TITLE
Ability to run the Coqui TTS extension on the CPU

### DIFF
--- a/extensions/coqui_tts/script.py
+++ b/extensions/coqui_tts/script.py
@@ -3,6 +3,7 @@ import json
 import os
 import random
 import time
+import torch
 from pathlib import Path
 
 import gradio as gr
@@ -23,7 +24,7 @@ params = {
     "voice": "female_01.wav",
     "language": "English",
     "model_name": "tts_models/multilingual/multi-dataset/xtts_v2",
-    "device": "cuda"
+    "device": "cuda" if torch.cuda.is_available() else "cpu"
 }
 
 this_dir = str(Path(__file__).parent.resolve())


### PR DESCRIPTION
I added a quick check to verify the availability of CUDA in Pytorch. If CUDA is not available, the extension runs on the CPU; if it is available, it utilizes CUDA.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
