### PR TITLE
Swap to huggingface_hub get_token function

### DIFF
--- a/download-model.py
+++ b/download-model.py
@@ -20,6 +20,7 @@ import requests
 import tqdm
 from requests.adapters import HTTPAdapter
 from tqdm.contrib.concurrent import thread_map
+from huggingface_hub import get_token
 
 base = "https://huggingface.co"
 
@@ -32,8 +33,8 @@ class ModelDownloader:
             self.session.mount('https://huggingface.co', HTTPAdapter(max_retries=max_retries))
         if os.getenv('HF_USER') is not None and os.getenv('HF_PASS') is not None:
             self.session.auth = (os.getenv('HF_USER'), os.getenv('HF_PASS'))
-        if os.getenv('HF_TOKEN') is not None:
-            self.session.headers = {'authorization': f'Bearer {os.getenv("HF_TOKEN")}'}
+        if get_token() is not None:
+            self.session.headers = {'authorization': f'Bearer {get_token()}'}
 
     def sanitize_model_and_branch_names(self, model, branch):
         if model[-1] == '/':


### PR DESCRIPTION
Uses huggingface_hub.get_token() to fetch the token. Can use either HF_TOKEN variable or huggingface-cli login; Variable is higher priority. Compatible with oneclick huggingface_hub version

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
