### PR TITLE
Stop model during graceful shutdown

### DIFF
--- a/modules/llama_cpp_server.py
+++ b/modules/llama_cpp_server.py
@@ -398,6 +398,7 @@ class LlamaServer:
     def stop(self):
         """Stop the server process."""
         if self.process:
+            logger.info("Terminating llama-server...")
             self.process.terminate()
             try:
                 self.process.wait(timeout=5)

--- a/server.py
+++ b/server.py
@@ -60,6 +60,13 @@ from modules.utils import gradio
 
 def signal_handler(sig, frame):
     logger.info("Received Ctrl+C. Shutting down Text generation web UI gracefully.")
+
+    # Try to stop the model if loaded
+    try:
+        shared.model.stop()
+    except:
+        pass
+
     sys.exit(0)
 
 


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

## Issue:

When using `Ctrl-c` to stop the ui once a llama model is loaded, the following error appears:

```
^C00:31:48-447215 INFO     Received Ctrl+C. Shutting down Text generation web UI gracefully.                                                       
Exception ignored in: <function LlamaServer.__del__ at 0x71c4c38ca8e0>
Traceback (most recent call last):
  File "/home/leszek/git_repos/leszekhanusz/text-generation-webui/modules/llama_cpp_server.py", line 396, in __del__
  File "/home/leszek/git_repos/leszekhanusz/text-generation-webui/modules/llama_cpp_server.py", line 401, in stop
  File "/home/leszek/miniconda3/envs/textgen/lib/python3.11/subprocess.py", line 2211, in terminate
AttributeError: 'NoneType' object has no attribute 'SIGTERM'
```

The problem is probably that the `stop` method of `LlamaServer` is called in `__del__`, too late when everything is shutting down during exit.

## Possible solution

To solve this small issue, we try to stop the model during graceful shutdown when control-c is received.

With this PR, the messages on the console becomes:

```
^C01:10:28-461166 INFO     Received Ctrl+C. Shutting down Text generation web UI gracefully.                                                       
01:10:28-462737 INFO     Terminating llama-server...                                                                                             
Received second interrupt, terminating immediately.
```