### PR TITLE
Add config for hyperion and hercules models to use chatml

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -190,3 +190,5 @@
   instruction_template: 'ChatML'
 .*synthia:
   instruction_template: 'Synthia'
+.*(hercules|hyperion):
+  instruction_template: 'ChatML'


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

Locutusque's Hercules and Hyperion models (linked below) use ChatML but are defaulting to alpaca leading to worse performance unless you manually change it

https://huggingface.co/Locutusque/Hercules-3.0-Mistral-7B

https://huggingface.co/Locutusque/Hyperion-3.0-Mistral-7B-alpha