### PR TITLE
existing embedding check bug fix

### DIFF
--- a/extensions/superboogav2/chromadb.py
+++ b/extensions/superboogav2/chromadb.py
@@ -148,7 +148,7 @@ class ChromaCollector():
             id_ = new_ids[i]
             metadata = metadatas[i] if metadatas is not None else None
             embedding = self.embeddings_cache.get(text)
-            if embedding is not None and embedding.any():
+            if embedding is not None and any(embedding):
                 existing_texts.append(text)
                 existing_embeddings.append(embedding)
                 existing_ids.append(id_)


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

This PR fixes getting an exception when the corpus have no non-existing embeddings. 
Currently this case leads to the AttributeError: 'list' object has no attribute 'any'