### PR TITLE
Fixes Linux shebangs

### DIFF
--- a/cmd_linux.sh
+++ b/cmd_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/update_wizard_linux.sh
+++ b/update_wizard_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 


### PR DESCRIPTION
The linux scripts were using `#!/bin/bash`, which causes problems in some Linux distributions (such as NixOS) because that file doesn't exist on that place. `#!/usr/bin/env bash` should used instead, in order to get bash from the correct place from the user's PATH variable.

I've tested and can confirm that these changes are enough to make the software work on NixOS.
## Changed files
- cmd_linux.sh
- start_linux.sh

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
