### PR TITLE
Add missing colon (:) for improved clarity in model download instruct…

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ text-generation-webui
 │   │   └── tokenizer.model
 ```
 
-In both cases, you can use the "Model" tab of the UI to download the model from Hugging Face automatically. It is also possible to download it via the command-line with 
+In both cases, you can use the "Model" tab of the UI to download the model from Hugging Face automatically. It is also possible to download it via the command-line with:
 
 ```
 python download-model.py organization/model


### PR DESCRIPTION
…ions

This commit adds a missing colon (:) at the end of a sentence in the model download instructions to improve readability and logical flow. This minor fix makes the instructions clearer and aligns with standard writing conventions.

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
