### PR TITLE
Fix max_length in chat.py to be just truncation length

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -169,7 +169,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
     prompt = make_prompt(messages)
 
     # Handle truncation
-    max_length = get_max_prompt_length(state)
+    max_length = state['truncation_length']
     while len(messages) > 0 and get_encoded_length(prompt) > max_length:
         # Try to save the system message
         if len(messages) > 1 and messages[0]['role'] == 'system':


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

get_max_prompt_length is returning truncate_prompt_length - max_new_tokens, which I'm not sure where the value is for that

If you have a model that has a max_new_tokens of 4096, and the truncate length is also 4096, then that makes the max prompt length returned be 0

This causes all messages to be removed from the prompt, resulting in a blank prompt sent to the model

This fixes issue https://github.com/oobabooga/text-generation-webui/issues/5374