### PR TITLE
Unescape backslashes

### DIFF
--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -239,6 +239,9 @@ def convert_to_markdown(string):
     pattern = re.compile(r'<code[^>]*>(.*?)</code>', re.DOTALL)
     html_output = pattern.sub(lambda x: html.unescape(x.group()), html_output)
 
+    # Unescape backslashes
+    html_output = html_output.replace('\\\\', '\\')
+
     # Add "long-list" class to <ul> or <ol> containing a long <li> item
     html_output = add_long_list_class(html_output)
 


### PR DESCRIPTION
This PR unescapes backslashes that were previously escaped, which fixes the issue that all single backslashes are converted to double backslashes.

Fixes #6395 and #6628
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).