### PR TITLE
Prevent llamacpp defaults from locking up consumer hardware

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -116,8 +116,8 @@ group.add_argument('--quant_type', type=str, default='nf4', help='quant_type for
 group = parser.add_argument_group('llama.cpp')
 group.add_argument('--flash-attn', action='store_true', help='Use flash-attention.')
 group.add_argument('--n_ctx', type=int, default=8192, help='Size of the prompt context.')
-group.add_argument('--threads', type=int, default=max(1, int(os.cpu_count() / 2)), help='Number of threads to use.')
-group.add_argument('--threads-batch', type=int, default=os.cpu_count() * 2, help='Number of threads to use for batches/prompt processing.')
+group.add_argument('--threads', type=int, default=0, help='Number of threads to use.')
+group.add_argument('--threads-batch', type=int, default=0, help='Number of threads to use for batches/prompt processing.')
 group.add_argument('--batch-size', type=int, default=256, help='Maximum number of prompt tokens to batch together when calling llama_eval.')
 group.add_argument('--no-mmap', action='store_true', help='Prevent mmap from being used.')
 group.add_argument('--mlock', action='store_true', help='Force the system to keep the model in RAM.')
@@ -149,7 +149,7 @@ group.add_argument('--cpp-runner', action='store_true', help='Use the ModelRunne
 
 # Cache
 group = parser.add_argument_group('Cache')
-group.add_argument('--cache_type', type=str, default='fp16', help='KV cache type; valid options: llama.cpp - fp16, q8_0, q4_0; ExLlamaV2 - fp16, fp8, q8, q6, q4. \nTry to match the quantization of the model you are using for the most benefit. There is no accuracy benefit using fp16 when the model is quantized smaller.')
+group.add_argument('--cache_type', type=str, default='fp16', help='KV cache type; valid options: llama.cpp - fp16, q8_0, q4_0; ExLlamaV2 - fp16, fp8, q8, q6, q4.')
 
 # DeepSpeed
 group = parser.add_argument_group('DeepSpeed')

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -116,9 +116,9 @@ group.add_argument('--quant_type', type=str, default='nf4', help='quant_type for
 group = parser.add_argument_group('llama.cpp')
 group.add_argument('--flash-attn', action='store_true', help='Use flash-attention.')
 group.add_argument('--n_ctx', type=int, default=8192, help='Size of the prompt context.')
-group.add_argument('--threads', type=int, default=0, help='Number of threads to use.')
-group.add_argument('--threads-batch', type=int, default=0, help='Number of threads to use for batches/prompt processing.')
-group.add_argument('--batch-size', type=int, default=2048, help='Maximum number of prompt tokens to batch together when calling llama_eval.')
+group.add_argument('--threads', type=int, default=max(1, int(os.cpu_count() / 2)), help='Number of threads to use.')
+group.add_argument('--threads-batch', type=int, default=os.cpu_count() * 2, help='Number of threads to use for batches/prompt processing.')
+group.add_argument('--batch-size', type=int, default=256, help='Maximum number of prompt tokens to batch together when calling llama_eval.')
 group.add_argument('--no-mmap', action='store_true', help='Prevent mmap from being used.')
 group.add_argument('--mlock', action='store_true', help='Force the system to keep the model in RAM.')
 group.add_argument('--n-gpu-layers', type=int, default=0, help='Number of layers to offload to the GPU.')
@@ -149,7 +149,7 @@ group.add_argument('--cpp-runner', action='store_true', help='Use the ModelRunne
 
 # Cache
 group = parser.add_argument_group('Cache')
-group.add_argument('--cache_type', type=str, default='fp16', help='KV cache type; valid options: llama.cpp - fp16, q8_0, q4_0; ExLlamaV2 - fp16, fp8, q8, q6, q4.')
+group.add_argument('--cache_type', type=str, default='fp16', help='KV cache type; valid options: llama.cpp - fp16, q8_0, q4_0; ExLlamaV2 - fp16, fp8, q8, q6, q4. \nTry to match the quantization of the model you are using for the most benefit. There is no accuracy benefit using fp16 when the model is quantized smaller.')
 
 # DeepSpeed
 group = parser.add_argument_group('DeepSpeed')


### PR DESCRIPTION
## Checklist:

- [X ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

$ pyflakes modules/shared.py 
$ pycodestyle modules/shared.py 
$ 

Default of 0 for threads and batch_threads means to spawn as many threads as there are tokens *all at once*. This can cause periods where a desktop can cease being interactive, high memory use and swapping on some setups. So I changed to thread=1/2 cpu count and batch_threads=2*cpu count. This should result in about 80% cpu util. People who have H100s that run completely on gpu hardware can up this as needed.

Lowered batch-size as well. 256 is 'safe' for consumer hardware. Uses slightly less vram and system ram and prevents periods of loss of interactivity on the desktop. batch-size -> number of tokens to process at once. When this was set to 2k and batch_threads was set to 0, it would drop 2k threads on cpu/gpu at a time. Obviously not acceptable for consumer hardware given io and interface bandwidth limits. A lower number will actually improve throughput on consumer hardware as it lower resource contention.

Added additional kv cache description. Cache should match the ggufs quantization level. There is no benefit using a fp16 cache for a q_4 model. It just means your cache can only hold 1/4 as many items with no accuracy benefit. Using the correct cache level can increase performance a lot. 