### PR TITLE
Load models from sub-directories

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -78,10 +78,8 @@ def get_available_models():
         for file in files:
             file_path = os.path.join(dirpath, file)
             relative_path = os.path.relpath(file_path, shared.args.model_dir)
-            
             if not file.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.py')) and 'llama-tokenizer' not in file:
                 model_list.append(relative_path)
-    
     return ['None'] + sorted(model_list, key=natural_keys)
 
 
@@ -90,7 +88,6 @@ def get_available_ggufs():
     for item in Path(f'{shared.args.model_dir}/').glob('*'):
         if item.is_file() and item.name.lower().endswith(".gguf"):
             model_list.append(item.name)
-
     return ['None'] + sorted(model_list, key=natural_keys)
 
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -74,10 +74,14 @@ def natural_keys(text):
 
 def get_available_models():
     model_list = []
-    for item in list(Path(f'{shared.args.model_dir}/').glob('*')):
-        if not item.name.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.py')) and 'llama-tokenizer' not in item.name:
-            model_list.append(item.name)
-
+    for dirpath, dirnames, files in os.walk(shared.args.model_dir, followlinks=True):
+        for file in files:
+            file_path = os.path.join(dirpath, file)
+            relative_path = os.path.relpath(file_path, shared.args.model_dir)
+            
+            if not file.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.py')) and 'llama-tokenizer' not in file:
+                model_list.append(relative_path)
+    
     return ['None'] + sorted(model_list, key=natural_keys)
 
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -78,7 +78,7 @@ def get_available_models():
         for file in files:
             file_path = os.path.join(dirpath, file)
             relative_path = os.path.relpath(file_path, shared.args.model_dir)
-            if not file.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.py')) and 'llama-tokenizer' not in file:
+            if not file.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.py')) and 'llama-tokenizer' not in relative_path:
                 model_list.append(relative_path)
     return ['None'] + sorted(model_list, key=natural_keys)
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -73,12 +73,13 @@ def natural_keys(text):
 
 
 def get_available_models():
+    exclude_extensions = ('.txt', '-np', '.pt', '.json', '.yaml', '.py', '.modelfile')
     model_list = []
     for dirpath, dirnames, files in os.walk(shared.args.model_dir, followlinks=True):
         for file in files:
             file_path = os.path.join(dirpath, file)
             relative_path = os.path.relpath(file_path, shared.args.model_dir)
-            if not file.endswith(('.txt', '-np', '.pt', '.json', '.yaml', '.py')) and 'llama-tokenizer' not in relative_path:
+            if not file.endswith(exclude_extensions) and 'llama-tokenizer' not in relative_path:
                 model_list.append(relative_path)
     return ['None'] + sorted(model_list, key=natural_keys)
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

* Support loading models from sub-directories
* Allow following symlinks in models directory
* Add .modelfile to excluded extensions

This PR enables organizing models into folders, and symlinking to other locations. I use this to keep one copy of models in a local folder that can be shared among all UIs.
