### PR TITLE
Add strftime_now to JINJA to sattisfy LLAMA 3.1 and 3.2 

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -30,8 +30,12 @@ from modules.text_generation import (
 )
 from modules.utils import delete_file, get_available_characters, save_file
 
-# Copied from the Transformers library
+def strftime_now(format):
+    return datetime.now().strftime(format)
+
 jinja_env = ImmutableSandboxedEnvironment(trim_blocks=True, lstrip_blocks=True)
+
+jinja_env.globals["strftime_now"] = strftime_now
 
 
 def str_presenter(dumper, data):


### PR DESCRIPTION
Added date function necessary for LLAMA 3.1 and 3.2 template (otherwise it will result in a default old date)
This is already part of Transformers code, but you are not using apply_chat_template, you are doing it manually so this function has been then left out.

## Checklist:

- [ X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

![image](https://github.com/user-attachments/assets/2e414185-cb4e-4579-96dd-2d1527614ad3)

