### PR TITLE
Add beforeunload js event to add a confirmation dialog when leaving page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -600,4 +600,15 @@ headerBar.addEventListener("click", (e) => {
   }
 });
 
+//------------------------------------------------
+// Add a confirmation dialog when leaving the page
+// Useful to avoid data loss
+//------------------------------------------------
+window.addEventListener('beforeunload', function (event) {
+  // Cancel the event
+  event.preventDefault();
+  // Chrome requires returnValue to be set
+  event.returnValue = '';
+});
+
 moveToChatTab();


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

# Description

This PR will add a `beforeunload` js event to `window` to add a confirmation dialog when leaving the page.

Fixes #6228

Tested on Firefox and Chrome.