### PR TITLE
Use reentrant generation lock

### DIFF
--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ import sys
 import time
 from functools import partial
 from pathlib import Path
-from threading import Lock, Thread
+from threading import RLock, Thread
 
 import yaml
 
@@ -243,7 +243,7 @@ if __name__ == "__main__":
         if shared.args.lora:
             add_lora_to_model(shared.args.lora)
 
-    shared.generation_lock = Lock()
+    shared.generation_lock = RLock()
 
     if shared.args.idle_timeout > 0:
         timer_thread = Thread(target=unload_model_if_idle)


### PR DESCRIPTION
The function get_next_logits acquires the generation lock, then calls generate_reply when use_samplers is True, trying to acquire the generation lock which fails and cause a deadlock because the lock is already acquired. This replaces the standard lock with a reentrant lock, making the 2nd lock acquisition by the same thread succeed.

Fixes: https://github.com/oobabooga/text-generation-webui/issues/6106

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
