### PR TITLE
Fix for chat options getting lost

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -23,7 +23,15 @@ document.querySelector(".header_bar").addEventListener("click", function(event) 
     if (extensions) {
       extensions.style.display = "flex";
     }
+
     this.style.marginBottom = chatVisible ? "0px" : "19px";
+
+    if (chatVisible && !showControlsChecked) {
+      document.querySelectorAll("#extensions").forEach(element => {
+        element.style.display = "none";
+      });
+    }
+
   } else {
     this.style.marginBottom = "19px";
     if (extensions) extensions.style.display = "none";

--- a/js/main.js
+++ b/js/main.js
@@ -23,17 +23,7 @@ document.querySelector(".header_bar").addEventListener("click", function(event) 
     if (extensions) {
       extensions.style.display = "flex";
     }
-
     this.style.marginBottom = chatVisible ? "0px" : "19px";
-
-    if (chatVisible && !showControlsChecked) {
-      document.querySelectorAll(
-        "#chat-tab > div > :nth-child(1), #chat-tab > div > :nth-child(3), #chat-tab > div > :nth-child(4), #extensions"
-      ).forEach(element => {
-        element.style.display = "none";
-      });
-    }
-
   } else {
     this.style.marginBottom = "19px";
     if (extensions) extensions.style.display = "none";

--- a/modules/ui_chat.py
+++ b/modules/ui_chat.py
@@ -21,7 +21,7 @@ def create_ui():
     shared.gradio['history'] = gr.State({'internal': [], 'visible': [], 'metadata': {}})
     shared.gradio['display'] = gr.JSON(value={}, visible=False)  # Hidden buffer
 
-    with gr.Tab('Chat', id='Chat', elem_id='chat-tab'):
+    with gr.Tab('Chat', elem_id='chat-tab'):
         with gr.Row(elem_id='past-chats-row', elem_classes=['pretty_scrollbar']):
             with gr.Column():
                 with gr.Row(elem_id='past-chats-buttons'):


### PR DESCRIPTION
The problem that this PR is intending to solve is that the chat options can be lost. The UI then looks like that:

![options_missing](https://github.com/user-attachments/assets/a75a49ce-ddca-4b81-883d-80ac86be9b01)

The path to reproduce is to open and close the options, hide/unhide the settings, and switch between the different tabs. Eventually, it reaches this state for me and only a reload of the UI fixes it.

For comparison, this is what it is expected to look:

![expected1](https://github.com/user-attachments/assets/875119b5-8fda-46ba-8a21-8b4b287af5ae)

and

![expected2](https://github.com/user-attachments/assets/cef075e4-a3ce-48fb-ba8c-30a2b29203d5)

From the error, I believe the reason is that the tab lookup is the problem (resulting ultimately in the `Attempted to select a non-interactive or hidden tab.` error in the code below):

```
function change_tab(id: object | string | number): void {
		const tab_to_activate = tabs.find((t) => t.id === id);
		if (
			tab_to_activate &&
			tab_to_activate.interactive &&
			tab_to_activate.visible
		) {
			selected = id;
			$selected_tab = id;
			$selected_tab_index = tabs.findIndex((t) => t.id === id);
			dispatch("change");
		} else {
			console.warn("Attempted to select a non-interactive or hidden tab.");
		}
	}
```

When testing, the problem goes away when the ID for the "Chat" tab is not explicitly set, but manged internally by Gradio. I did not notice any negative side-effects yet after removing it.

Tested with Firefox and Chromium.

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
