### PR TITLE
Fix for systems that have bash in a non-standard directory

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -189,8 +189,8 @@ def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, 
             conda_sh_path = os.path.join(script_dir, "installer_files", "conda", "etc", "profile.d", "conda.sh")
             cmd = f'. "{conda_sh_path}" && conda activate "{conda_env_path}" && {cmd}'
 
-    # Set executable to None for Windows, /bin/bash for everything else
-    executable = None if is_windows() else '/bin/bash'
+    # Set executable to None for Windows, bash for everything else
+    executable = None if is_windows() else 'bash'
 
     # Run shell commands
     result = subprocess.run(cmd, shell=True, capture_output=capture_output, env=env, executable=executable)


### PR DESCRIPTION
As talked on #6386 

This fixes the software once again on NixOS, while still forcing bash as 6386 did.


(honestly I’m skeptical that the shell conda is ran from makes a difference, it definitely shouldn’t since the program (conda) itself should call the necessary shell if needed, buuuuuuut after the deeply traumatising experience of reading the miniconda installer script a while ago for some troubleshooting it wouldn’t surprise me at all if conda didn’t check before using bash syntax on sh to do some cursed stuff)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
