### PR TITLE
OpenAI extension list currently loaded models not dummy models.

### DIFF
--- a/extensions/openai/models.py
+++ b/extensions/openai/models.py
@@ -14,7 +14,15 @@ def get_current_model_info():
 
 
 def list_models():
-    return {'model_names': get_available_models()[1:]}
+    result = {
+        "object": "list",
+        "data": []
+    }
+    # get models and add them to the result
+    for model in get_available_models():
+        result["data"].append(model_info_dict(model))
+
+    return {'model_names': result}
 
 
 def list_dummy_models():

--- a/extensions/openai/models.py
+++ b/extensions/openai/models.py
@@ -22,7 +22,7 @@ def list_models():
     for model in get_available_models():
         result["data"].append(model_info_dict(model))
 
-    return {'model_names': result}
+    return result
 
 
 def list_dummy_models():

--- a/extensions/openai/script.py
+++ b/extensions/openai/script.py
@@ -145,7 +145,7 @@ async def handle_models(request: Request):
     is_list = request.url.path.split('?')[0].split('#')[0] == '/v1/models'
 
     if is_list:
-        response = OAImodels.list_dummy_models()
+        response = OAImodels.list_models()
     else:
         model_name = path[len('/v1/models/'):]
         response = OAImodels.model_info_dict(model_name)


### PR DESCRIPTION
Fixes [bug #5675](https://github.com/oobabooga/text-generation-webui/issues/5675) that lists dummy models instead of loaded models in OpenAI extension. `v1/models`.

## Checklist:

- [ x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
