### PR TITLE
Add an API endpoint to load the last-used model

### DIFF
--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -26,7 +26,7 @@ from extensions.openai.tokens import token_count, token_decode, token_encode
 from extensions.openai.utils import _start_cloudflared
 from modules import shared
 from modules.logging_colors import logger
-from modules.models import unload_model
+from modules.models import unload_model, load_last_model
 from modules.text_generation import stop_everything_event
 
 from .typing import (
@@ -323,6 +323,21 @@ async def handle_load_model(request_data: LoadModelRequest):
     except:
         traceback.print_exc()
         return HTTPException(status_code=400, detail="Failed to load the model.")
+
+
+@app.post("/v1/internal/model/loadlast", dependencies=check_admin_key)
+async def handle_load_last_model():
+    '''
+    This endpoint is experimental and may change in the future.
+
+    Loads the last model used before it was unloaded.
+    '''
+    try:
+        load_last_model()
+        return JSONResponse(content="OK")
+    except:
+        traceback.print_exc()
+        return HTTPException(status_code=400, detail="Failed to load the last-used model.")
 
 
 @app.post("/v1/internal/model/unload", dependencies=check_admin_key)

--- a/modules/models.py
+++ b/modules/models.py
@@ -396,9 +396,13 @@ def unload_model():
     clear_torch_cache()
 
 
+def load_last_model():
+    shared.model, shared.tokenizer = load_model(shared.previous_model_name)
+
+
 def reload_model():
     unload_model()
-    shared.model, shared.tokenizer = load_model(shared.model_name)
+    shared.model, shared.tokenizer = load_model(shared.previous_model_name)
 
 
 def unload_model_if_idle():


### PR DESCRIPTION
Adds an internal API endpoint to the OpenAI API that allows loading of the last used model.

This new endpoint would be particularly helpful for scenarios where VRAM management is necessary - a third-party application can ask text-generation-webui to vacate VRAM (e.g. with `/v1/internal/model/unload`), then quickly reload the model that was just active once some other task is done (for example, image generation). That technique is employed in the [`sd_api_pictures`](https://github.com/oobabooga/text-generation-webui/tree/main/extensions/sd_api_pictures) extension with AUTOMATIC1111's Web UI. This PR would allow other applications to perform the same technique with text-generation-webui.

`/v1/internal/model/loadlast` triggers the new `models.load_last_model()` function if it's POSTed to.

As a bonus, this also fixes a bug in `models.reload_model()` - it would fail since `shared.model_name` was set to `None` by `models.unload_model()`, meaning that `reload_model()` would then attempt to load `None` as a result. Setting it to the newly-added `shared.last_model_name` variable should fix that issue.