### PR TITLE
fix cloudflare request blocker str/byte mismatch

### DIFF
--- a/modules/block_requests.py
+++ b/modules/block_requests.py
@@ -43,10 +43,11 @@ def my_open(*args, **kwargs):
         with original_open(*args, **kwargs) as f:
             file_contents = f.read()
 
-        file_contents = file_contents.replace(b'\t\t<script\n\t\t\tsrc="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.contentWindow.min.js"\n\t\t\tasync\n\t\t></script>', b'')
-        file_contents = file_contents.replace(b'cdnjs.cloudflare.com', b'127.0.0.1')
+        file_contents = file_contents.replace('\t\t<script\n\t\t\tsrc="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.contentWindow.min.js"\n\t\t\tasync\n\t\t></script>', '')
+        file_contents = file_contents.replace('cdnjs.cloudflare.com', '127.0.0.1')
 
-        return io.BytesIO(file_contents)
+        
+        return io.TextIOWrapper(io.BytesIO(file_contents.encode(kwargs["encoding"])))
     else:
         return original_open(*args, **kwargs)
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

Fixes #5839 with minimal alterations. The previous version is opened the index.html template as plain text, but tried to edit as bytes Made string replacements instead then added the TextIOWrapper to prevent an error with jinja2 template validation.