### PR TITLE
Fix bug with intentional trailing spaces in instruct template prefix

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -170,7 +170,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
                 if len(suffix) > 0:
                     prompt = prompt[:-len(suffix)]
             else:
-                prefix = get_generation_prompt(renderer, impersonate=impersonate)[0]
+                prefix = get_generation_prompt(renderer, impersonate=impersonate, strip_trailing_spaces=False)[0]
                 if state['mode'] == 'chat' and not impersonate:
                     prefix = apply_extensions('bot_prefix', prefix, state)
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

If we have an intentional trailing space in an instruct template prefix (e.g. `'[INST] ' + message['content'] + ' [/INST]'`) it gets stripped out during impersonation and we end up with something like `[INST]<impersonated message>`. However when I press generate it gets corrected back into `[INST] <impersonated message>`, which causes the backend to reprocess all the impersonated text.

This replaces my PR #5853.