### PR TITLE
Fix: use embedded Python in one_click

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -222,6 +222,12 @@ def clear_cache():
 def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, env=None):
     # Use the conda environment
     if environment:
+        # Determine embedded Python path based on platform
+        python_path  = os.path.join(conda_env_path, "python.exe" if is_windows() else "bin/python")
+        
+        # Replace all standalone 'python' calls with full path
+        cmd = re.sub(r'(?<![\w"])python(?=\s)', lambda _: f'"{python_path}"', cmd)
+        
         if is_windows():
             conda_bat_path = os.path.join(script_dir, "installer_files", "conda", "condabin", "conda.bat")
             cmd = f'"{conda_bat_path}" activate "{conda_env_path}" >nul && {cmd}'


### PR DESCRIPTION
### 🔧 Summary

This PR ensures that all `python` commands executed through `run_cmd()` are routed through the embedded Conda environment's interpreter (`installer_files/env/python.exe` on Windows, or `bin/python` on Unix-like systems) **only when `environment=True`**.

---

### 🐛 Problem

Previously, commands like `python -m pip install ...` could unintentionally invoke the system-wide Python if it was in `PATH`, especially on Windows with global Python 3.13 or Anaconda installed. This caused:

- Duplicate or conflicting environments
- PyTorch (among others) being installed in the wrong location

---

### ✅ Fix

This patch:
- Replaces standalone `python` calls with the full embedded path (using `re.sub` and `lambda`)
- Applies the replacement only when `environment=True`
- Supports both Windows (`python.exe`) and Unix-like systems (`bin/python`)
- Avoids issues caused by `re.escape()` corrupting shell paths

---

### 📝 Note

This change has only been tested on Windows. While the code accounts for cross-platform paths, additional testing on Linux/macOS would be appreciated.

---

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
