### PR TITLE
Refactor the history format

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -1,5 +1,4 @@
 import base64
-import copy
 import re
 import time
 from collections import deque

--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -97,7 +97,7 @@ def convert_history(history):
     if any('content' in entry and isinstance(entry['content'], list) for entry in history):
         temp_history = []
         for entry in history:
-            if isinstance(entry.get('content'), list):
+            if isinstance(entry['content'], list):
                 for item in entry['content']:
                     if not isinstance(item, dict):
                         continue

--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -1,4 +1,3 @@
-import copy
 import time
 from collections import deque
 
@@ -84,7 +83,6 @@ def convert_history(history):
     Converts OpenAI chat histories to our internal format.
     Our new format is a list of message objects similar to OpenAI's format.
     '''
-    system_message = ""
     new_history = []
 
     for entry in history:

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -591,17 +591,28 @@ def redraw_html(history, name1, name2, mode, style, character, reset_cache=False
 
 def start_new_chat(state):
     mode = state['mode']
-    history = {'internal': [], 'visible': []}
+    history = []
 
     if mode != 'instruct':
         greeting = replace_character_names(state['greeting'], state['name1'], state['name2'])
+        # Add assistant's greeting
         if greeting != '':
-            history['internal'] += [['<|BEGIN-VISIBLE-CHAT|>', greeting]]
-            history['visible'] += [['', apply_extensions('output', html.escape(greeting), state, is_chat=True)]]
+            history.append({
+                'role': 'user',
+                'content': '<|BEGIN-VISIBLE-CHAT|>',
+                'visible-content': '',
+                'date': current_date()
+            })
+
+            history.append({
+                'role': 'assistant',
+                'content': greeting,
+                'visible-content': apply_extensions('output', html.escape(greeting), state, is_chat=True),
+                'date': current_date()
+            })
 
     unique_id = datetime.now().strftime('%Y%m%d-%H-%M-%S')
     save_history(history, unique_id, state['character_menu'], state['mode'])
-
     return history
 
 
@@ -1343,7 +1354,7 @@ def handle_your_picture_change(picture, state):
 
 def handle_send_instruction_click(state):
     state['mode'] = 'instruct'
-    state['history'] = {'internal': [], 'visible': []}
+    state['history'] = []
 
     output = generate_chat_prompt("Input", state)
 

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -139,10 +139,6 @@ def generate_chat_prompt(user_input, state, **kwargs):
     also_return_rows = kwargs.get('also_return_rows', False)
     history = kwargs.get('history', state['history'])
 
-    # Ensure history is in the new format
-    if not isinstance(history, list):
-        history = convert_old_history_to_new(history)
-
     # Templates
     chat_template_str = state['chat_template_str']
     if state['mode'] != 'instruct':

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -135,6 +135,7 @@ def get_thinking_suppression_string(template):
 def generate_chat_prompt(user_input, state, **kwargs):
     impersonate = kwargs.get('impersonate', False)
     _continue = kwargs.get('_continue', False)
+    regenerate = kwargs.get('regenerate', False)
     also_return_rows = kwargs.get('also_return_rows', False)
     history = kwargs.get('history', state['history'])
 
@@ -198,7 +199,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
                     messages.insert(insert_pos, {"role": "assistant", "content": assistant_msg})
 
     user_input = user_input.strip()
-    if user_input and not impersonate and not _continue:
+    if user_input and not impersonate and not _continue and not regenerate:
         messages.append({"role": "user", "content": user_input})
 
     def make_prompt(messages):
@@ -470,6 +471,7 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
     # Generate the prompt
     kwargs = {
         '_continue': _continue,
+        'regenerate': regenerate,
         'history': output if _continue else output[:-1] if output else []
     }
     prompt = apply_extensions('custom_generate_chat_prompt', text, state, **kwargs)

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -36,6 +36,10 @@ def strftime_now(format):
     return datetime.now().strftime(format)
 
 
+def current_date():
+    return strftime_now('%Y-%m-%d %H:%M')
+
+
 jinja_env = ImmutableSandboxedEnvironment(
     trim_blocks=True,
     lstrip_blocks=True,

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -619,26 +619,26 @@ def send_last_reply_to_input(history):
 
 
 def replace_last_reply(text, state):
+    if not text.strip():
+        return state['history']
+
     history = state['history']
-    if len(text.strip()) == 0:
-        return history
 
-    # Find the last assistant message (could be single or in a regeneration list)
-    last_assistant = None
-    for msg in reversed(history):
-        if isinstance(msg, dict) and msg['role'] == 'assistant':
-            last_assistant = msg
-        elif isinstance(msg, list) and msg and msg[-1]['role'] == 'assistant':
-            last_assistant = msg
+    # Find the last assistant message
+    for item in reversed(history):
+        assistant_msg = None
+        if isinstance(item, dict) and item.get('role') == 'assistant':
+            assistant_msg = item
+        elif isinstance(item, list) and item and item[-1].get('role') == 'assistant':
+            assistant_msg = item[-1]
 
-    if last_assistant:
-        visible_text = html.escape(text)
-        internal_text = apply_extensions('input', text, state, is_chat=True)
-        last_assistant.update({
-            'content': internal_text,
-            'visible-content': visible_text,
-            'date': current_date()
-        })
+        if assistant_msg:
+            assistant_msg.update({
+                'content': apply_extensions('input', text, state, is_chat=True),
+                'visible-content': html.escape(text),
+                'date': current_date()
+            })
+            break
 
     return history
 

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -37,7 +37,7 @@ def strftime_now(format):
 
 
 def current_date():
-    return strftime_now('%Y-%m-%d %H:%M')
+    return strftime_now('%Y-%m-%d %H:%M:%S')
 
 
 jinja_env = ImmutableSandboxedEnvironment(

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -398,16 +398,13 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
             if regenerate:
                 if last_assistant_idx != -1:
                     if isinstance(output[last_assistant_idx], dict):
-                        regen_list = [output[last_assistant_idx]]
+                        regen_list = [output[last_assistant_idx], msg]
+                        yield output[:last_assistant_idx] + [regen_list] + output[last_assistant_idx + 1:]
                     else:
-                        regen_list = output[last_assistant_idx]
-
-                    regen_list.append(msg)
-                    output = output[:last_assistant_idx] + [regen_list] + output[last_assistant_idx + 1:]
+                        regen_list = output[last_assistant_idx] + [msg]
+                        yield output[:last_assistant_idx] + [regen_list] + output[last_assistant_idx + 1:]
                 else:
-                    output.append(msg)
-
-                yield output
+                    yield output + [msg]
 
             elif _continue and last_assistant_idx != -1:
                 container = output[last_assistant_idx]

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -611,9 +611,9 @@ def send_last_reply_to_input(history):
 
     last_msg = history[-1]
     if isinstance(last_msg, dict) and last_msg['role'] == 'assistant':
-        return html.unescape(last_msg['visible-content'])
+        return html.unescape(last_msg['visible-content']).strip()
     elif isinstance(last_msg, list) and last_msg and last_msg[-1]['role'] == 'assistant':
-        return html.unescape(last_msg[-1]['visible-content'])
+        return html.unescape(last_msg[-1]['visible-content']).strip()
 
     return ''
 

--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -349,9 +349,7 @@ remove_button = f'<button class="footer-button footer-remove-button" title="Remo
 def generate_instruct_html(history):
     output = f'<style>{instruct_css}</style><div class="chat" id="chat"><div class="messages">'
 
-    # Process each message
     for i, item in enumerate(history):
-        # Skip system messages
         if isinstance(item, dict) and item['role'] == 'user' and item['content'] == '<|BEGIN-VISIBLE-CHAT|>':
             continue
 
@@ -370,18 +368,14 @@ def generate_instruct_html(history):
                 )
 
         # Handle assistant messages (both single messages and regeneration lists)
-        elif (isinstance(item, dict) and item['role'] == 'assistant') or \
-             (isinstance(item, list) and item and item[0]['role'] == 'assistant'):
-
-            # Get the actual message content (either from the message or last in regeneration list)
+        elif (isinstance(item, dict) and item['role'] == 'assistant') or (isinstance(item, list) and item and item[0]['role'] == 'assistant'):
             if isinstance(item, dict):
                 assistant_msg = item
-            else:  # it's a regeneration list
+            else:
                 assistant_msg = item[-1]
 
             is_last = (i == len(history) - 1)
             converted = convert_to_markdown_wrapped(assistant_msg['visible-content'], message_id=i, use_cache=not is_last)
-
             output += (
                 f'<div class="assistant-message" '
                 f'data-raw="{html.escape(assistant_msg["content"], quote=True)}">'
@@ -413,9 +407,7 @@ def generate_cai_chat_html(history, name1, name2, style, character, reset_cache=
         if Path("user_data/cache/pfp_me.png").exists() else ''
     )
 
-    # Process each message
     for i, item in enumerate(history):
-        # Skip system messages
         if isinstance(item, dict) and item['role'] == 'user' and item['content'] == '<|BEGIN-VISIBLE-CHAT|>':
             continue
 
@@ -436,18 +428,14 @@ def generate_cai_chat_html(history, name1, name2, style, character, reset_cache=
                 )
 
         # Handle assistant messages (both single messages and regeneration lists)
-        elif (isinstance(item, dict) and item['role'] == 'assistant') or \
-             (isinstance(item, list) and item and item[0]['role'] == 'assistant'):
-
-            # Get the actual message content (either from the message or last in regeneration list)
+        elif (isinstance(item, dict) and item['role'] == 'assistant') or (isinstance(item, list) and item and item[0]['role'] == 'assistant'):
             if isinstance(item, dict):
                 assistant_msg = item
-            else:  # it's a regeneration list
+            else:
                 assistant_msg = item[-1]
 
             is_last = (i == len(history) - 1)
             converted = convert_to_markdown_wrapped(assistant_msg['visible-content'], message_id=i, use_cache=not is_last)
-
             output += (
                 f'<div class="message" '
                 f'data-raw="{html.escape(assistant_msg["content"], quote=True)}">'
@@ -470,9 +458,7 @@ def generate_cai_chat_html(history, name1, name2, style, character, reset_cache=
 def generate_chat_html(history, name1, name2, reset_cache=False):
     output = f'<style>{chat_styles["wpp"]}</style><div class="chat" id="chat"><div class="messages">'
 
-    # Process each message
     for i, item in enumerate(history):
-        # Skip system messages
         if isinstance(item, dict) and item['role'] == 'user' and item['content'] == '<|BEGIN-VISIBLE-CHAT|>':
             continue
 
@@ -491,18 +477,14 @@ def generate_chat_html(history, name1, name2, reset_cache=False):
                 )
 
         # Handle assistant messages (both single messages and regeneration lists)
-        elif (isinstance(item, dict) and item['role'] == 'assistant') or \
-             (isinstance(item, list) and item and item[0]['role'] == 'assistant'):
-
-            # Get the actual message content (either from the message or last in regeneration list)
+        elif (isinstance(item, dict) and item['role'] == 'assistant') or (isinstance(item, list) and item and item[0]['role'] == 'assistant'):
             if isinstance(item, dict):
                 assistant_msg = item
-            else:  # it's a regeneration list
+            else:
                 assistant_msg = item[-1]
 
             is_last = (i == len(history) - 1)
             converted = convert_to_markdown_wrapped(assistant_msg['visible-content'], message_id=i, use_cache=not is_last)
-
             output += (
                 f'<div class="message" '
                 f'data-raw="{html.escape(assistant_msg["content"], quote=True)}">'

--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -531,7 +531,7 @@ def time_greeting():
 
 
 def chat_html_wrapper(history, name1, name2, mode, style, character, reset_cache=False):
-    if len(history['visible']) == 0:
+    if len(history) == 0:
         greeting = f"<div class=\"welcome-greeting\">{time_greeting()} How can I help you today?</div>"
         result = f'<div class="chat" id="chat">{greeting}</div>'
     elif mode == 'instruct':

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -47,7 +47,7 @@ def create_ui():
         with gr.Row():
             with gr.Column(elem_id='chat-col'):
                 shared.gradio['display'] = gr.JSON(value={}, visible=False)  # Hidden buffer
-                shared.gradio['html_display'] = gr.HTML(value=chat_html_wrapper({'internal': [], 'visible': []}, '', '', 'chat', 'cai-chat', '')['html'], visible=True)
+                shared.gradio['html_display'] = gr.HTML(value=chat_html_wrapper([], '', '', 'chat', 'cai-chat', '')['html'], visible=True)
                 with gr.Row(elem_id="chat-input-row"):
                     with gr.Column(scale=1, elem_id='gr-hover-container'):
                         gr.HTML(value='<div class="hover-element" onclick="void(0)"><span style="width: 100px; display: block" id="hover-element-button">&#9776;</span><div class="hover-menu" id="hover-menu"></div>', elem_id='gr-hover')


### PR DESCRIPTION
The goal of this PR is to refactor the history format in the project from

```
{
    'internal': [[message, reply]],
    'visible': [[visible_message, visible_reply]]
}
```

to

```
[
    {
        'role': 'user',
        'content': '',
        'visible-content': '',
        'date': ''
    },
    [
        {
            'role': 'assistant',
            'content': '',
            'visible-content': '',
            'date': ''
        },
        {
            'role': 'assistant',
            'content': '',
            'visible-content': '',
            'date': ''
        },
    ]
]
```

where an entry with two options is a "regenerate".

This will make it possible to:

- Add date/time to chat/chat-instruct messages in the UI
- Add "swipes"
- Simplify the chat completions API handling a lot
- Add fields for attachments like images or documents for RAG/multimodal support.

### Status

It seems to be fully implemented now, but more testing is needed. There might be bugs.