### PR TITLE
Update models.py

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -33,7 +33,7 @@ transformers.logging.set_verbosity_error()
 local_rank = None
 if shared.args.deepspeed:
     import deepspeed
-    from transformers.deepspeed import (
+    from transformers.integrations.deepspeed import (
         HfDeepSpeedConfig,
         is_deepspeed_zero3_enabled
     )


### PR DESCRIPTION
## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

This update resolves the deprecation of the transformers `transformers.deepspeed` import usage around transformers version 4.46.  See: https://github.com/huggingface/transformers/issues/34582

Smoke-tested with deepspeed 0.16.3 and transformers 4.48.2

