### PR TITLE
Add `impersonate` feature to API `/v1/chat/completions`

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -320,11 +320,10 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
 
     # generate reply #######################################
     prompt = generate_chat_prompt(user_input, generate_params, _continue=continue_, impersonate=impersonate)
+    if impersonate:
+        prompt += user_input
     if prompt_only:
-        if impersonate:
-            yield {'prompt': prompt + user_input}
-        else:
-            yield {'prompt': prompt}
+        yield {'prompt': prompt}
         return
 
     debug_msg({'prompt': prompt, 'generate_params': generate_params})
@@ -334,8 +333,7 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
 
     if impersonate:
         stopping_strings = get_stopping_strings(generate_params)
-        generator = generate_reply(prompt + user_input, generate_params, stopping_strings=stopping_strings, is_chat=True)
-
+        generator = generate_reply(prompt, generate_params, stopping_strings=stopping_strings, is_chat=True)
     else:
         generator = generate_chat_reply(
             user_input, generate_params, regenerate=False, _continue=continue_, loading_message=False)

--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -245,7 +245,7 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
     continue_ = body['continue_']
     impersonate = body['impersonate']
     if impersonate:
-        continue_ = False
+        continue_ = False # While impersonate, continue_ should be False. References impersonate_wrapper in chat.py
 
     # Instruction template
     if body['instruction_template_str']:
@@ -342,7 +342,12 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
     seen_content = ''
 
     for a in generator:
-        answer = a if impersonate else a['internal'][-1][1]
+        if impersonate:
+            # The generate_chat_reply returns the entire message, but generate_reply will only start from new content.
+            # So we need to add the user_input to keep output consistent.
+            answer = user_input + a
+        else:
+            answer = a['internal'][-1][1]
         if stream:
             len_seen = len(seen_content)
             new_content = answer[len_seen:]

--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -371,6 +371,7 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
 
         yield chunk
     else:
+        role = 'user' if impersonate else 'assistant'
         resp = {
             "id": cmpl_id,
             "object": object_type,
@@ -379,7 +380,7 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
             resp_list: [{
                 "index": 0,
                 "finish_reason": stop_reason,
-                "message": {"role": "assistant", "content": answer}
+                "message": {"role": role, "content": answer}
             }],
             "usage": {
                 "prompt_tokens": token_count,

--- a/extensions/openai/typing.py
+++ b/extensions/openai/typing.py
@@ -114,6 +114,8 @@ class ChatCompletionRequestParams(BaseModel):
 
     continue_: bool = Field(default=False, description="Makes the last bot message in the history be continued instead of starting a new message.")
 
+    impersonate: bool = Field(default=False, description="Impersonate the user in the chat. Makes the model continue generate the last user message.")
+
 
 class ChatCompletionRequest(GenerationOptions, ChatCompletionRequestParams):
     pass


### PR DESCRIPTION
The feature same as the impersonate feature on webui.

Add an `impersonate` param to active this feature in `/v1/chat/completions`.

Updated:
Prepend `user_input` in impersonate reply for consistency
It will always returns the entire message now

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

<details>
<summary> Test Images </summary>

Impersonate:
![image](https://github.com/user-attachments/assets/cf4d7940-cdc3-4dc9-b9c4-3828ef728628)

Normal response:
![image](https://github.com/user-attachments/assets/9e8db58a-f0ab-4948-93ff-64fe77d0a893)

</details>