### PR TITLE
docker: Remove misleading CLI_ARGS

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -2,8 +2,6 @@
 # however for me to work i had to specify the exact version for my card ( 2060 ) it was 7.5
 # https://developer.nvidia.com/cuda-gpus you can find the version for your card here
 TORCH_CUDA_ARCH_LIST=7.5
-# your command-line flags go here:
-CLI_ARGS=--listen
 # the port the webui binds to on the host
 HOST_PORT=7860
 # the port the webui binds to inside the container


### PR DESCRIPTION
CLI_ARGS don't do anything since b1463df. Fixes #5422.

## Checklist:

- [ x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).