### PR TITLE
Force /bin/bash shell for conda

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -190,7 +190,7 @@ def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, 
             cmd = f'. "{conda_sh_path}" && conda activate "{conda_env_path}" && {cmd}'
 
     # Run shell commands
-    result = subprocess.run(cmd, shell=True, capture_output=capture_output, env=env)
+    result = subprocess.run(cmd, shell=True, executable='/bin/bash', capture_output=capture_output, env=env)
 
     # Assert the command ran successfully
     if assert_success and result.returncode != 0:


### PR DESCRIPTION
I have found that conda may use a different shell in some instances, such as /bin/sh. This fix ensures it executes /bin/bash instead.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
