### PR TITLE
requirements: add psutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_amd_noavx2.txt
+++ b/requirements_amd_noavx2.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_apple_intel.txt
+++ b/requirements_apple_intel.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_apple_silicon.txt
+++ b/requirements_apple_silicon.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_cpu_only.txt
+++ b/requirements_cpu_only.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_cpu_only_noavx2.txt
+++ b/requirements_cpu_only_noavx2.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -15,6 +15,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich

--- a/requirements_nowheels.txt
+++ b/requirements_nowheels.txt
@@ -13,6 +13,7 @@ optimum==1.17.*
 pandas
 peft==0.8.*
 Pillow>=9.5.0
+psutil
 pyyaml
 requests
 rich


### PR DESCRIPTION
I'm not sure why psutil wasn't listed in the requirements already. It's directly imported by ui_model_menu.py.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).