### PR TITLE
[Hotfix] Revert sse-starlette version bump because it breaks API request cancellation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # llama-cpp-python (CPU only, AVX2)

--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -28,7 +28,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # llama-cpp-python (CPU only, AVX2)

--- a/requirements_amd_noavx2.txt
+++ b/requirements_amd_noavx2.txt
@@ -28,7 +28,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # llama-cpp-python (CPU only, no AVX2)

--- a/requirements_apple_intel.txt
+++ b/requirements_apple_intel.txt
@@ -28,7 +28,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # Mac wheels

--- a/requirements_apple_silicon.txt
+++ b/requirements_apple_silicon.txt
@@ -28,7 +28,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # Mac wheels

--- a/requirements_cpu_only.txt
+++ b/requirements_cpu_only.txt
@@ -28,7 +28,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # llama-cpp-python (CPU only, AVX2)

--- a/requirements_cpu_only_noavx2.txt
+++ b/requirements_cpu_only_noavx2.txt
@@ -28,7 +28,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # llama-cpp-python (CPU only, no AVX2)

--- a/requirements_noavx2.txt
+++ b/requirements_noavx2.txt
@@ -30,7 +30,7 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken
 
 # llama-cpp-python (CPU only, no AVX2)

--- a/requirements_nowheels.txt
+++ b/requirements_nowheels.txt
@@ -28,5 +28,5 @@ wandb
 # API
 SpeechRecognition==3.10.0
 flask_cloudflared==0.0.14
-sse-starlette==2.1.0
+sse-starlette==1.6.5
 tiktoken


### PR DESCRIPTION
Fixes #5871.

The major-version bump of sse-starlette breaks API request cancellation, that is, cancelling an API request no longer terminates the generation process. This is a showstopper because it leads to out-of-control generations that only end when they encounter an EOS token or `max_new_tokens` is reached. In practice, this breaks most standard interactive use cases.

Identifying the root cause of this problem was complicated by several other issues:

* Unlike all other extensions, the OpenAI API extension does not have its own requirements file (why?). I looked at the `extensions/openai` folder and found no recent changes. This led me to wrongly conclude that the problem lies elsewhere, because the sse-starlette dependency is specified in the root `requirements.txt`.
* ExLlamav2 is currently broken (#5851), so I wasn't able to easily exclude llama.cpp as the culprit.
* I'm on a slow connection so I'm unable to bisect economically, because each dependency change requires hundreds of Megabytes of Pip downloads (#5693).

I was left with the assumption that llama.cpp must be the problem, considering the recent unrelated issues there, which led me on a wild goose chase that went nowhere. But eventually, I figured out the problem with the updated dependency.

The recent updates have been rather bumpy. In the past 2 weeks, llama.cpp, ExLlamav2, and the API were all broken. Perhaps a slightly slower release cadence might make sense.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
