### PR TITLE
llama_cpp: add speculative decoding

### DIFF
--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -48,6 +48,8 @@ loaders_and_params = OrderedDict({
         'no_mmap',
         'mlock',
         'numa',
+        'draft_model',
+        'num_pred_tokens',
     ],
     'llamacpp_HF': [
         'n_gpu_layers',

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -133,6 +133,8 @@ group.add_argument('--cache-capacity', type=str, help='Maximum cache capacity (l
 group.add_argument('--row_split', action='store_true', help='Split the model by rows across GPUs. This may improve multi-gpu performance.')
 group.add_argument('--streaming-llm', action='store_true', help='Activate StreamingLLM to avoid re-evaluating the entire prompt when old messages are removed.')
 group.add_argument('--attention-sink-size', type=int, default=5, help='StreamingLLM: number of sink tokens. Only used if the trimmed prompt does not share a prefix with the old prompt.')
+group.add_argument('--draft_model', type=str, default="", help='Draft Model for speculative decoding')
+group.add_argument('--num_pred_tokens', type=int, default=0, help='Number of tokens to predict using prompt lookup decoding or speculative decoding. Set to 0 to disable')
 group.add_argument('--tokenizer-dir', type=str, help='Load the tokenizer from this folder. Meant to be used with llamacpp_HF through the command-line.')
 
 # ExLlamaV2

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -123,6 +123,8 @@ def list_model_elements():
         'compute_dtype',
         'quant_type',
         'attention_sink_size',
+        'draft_model',
+        'num_pred_tokens',
         'num_experts_per_token',
         'tensorcores',
         'load_in_8bit',

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -100,6 +100,8 @@ def create_ui():
                             shared.gradio['compute_dtype'] = gr.Dropdown(label="compute_dtype", choices=["bfloat16", "float16", "float32"], value=shared.args.compute_dtype, info='Used by load-in-4bit.')
                             shared.gradio['quant_type'] = gr.Dropdown(label="quant_type", choices=["nf4", "fp4"], value=shared.args.quant_type, info='Used by load-in-4bit.')
                             shared.gradio['attention_sink_size'] = gr.Number(label="attention_sink_size", value=shared.args.attention_sink_size, precision=0, info='StreamingLLM: number of sink tokens. Only used if the trimmed prompt doesn\'t share a prefix with the old prompt.')
+                            shared.gradio['draft_model'] = gr.Dropdown(choices=utils.get_available_models(), value=shared.args.draft_model, label="Draft Model", info='Draft Model for speculative decoding')
+                            shared.gradio['num_pred_tokens'] = gr.Number(label="num_pred_tokens", value=shared.args.num_pred_tokens, precision=0, info='Number of tokens to predict using prompt lookup decoding or speculative decoding. Set to 0 to disable')
                             shared.gradio['num_experts_per_token'] = gr.Number(label="Number of experts per token", value=shared.args.num_experts_per_token, info='Only applies to MoE models like Mixtral.')
 
                         with gr.Column():


### PR DESCRIPTION
This PR implements basic support for speculative decoding for the llama_cpp loader. It supports loading a gguf model as a draft model or using the built-in LlamaPromptLookupDecoding class. Tested with `Qwen2.5-Coder-32B-Instruct-Q4_K_L.gguf` and `qwen2.5-coder-1.5b-instruct-q4_k_m.gguf` as the draft model, showing a significant speed-up:
no speculative decoding:  22t/s
prompt lookup decoding: 24t/s
draft model decoding: 30t/s
The PR still needs some testing. Not sure if setting all the parameters for the draft model in the UI would be desirable or if copying parameters from the main model would be more appropriate.
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
