### PR TITLE
SuperboogaV2 minor update to avoid json serialization errors

### DIFF
--- a/extensions/superboogav2/chromadb.py
+++ b/extensions/superboogav2/chromadb.py
@@ -292,6 +292,8 @@ class ChromaCollector():
 
         for doc in documents:
             doc_tokens = encode(doc)[0]
+            if isinstance(doc_tokens, np.ndarray):
+                doc_tokens = doc_tokens.tolist()
             doc_token_count = len(doc_tokens)
             if current_token_count + doc_token_count > max_token_count:
                 # If adding this document would exceed the max token count,


### PR DESCRIPTION
## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

`chromadb.py` was passing document tokens to `modules.text_generation.decode()` as `np.ndarray` which caused json serialization errors. It now converts them to `list` to avoid issues.