### PR TITLE
Set an default empty string for `user_bio` to fix #5717 issue.

### DIFF
--- a/extensions/openai/typing.py
+++ b/extensions/openai/typing.py
@@ -107,7 +107,7 @@ class ChatCompletionRequestParams(BaseModel):
     context: str | None = Field(default=None, description="Overwrites the value set by character field.")
     greeting: str | None = Field(default=None, description="Overwrites the value set by character field.")
     user_name: str | None = Field(default=None, description="Your name (the user). By default, it's \"You\".", alias="name1")
-    user_bio: str | None = Field(default=None, description="The user description/personality.")
+    user_bio: str | None = Field(default='', description="The user description/personality.")
     chat_template_str: str | None = Field(default=None, description="Jinja2 template for chat.")
 
     chat_instruct_command: str | None = None


### PR DESCRIPTION
quick fix for #5717 

the other parameters, like `bot_name`, `context` etc. used for overwrites the character card
so keep them None

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
