### PR TITLE
Fix missing bos token

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -138,15 +138,21 @@ def encode(prompt, add_special_tokens=True, add_bos_token=True, truncation_lengt
             input_ids = np.array(input_ids).reshape(1, len(input_ids))
     else:
         input_ids = shared.tokenizer.encode(str(prompt), return_tensors='pt', add_special_tokens=add_special_tokens)
-        if not add_bos_token:
-            # Check if we need to remove a bos token which may have been added due to add_special_tokens
-            while len(input_ids[0]) > 0 and input_ids[0][0] == shared.tokenizer.bos_token_id:
-                input_ids = input_ids[:, 1:]
-        if add_bos_token and input_ids[0][0] != shared.tokenizer.bos_token_id:
-            # We need to insert a bos token. It has not been added, even though it usually would have been added by add_special_tokens.
-            # (There are many models out there which are configured in a way such that bos token doesn't get added by add_special_tokens, so we check that here.)
-            bos_tensor = torch.tensor([[shared.tokenizer.bos_token_id]])
-            input_ids = torch.cat((bos_tensor, input_ids), 1)
+
+        if hasattr(shared.tokenizer, 'bos_token_id'):
+            if add_bos_token:
+                if (len(input_ids[0]) > 0 and input_ids[0][0] != shared.tokenizer.bos_token_id) or len(input_ids[0]) == 0:
+                    # Add a missing bos token (it may not have been added due to faulty model metadata)
+                    bos_tensor = torch.tensor([[shared.tokenizer.bos_token_id]])
+                    input_ids = torch.cat((bos_tensor, input_ids), 1)
+
+                # Prevent double bos token due to jinja templates with <s> somewhere
+                while len(input_ids[0]) > 1 and input_ids[0][0] == shared.tokenizer.bos_token_id and input_ids[0][1] == shared.tokenizer.bos_token_id:
+                    input_ids = input_ids[:, 1:]
+            else:
+                # Remove any bos token that may have been added
+                while len(input_ids[0]) > 0 and input_ids[0][0] == shared.tokenizer.bos_token_id:
+                    input_ids = input_ids[:, 1:]
 
     # Handling truncation
     if truncation_length is not None:


### PR DESCRIPTION
## Expected behavior

When the UI checkbox to add bos token is checked, user expects bos token to be added.

## Actual behavior

When the UI checkbox to add bos token is checked, some models add bos token, but some models don't add bos token. The (mis)configuration of the tokenizer config file affects whether bos token gets added or not.

## Scope

Affects both UI users and API users (in API case tested with API parameter to add bos token rather than UI checkbox).

Affects at least model loaders which use huggingface transformers tokenizer (e.g. ExllamaV2_HF).

I checked various models I had on disk, and about half of Llama 3 models from my disk were affected by this issue. I also tried some Lllama 2 models, none of them were affected.

A few examples of affected models:
- https://huggingface.co/LoneStriker/bagel-8b-v1.0-8.0bpw-h8-exl2
- https://huggingface.co/bartowski/Einstein-v6.1-Llama3-8B-exl2

I don't know if it makes a difference, but I didn't use the downloader script to download models, I manually downloaded them.

## Cause

My understanding is that Meta distributed some misconfigured tokenizer.json files and silently updated them later. Copies of the misconfigured tokenizer.json files are now circulating amongst fine tuners and quantizers.

How are the tokenizer.json files misconfigured? They have the bos token defined in some places, but not in all the places where it's needed. I don't really know what these files are supposed to contain. I looked at one llama 3 tokenizer file which appeared to be working correctly, and I found that it had this definition, which was missing from the misconfigured tokenizer files:

```
"special_tokens": {
          "<|begin_of_text|>": {
            "id": "<|begin_of_text|>",
            "ids": [
              128000
            ],
            "tokens": [
              "<|begin_of_text|>"
            ]
          }
        }
```

The way bos token is implemented in TGW is that the transformers tokenizer is called with `add_special_tokens=True`, so if the bos token is not defined in special_tokens, it won't be added.

## Do we need a fix in TGW if it's a model issue?

We need a fix in TGW because we have UI checkbox and API parameter that set user expectations.

Also, many models quality is severely degraded in TGW if it's not fixed (even if it's technically somebody else's fault).

## How to fix this

After transformers tokenizer encode, we check that the bos token is added and manually add it if it is not.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
