### PR TITLE
Fix model config loading in shared.py

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -310,11 +310,13 @@ if args.api or args.public_api:
     add_extension('openai', last=True)
 
 # Load model-specific settings
-with Path(f'{args.model_dir}/config.yaml') as p:
-    if p.exists():
-        model_config = yaml.safe_load(open(p, 'r').read())
-    else:
-        model_config = {}
+p = Path(f'{args.model_dir}/config.yaml')
+if p.exists():
+    model_config = yaml.safe_load(open(p, 'r').read())
+else:
+    model_config = {}
+del p
+
 
 # Load custom model-specific settings
 user_config = load_user_config()


### PR DESCRIPTION
On my setup (Python 3.13, which I presume is the issue?) model loading errors out:

```
│ /home/alpha/AI/text-generation-webui/server.py:4 in <module>                                                                                                                                                         │
│                                                                                                                                                                                                                      │
│     3                                                                                                                                                                                                                │
│ ❱   4 from modules import shared                                                                                                                                                                                     │
│     5 from modules.block_requests import OpenMonkeyPatch, RequestBlocker                                                                                                                                             │
│                                                                                                                                                                                                                      │
│ /home/alpha/AI/text-generation-webui/modules/shared.py:313 in <module>                                                                                                                                               │
│                                                                                                                                                                                                                      │
│   312 # Load model-specific settings                                                                                                                                                                                 │
│ ❱ 313 with Path(f'{args.model_dir}/config.yaml') as p:                                                                                                                                                               │
│   314     if p.exists():                                                                                                                                                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: 'PosixPath' object does not support the context manager protocol
```

More specifically, a Path object cant be used in a with statement. This fixes it with no changes to functionality.

## Checklist:

- [ X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
