### PR TITLE
Save the extensions after Gradio 4

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -1,9 +1,72 @@
+'''
+Copied from: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14184
+'''
+
+import inspect
+import warnings
+from functools import wraps
+
 import gradio as gr
 
 
-def Box(*args, **kwargs):
-    return gr.Blocks(*args, **kwargs)
+class GradioDeprecationWarning(DeprecationWarning):
+    pass
 
 
-if not hasattr(gr, 'Box'):
-    gr.Box = Box
+def repair(grclass):
+    if not getattr(grclass, 'EVENTS', None):
+        return
+
+    @wraps(grclass.__init__)
+    def __repaired_init__(self, *args, tooltip=None, source=None, original=grclass.__init__, **kwargs):
+        if source:
+            kwargs["sources"] = [source]
+
+        allowed_kwargs = inspect.signature(original).parameters
+        fixed_kwargs = {}
+        for k, v in kwargs.items():
+            if k in allowed_kwargs:
+                fixed_kwargs[k] = v
+            else:
+                warnings.warn(f"unexpected argument for {grclass.__name__}: {k}", GradioDeprecationWarning, stacklevel=2)
+
+        original(self, *args, **fixed_kwargs)
+
+        self.webui_tooltip = tooltip
+
+        for event in self.EVENTS:
+            replaced_event = getattr(self, str(event))
+
+            def fun(*xargs, _js=None, replaced_event=replaced_event, **xkwargs):
+                if _js:
+                    xkwargs['js'] = _js
+
+                return replaced_event(*xargs, **xkwargs)
+
+            setattr(self, str(event), fun)
+
+    grclass.__init__ = __repaired_init__
+    grclass.update = gr.update
+
+
+for component in set(gr.components.__all__ + gr.layouts.__all__):
+    repair(getattr(gr, component, None))
+
+
+class Dependency(gr.events.Dependency):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        def then(*xargs, _js=None, **xkwargs):
+            if _js:
+                xkwargs['js'] = _js
+
+            return original_then(*xargs, **xkwargs)
+
+        original_then = self.then
+        self.then = then
+
+
+gr.events.Dependency = Dependency
+
+gr.Box = gr.Group


### PR DESCRIPTION
Gradio 4 arbitrarily renames the `_js` kwarg in events to `js`, breaking many extensions.

I have copied the code created by AUTOMATIC1111 at https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14184 to solve this issue.