### PR TITLE
Make token bans work again on HF loaders

### DIFF
--- a/modules/sampler_hijack.py
+++ b/modules/sampler_hijack.py
@@ -454,7 +454,7 @@ def get_logits_processor_patch(self, **kwargs):
             )
 
         # Stuff we don't need
-        elif warpers[i].__class__.__name__ in ['SuppressTokensLogitsProcessor', 'RepetitionPenaltyLogitsProcessor']:
+        elif warpers[i].__class__.__name__ in ['RepetitionPenaltyLogitsProcessor']:
             del warpers[i]
 
     # Add custom warpers


### PR DESCRIPTION
Token bans on HF don't work if `SuppressTokensLogitsProcessor` is removed, since they work by setting the `suppress_tokens` parameter.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
