### PR TITLE
nvidia docker: make sure gradio listens on 0.0.0.0

### DIFF
--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -18,4 +18,4 @@ COPY CMD_FLAGS.txt /home/app/text-generation-webui/
 EXPOSE ${CONTAINER_PORT:-7860} ${CONTAINER_API_PORT:-5000} ${CONTAINER_API_STREAM_PORT:-5005}
 WORKDIR /home/app/text-generation-webui
 # set umask to ensure group read / write at runtime
-CMD umask 0002 && export HOME=/home/app/text-generation-webui && ./start_linux.sh
+CMD umask 0002 && export HOME=/home/app/text-generation-webui && ./start_linux.sh --listen


### PR DESCRIPTION
add --listen, otherwise it listens on 127.0.0.1 and you cant get to it from outside the docker container

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
