### PR TITLE
Filter whitespaces in downloader fields in model tab

### DIFF
--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -260,6 +260,8 @@ def download_model_wrapper(repo_id, specific_file, progress=gr.Progress(), retur
             yield ("Please enter a model path")
             return
 
+        repo_id = repo_id.strip()
+        specific_file = specific_file.strip()
         downloader = importlib.import_module("download-model").ModelDownloader()
 
         progress(0.0)


### PR DESCRIPTION
Sometimes users accidentally contaminate downloader fields in Model tab with whitespaces or newlines and it prevents from downloading models. As of now such contamination creates broken download links and it returns errors from HF and it can be confusing for a user since it's hard to notice such symbols in the text fields.
This PR adds strip() to "repo_id" and "specific_file" variables in the downloader to filter out such symbols.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
