### PR TITLE
typo in OpenAI API documentation

### DIFF
--- a/docs/12 - OpenAI API.md
+++ b/docs/12 - OpenAI API.md
@@ -219,7 +219,7 @@ print()
 
 ### Environment variables
 
-The following environment variables can be used (they take precendence over everything else):
+The following environment variables can be used (they take precedence over everything else):
 
 | Variable Name          | Description                                                                                        | Example Value              |
 |------------------------|------------------------------------|----------------------------|


### PR DESCRIPTION
Corrected the typo in the OpenAI API.md file where "precendence" was changed to "precedence" under the Environment variables section.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
