### PR TITLE
Fix missing type checking by first_token being [None] for rwkv-5 models

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -276,9 +276,13 @@ def get_reply_from_output_ids(output_ids, state=None, starting_from=0):
         first_token = shared.tokenizer.convert_ids_to_tokens(int(output_ids[starting_from]))
         if isinstance(first_token, (bytes,)):
             first_token = first_token.decode('utf8')
-
-        if first_token.startswith('▁'):
-            reply = ' ' + reply
+        elif isinstance(first_token, str):
+            if first_token.startswith('▁'):
+                reply = ' ' + reply
+        elif isinstance(first_token, list) and len(first_token) > 0:
+            if isinstance(first_token[0], str):
+                if first_token[0].startswith('▁'):
+                    reply = ' ' + reply
 
     return reply
 


### PR DESCRIPTION
## Summery

This fix bug when loaindg RWKV-5 models with rwkv loader. Where `first_token` returned by rwkv custom `convert_ids_to_tokens` is `[None]` for most cases

sample run script
```
CUDA_VISIBLE_DEVICES=0 python server.py --model rwkv-5-world-7b \
    --loader rwkv \
    --trust-remote-code \
    --verbose \
    --api \
    --api-port 5051 \
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
