### PR TITLE
UI Darker theme

### DIFF
--- a/css/chat_style-cai-chat.css
+++ b/css/chat_style-cai-chat.css
@@ -55,7 +55,7 @@
 }
 
 .dark .message-body p em {
-    color: rgb(138 138 138) !important;
+    color: rgb(180, 180, 180) !important;
 }
 
 .message-body p em {

--- a/css/main.css
+++ b/css/main.css
@@ -1,5 +1,5 @@
 :root {
-    --darker-gray: #202123;
+    --darker-gray: #171717;
     --dark-gray: #202123;
     --light-gray: #303030;
     --light-theme-gray: #f5f5f5;

--- a/css/main.css
+++ b/css/main.css
@@ -1,7 +1,7 @@
 :root {
     --darker-gray: #202123;
-    --dark-gray: #343541;
-    --light-gray: #444654;
+    --dark-gray: #202123;
+    --light-gray: #303030;
     --light-theme-gray: #f5f5f5;
     --border-color-dark: #525252;
     --header-width: 112px;
@@ -265,7 +265,7 @@ button {
 
 .dark .pretty_scrollbar::-webkit-scrollbar-thumb,
 .dark .pretty_scrollbar::-webkit-scrollbar-thumb:hover {
-    background: #ccc;
+    background: #565869;
     border-radius: 10px;
 }
 


### PR DESCRIPTION
<details><summary>Improved dark mode with colors matching current ChatGPT's interface.</summary>

Fixes #6673 

```diff
# Base colors
-    --dark-gray: #343541;
-    --light-gray: #444654;
+    --dark-gray: #202123;
+    --light-gray: #303030;

# Emphasized text (*actions*) brighter for visibility
-    color: rgb(138 138 138) !important;
+    color: rgb(180, 180, 180) !important;

# Scrollbar darker
-    background: #ccc;
+    background: #565869;
```

</details>


Before | After
---- | ----
![BEFORE](https://github.com/user-attachments/assets/d382a3e6-2187-4a45-b149-8fc2034cc749) | ![AFTER](https://github.com/user-attachments/assets/18d061ca-6e11-4adf-982c-df5c01500b53)