### PR TITLE
Fix HuggingFace Chat UI

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -154,8 +154,9 @@ def convert_history(history):
                     elif item['type'] == 'text' and isinstance(item['text'], str):
                         content = item['text']
 
-                if image_url and content:
+                if image_url:
                     new_history.append({"image_url": image_url, "role": "user"})
+                if content:
                     new_history.append({"content": content, "role": "user"})
             else:
                 new_history.append(entry)


### PR DESCRIPTION
HuggingFace Chat UI sends a multi-modal style request with only a single "text" element. However, our code required both an image and the text, breaking support for HuggingFace Chat UI. This change relaxes this requirement on our end, allowing a single "text" or "image_url" as well.

This fixes #6299