### PR TITLE
Fix typo: "Atttention" to "Attention"

### DIFF
--- a/modules/LoRA.py
+++ b/modules/LoRA.py
@@ -73,7 +73,7 @@ def add_lora_autogptq(lora_names):
         if len(lora_names) > 1:
             logger.warning('AutoGPTQ can only work with 1 LoRA at the moment. Only the first one in the list will be loaded.')
         if not shared.args.no_inject_fused_attention:
-            logger.warning('Fused Atttention + AutoGPTQ may break Lora loading. Disable it.')
+            logger.warning('Fused Attention + AutoGPTQ may break Lora loading. Disable it.')
 
         peft_config = GPTQLoraConfig(
             inference_mode=True,


### PR DESCRIPTION
Corrected the typo "Atttention" to "Attention" in the function add_lora_autogptq.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
