### PR TITLE
Fix ggggoooofs with no BOS token present, mainly qwen2 models.

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -64,7 +64,9 @@ def get_model_metadata(model):
         if 'tokenizer.chat_template' in metadata:
             template = metadata['tokenizer.chat_template']
             eos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.eos_token_id']]
-            bos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.bos_token_id']]
+            if 'tokenizer.ggml.bos_token_id' in metadata:
+                bos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.bos_token_id']]
+            else: bos_token = None
             template = template.replace('eos_token', "'{}'".format(eos_token))
             template = template.replace('bos_token', "'{}'".format(bos_token))
 

--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -66,7 +66,9 @@ def get_model_metadata(model):
             eos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.eos_token_id']]
             if 'tokenizer.ggml.bos_token_id' in metadata:
                 bos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.bos_token_id']]
-            else: bos_token = None
+            else:
+                bos_token = ""
+
             template = template.replace('eos_token', "'{}'".format(eos_token))
             template = template.replace('bos_token', "'{}'".format(bos_token))
 


### PR DESCRIPTION
Despite the bos token fix I still get this error:

```
  File "/home/supermicro/ai/text-generation-webui-testing/modules/models_settings.py", line 73, in get_model_metadata
    bos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.bos_token_id']]
                                                  ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'tokenizer.ggml.bos_token_id'
```


Happens on tess qwen2 or dolphin qwen2. They are missing that key in the GGUF meta data and the models refuse to load.
There's another issue when using llama.cpp plain where it complains that it's inserting the BOS token twice. It seems l.cpp automatically interprets no bos token as being token "11" which can be "," but is probably some sort of null.

I can't imagine it's able to insert any kind of token if the "," means null.


