### PR TITLE
Setting default alpha_value and fixing loading some newer DeepSeekCoder GGUFs

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -16,6 +16,7 @@ def get_fallback_settings():
         'n_ctx': 2048,
         'rope_freq_base': 0,
         'compress_pos_emb': 1,
+        'alpha_value': 1,
         'truncation_length': shared.settings['truncation_length'],
         'skip_special_tokens': shared.settings['skip_special_tokens'],
         'custom_stopping_strings': shared.settings['custom_stopping_strings'],
@@ -57,6 +58,8 @@ def get_model_metadata(model):
             elif k.endswith('rope.freq_base'):
                 model_settings['rope_freq_base'] = metadata[k]
             elif k.endswith('rope.scale_linear'):
+                model_settings['compress_pos_emb'] = metadata[k]
+            elif k.endswith('rope.scaling.factor'):
                 model_settings['compress_pos_emb'] = metadata[k]
             elif k.endswith('block_count'):
                 model_settings['n_gpu_layers'] = metadata[k] + 1


### PR DESCRIPTION
1. Ensures alpha_value resets back to 1 after selecting a new model. Previously if any model had a unusual alpha_value in saved settings or of it was changed manually, this value wouldn't reset after choosing another model. This could cause poor performance of a newly loaded model.
2. Ensures rope scaling is loaded from metadata of newer GGUF models, notably from newer DeepSeekCoder finetunes where this value is now saved in rope.scaling.factor instead of rope.scale_linear where it used to be saved in old GGUFs.  Though there might be needed additional check for rope.scaling.type: linear or yarn. But I couldn't find information how to properly load Yarn models in TGW to decide if it's needed to check the scaling type.

## Checklist:

- [ X ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
