### PR TITLE
Remove 'dark' from document.body.classList when starting interface with dark_theme: false

### DIFF
--- a/server.py
+++ b/server.py
@@ -154,6 +154,9 @@ def create_interface():
                 if ({str(shared.settings['dark_theme']).lower()}) {{
                     document.getElementsByTagName('body')[0].classList.add('dark');
                 }}
+                else {{
+                    document.getElementsByTagName('body')[0].classList.remove('dark');
+                }}
                 {js}
                 {ui.show_controls_js}
                 toggle_controls(x);


### PR DESCRIPTION
This PR fixes the problem described in issue #6613. 
It's likely not fixing the root cause, which would be to not set the class name of the `body` to 'dark' in the first place when `dark_theme` is set to `false`  in the settings. 
However, I was unable to determine what causes this behavior, so I simply removed 'dark' from the `classList` in the same piece of javascript that adds it when `dark_theme` is `true` at startup.


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
