### PR TITLE
Update main.css to allow scrolling in code blocks

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -408,6 +408,10 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     margin-bottom: 0 !important;
 }
 
+#default-tab .prose pre, #notebook-tab .prose pre {
+    overflow: scroll;
+}
+
 .message-body code {
     white-space: pre-wrap !important;
     word-wrap: break-word !important;


### PR DESCRIPTION
Simple css addition to allow scrolling in code blocks found on the Default and Notebook tabs.

This prevents the code from running off the page and out of view.
![2024-02-13_10 18 48am_PEb](https://github.com/oobabooga/text-generation-webui/assets/311287/cc1e8bc4-d608-4c7c-ba34-e385d2b6fec3)


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
