### PR TITLE
Bump transformers to 4.38.1 for gemma compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_amd_noavx2.txt
+++ b/requirements_amd_noavx2.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_amd_noavx2.txt
+++ b/requirements_amd_noavx2.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_apple_intel.txt
+++ b/requirements_apple_intel.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_apple_intel.txt
+++ b/requirements_apple_intel.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_apple_silicon.txt
+++ b/requirements_apple_silicon.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_apple_silicon.txt
+++ b/requirements_apple_silicon.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_cpu_only.txt
+++ b/requirements_cpu_only.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_cpu_only.txt
+++ b/requirements_cpu_only.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_cpu_only_noavx2.txt
+++ b/requirements_cpu_only_noavx2.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_cpu_only_noavx2.txt
+++ b/requirements_cpu_only_noavx2.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 

--- a/requirements_nowheels.txt
+++ b/requirements_nowheels.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers>=4.38.1
+transformers>=4.38.*
 tqdm
 wandb
 

--- a/requirements_nowheels.txt
+++ b/requirements_nowheels.txt
@@ -19,7 +19,7 @@ safetensors==0.4.*
 scipy
 sentencepiece
 tensorboard
-transformers==4.37.*
+transformers>=4.38.1
 tqdm
 wandb
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

4.38.0 is required for Gemma, 4.38.1 adds another fix for attention, probably worth the bump

https://github.com/huggingface/transformers/releases/tag/v4.38.0

https://github.com/huggingface/transformers/releases/tag/v4.38.1
