### PR TITLE
Multi platform single repo

### DIFF
--- a/cmd_linux.sh
+++ b/cmd_linux.sh
@@ -8,8 +8,8 @@ if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can no
 { conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
 
 # config
-CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
-INSTALL_ENV_DIR="$(pwd)/installer_files/env"
+CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda_linux"
+INSTALL_ENV_DIR="$(pwd)/installer_files/env_linux"
 
 # environment isolation
 export PYTHONNOUSERSITE=1

--- a/cmd_macos.sh
+++ b/cmd_macos.sh
@@ -8,8 +8,8 @@ if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can no
 { conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
 
 # config
-CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
-INSTALL_ENV_DIR="$(pwd)/installer_files/env"
+CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda_osx"
+INSTALL_ENV_DIR="$(pwd)/installer_files/env_osx"
 
 # environment isolation
 export PYTHONNOUSERSITE=1

--- a/cmd_windows.bat
+++ b/cmd_windows.bat
@@ -14,8 +14,8 @@ set TEMP=%cd%\installer_files
 (call conda deactivate && call conda deactivate && call conda deactivate) 2>nul
 
 @rem config
-set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
-set INSTALL_ENV_DIR=%cd%\installer_files\env
+set CONDA_ROOT_PREFIX=%cd%\installer_files\conda_windows
+set INSTALL_ENV_DIR=%cd%\installer_files\env_windows
 
 @rem environment isolation
 set PYTHONNOUSERSITE=1

--- a/one_click.py
+++ b/one_click.py
@@ -19,10 +19,35 @@ import sys
 TORCH_VERSION = "2.4.1"
 TORCHVISION_VERSION = "0.19.1"
 TORCHAUDIO_VERSION = "2.4.1"
+# Platform handling
+
+
+def is_linux():
+    return sys.platform.startswith("linux")
+
+
+def is_windows():
+    return sys.platform.startswith("win")
+
+
+def is_macos():
+    return sys.platform.startswith("darwin")
+
+
+def platform_name():
+    if is_linux():
+        return "linux"
+    elif is_windows():
+        return "windows"
+    elif is_macos():
+        return "osx"
+    else:
+        return ""
+
 
 # Environment
 script_dir = os.getcwd()
-conda_env_path = os.path.join(script_dir, "installer_files", "env")
+conda_env_path = os.path.join(script_dir, "installer_files", "env_" + platform_name())
 
 # Command-line flags
 cmd_flags_path = os.path.join(script_dir, "CMD_FLAGS.txt")
@@ -40,18 +65,6 @@ def signal_handler(sig, frame):
 
 
 signal.signal(signal.SIGINT, signal_handler)
-
-
-def is_linux():
-    return sys.platform.startswith("linux")
-
-
-def is_windows():
-    return sys.platform.startswith("win")
-
-
-def is_macos():
-    return sys.platform.startswith("darwin")
 
 
 def is_x86_64():
@@ -183,10 +196,10 @@ def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, 
     # Use the conda environment
     if environment:
         if is_windows():
-            conda_bat_path = os.path.join(script_dir, "installer_files", "conda", "condabin", "conda.bat")
+            conda_bat_path = os.path.join(script_dir, "installer_files", "conda_" + platform_name(), "condabin", "conda.bat")
             cmd = f'"{conda_bat_path}" activate "{conda_env_path}" >nul && {cmd}'
         else:
-            conda_sh_path = os.path.join(script_dir, "installer_files", "conda", "etc", "profile.d", "conda.sh")
+            conda_sh_path = os.path.join(script_dir, "installer_files", "conda_" + platform_name(), "etc", "profile.d", "conda.sh")
             cmd = f'. "{conda_sh_path}" && conda activate "{conda_env_path}" && {cmd}'
 
     # Set executable to None for Windows, bash for everything else

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -17,8 +17,8 @@ esac
 
 # config
 INSTALL_DIR="$(pwd)/installer_files"
-CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
-INSTALL_ENV_DIR="$(pwd)/installer_files/env"
+CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda_linux"
+INSTALL_ENV_DIR="$(pwd)/installer_files/env_linux"
 MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-${OS_ARCH}.sh"
 conda_exists="F"
 

--- a/start_macos.sh
+++ b/start_macos.sh
@@ -17,8 +17,8 @@ esac
 
 # config
 INSTALL_DIR="$(pwd)/installer_files"
-CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
-INSTALL_ENV_DIR="$(pwd)/installer_files/env"
+CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda_osx"
+INSTALL_ENV_DIR="$(pwd)/installer_files/env_osx"
 MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-${OS_ARCH}.sh"
 conda_exists="F"
 

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -23,8 +23,8 @@ set TEMP=%cd%\installer_files
 
 @rem config
 set INSTALL_DIR=%cd%\installer_files
-set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
-set INSTALL_ENV_DIR=%cd%\installer_files\env
+set CONDA_ROOT_PREFIX=%cd%\installer_files\conda_windows
+set INSTALL_ENV_DIR=%cd%\installer_files\env_windows
 set MINICONDA_DOWNLOAD_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Windows-x86_64.exe
 set MINICONDA_CHECKSUM=307194e1f12bbeb52b083634e89cc67db4f7980bd542254b43d3309eaf7cb358
 set conda_exists=F

--- a/update_wizard_linux.sh
+++ b/update_wizard_linux.sh
@@ -8,8 +8,8 @@ if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can no
 { conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
 
 # config
-CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
-INSTALL_ENV_DIR="$(pwd)/installer_files/env"
+CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda_linux"
+INSTALL_ENV_DIR="$(pwd)/installer_files/env_linux"
 
 # environment isolation
 export PYTHONNOUSERSITE=1

--- a/update_wizard_macos.sh
+++ b/update_wizard_macos.sh
@@ -8,8 +8,8 @@ if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can no
 { conda deactivate && conda deactivate && conda deactivate; } 2> /dev/null
 
 # config
-CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
-INSTALL_ENV_DIR="$(pwd)/installer_files/env"
+CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda_osx"
+INSTALL_ENV_DIR="$(pwd)/installer_files/env_osx"
 
 # environment isolation
 export PYTHONNOUSERSITE=1

--- a/update_wizard_windows.bat
+++ b/update_wizard_windows.bat
@@ -14,8 +14,8 @@ set TEMP=%cd%\installer_files
 (call conda deactivate && call conda deactivate && call conda deactivate) 2>nul
 
 @rem config
-set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
-set INSTALL_ENV_DIR=%cd%\installer_files\env
+set CONDA_ROOT_PREFIX=%cd%\installer_files\conda_windows
+set INSTALL_ENV_DIR=%cd%\installer_files\env_windows
 
 @rem environment isolation
 set PYTHONNOUSERSITE=1

--- a/wsl.sh
+++ b/wsl.sh
@@ -24,8 +24,8 @@ if [[ ! $(realpath "$(pwd)/..") = /mnt/* ]]; then
     INSTALL_DIR_PREFIX="$(realpath "$(pwd)/..")" && INSTALL_INPLACE=1
 fi
 INSTALL_DIR="$INSTALL_DIR_PREFIX/text-generation-webui"
-CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"
-INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"
+CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda_linux"
+INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env_linux"
 MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-x86_64.sh"
 conda_exists="F"
 


### PR DESCRIPTION
This change will allow users to use the same repo between multiple operating systems when using a file system like btrfs on a portable device like a flashdrive.


I currently have this under draft because i seem to be encountering en error where server.py cant find modules and I dont know why.

Edit: it seems to function if I call server.py directly from inside a window with the env set.

Edit: a full system reboot and btrfs rebalance seems to have made it function as desired i am now opening this pullreq
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
