### PR TITLE
Update ui_model_menu.py blocking the --multi-user access in backend

### DIFF
--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -130,6 +130,9 @@ def create_ui():
 
 
 def create_event_handlers():
+    mu = shared.args.multi_user
+    if mu:
+        return  
     shared.gradio['loader'].change(loaders.make_loader_params_visible, gradio('loader'), gradio(loaders.get_all_params()), show_progress=False)
 
     # In this event handler, the interface state is read and updated

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -133,6 +133,7 @@ def create_event_handlers():
     mu = shared.args.multi_user
     if mu:
         return  
+
     shared.gradio['loader'].change(loaders.make_loader_params_visible, gradio('loader'), gradio(loaders.get_all_params()), show_progress=False)
 
     # In this event handler, the interface state is read and updated

--- a/modules/ui_session.py
+++ b/modules/ui_session.py
@@ -27,9 +27,10 @@ def create_ui():
                         shared.gradio['bool_menu'] = gr.CheckboxGroup(choices=get_boolean_arguments(), value=get_boolean_arguments(active=True), label="Boolean command-line flags", elem_classes='checkboxgroup-table')
 
         shared.gradio['theme_state'] = gr.Textbox(visible=False, value='dark' if shared.settings['dark_theme'] else 'light')
-        shared.gradio['save_settings'].click(
-            ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
-            handle_save_settings, gradio('interface_state', 'preset_menu', 'extensions_menu', 'show_controls', 'theme_state'), gradio('save_contents', 'save_filename', 'save_root', 'file_saver'), show_progress=False)
+        if not mu:
+            shared.gradio['save_settings'].click(
+                ui.gather_interface_values, gradio(shared.input_elements), gradio('interface_state')).then(
+                handle_save_settings, gradio('interface_state', 'preset_menu', 'extensions_menu', 'show_controls', 'theme_state'), gradio('save_contents', 'save_filename', 'save_root', 'file_saver'), show_progress=False)
 
         shared.gradio['toggle_dark_mode'].click(
             lambda x: 'dark' if x == 'light' else 'light', gradio('theme_state'), gradio('theme_state')).then(
@@ -42,9 +43,10 @@ def create_ui():
         )
 
         # Reset interface event
-        shared.gradio['reset_interface'].click(
-            set_interface_arguments, gradio('extensions_menu', 'bool_menu'), None).then(
-            None, None, None, js='() => {document.body.innerHTML=\'<h1 style="font-family:monospace;padding-top:20%;margin:0;height:100vh;color:lightgray;text-align:center;background:var(--body-background-fill)">Reloading...</h1>\'; setTimeout(function(){location.reload()},2500); return []}')
+        if not mu:
+            shared.gradio['reset_interface'].click(
+                set_interface_arguments, gradio('extensions_menu', 'bool_menu'), None).then(
+                None, None, None, js='() => {document.body.innerHTML=\'<h1 style="font-family:monospace;padding-top:20%;margin:0;height:100vh;color:lightgray;text-align:center;background:var(--body-background-fill)">Reloading...</h1>\'; setTimeout(function(){location.reload()},2500); return []}')
 
 
 def handle_save_settings(state, preset, extensions, show_controls, theme):


### PR DESCRIPTION
In the --multi-user mode, the app is blocking the access by disabling the UI components. But with a simple inspect an abuser could enable it and run the action. So we should block the access also in the backend. A simple way is to block it in the event_handlers. Here specifically the abuser can't unload the model by doing a simple inspect in the browser!

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
