### PR TITLE
Big picture fixes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -717,6 +717,11 @@ div.svelte-362y77>*, div.svelte-362y77>.form>* {
     width: calc((100vw - 880px - 120px) /2);
 }
 
+.pfp_character {
+    position: relative;
+    z-index: 100;
+}
+
 .pfp_character:hover {
     cursor: pointer;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -354,6 +354,12 @@ function addBigPicture() {
   var timestamp = new Date().getTime();
   imgElement.src = "/file/cache/pfp_character.png?time=" + timestamp;
   imgElement.classList.add("bigProfilePicture");
+  imgElement.addEventListener("load", function () {
+    this.style.visibility = "visible";
+  });
+  imgElement.addEventListener("error", function () {
+    this.style.visibility = "hidden";
+  });
 
   var imgElementParent = document.getElementById("chat").parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode;
   imgElementParent.appendChild(imgElement);


### PR DESCRIPTION
- Hides big character picture if it fires an error event (ie. 404)
- Makes character pfp always clickable. This is mainly for the *TheEncrypted777* chat style, where part of the img element ends up behind the text element.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
