### PR TITLE
Respect model and lora directory settings when downloading files

### DIFF
--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -287,6 +287,12 @@ def download_model_wrapper(repo_id, specific_file, progress=gr.Progress(), retur
 
         yield ("Getting the output folder")
         output_folder = downloader.get_output_folder(model, branch, is_lora, is_llamacpp=is_llamacpp)
+
+        if output_folder == Path("models"):
+            output_folder = Path(shared.args.model_dir)
+        elif output_folder == Path("loras"):
+            output_folder = Path(shared.args.lora_dir)
+
         if check:
             progress(0.5)
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

Currently all downloaded files are placed in the same directory as the installation. This change makes them download to the folder specified by the user.