### PR TITLE
Make compress_pos_emb float

### DIFF
--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -105,7 +105,7 @@ def create_ui():
                             with gr.Blocks():
                                 shared.gradio['alpha_value'] = gr.Number(label='alpha_value', value=shared.args.alpha_value, precision=2, info='Positional embeddings alpha factor for NTK RoPE scaling. Recommended values (NTKv1): 1.75 for 1.5x context, 2.5 for 2x context. Use either this or compress_pos_emb, not both.')
                                 shared.gradio['rope_freq_base'] = gr.Number(label='rope_freq_base', value=shared.args.rope_freq_base, precision=0, info='Positional embeddings frequency base for NTK RoPE scaling. Related to alpha_value by rope_freq_base = 10000 * alpha_value ^ (64 / 63). 0 = from model.')
-                                shared.gradio['compress_pos_emb'] = gr.Number(label='compress_pos_emb', value=shared.args.compress_pos_emb, precision=0, info='Positional embeddings compression factor. Should be set to (context length) / (model\'s original context length). Equal to 1/rope_freq_scale.')
+                                shared.gradio['compress_pos_emb'] = gr.Number(label='compress_pos_emb', value=shared.args.compress_pos_emb, precision=2, info='Positional embeddings compression factor. Should be set to (context length) / (model\'s original context length). Equal to 1/rope_freq_scale.')
 
                             shared.gradio['autogptq_info'] = gr.Markdown('ExLlamav2_HF is recommended over AutoGPTQ for models derived from Llama.')
 


### PR DESCRIPTION
`compress_pos_emb` originally had a slider gradation of 0.01, allowing the user to set float values, but this behaviour was changed in #6233. The UI now uses `gr.Number` instead of `gr.Slider` to represent RoPE scaling values so that devs don't have to repeatedly update the max value limit and as a side effect the gradation of `compress_pos_emb` became integer.

I find float values useful (a value of 1.3 allows Llama 3.0 models to work nicely with a 12k context, whereas 1 is insufficient and 2 causes noticeable drop in quality). This PR therefore replicates the previous behaviour by setting the precision to 2.

I have tested the change by setting `compress_pos_emb` to 1.3 and confirming that the value sent to `llama.cpp` is correct, i.e.
```
llama_new_context_with_model: freq_scale = 0.769231
```

I don't believe that this will cause problems with the rest of the code because float values were originally permitted.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
