### PR TITLE
Restoring github.py for Updating Extensions

### DIFF
--- a/modules/github.py
+++ b/modules/github.py
@@ -1,0 +1,38 @@
+import subprocess
+from pathlib import Path
+
+new_extensions = set()
+
+
+def clone_or_pull_repository(github_url):
+    global new_extensions
+
+    repository_folder = Path("extensions")
+    repo_name = github_url.rstrip("/").split("/")[-1].split(".")[0]
+
+    # Check if the repository folder exists
+    if not repository_folder.exists():
+        repository_folder.mkdir(parents=True)
+
+    repo_path = repository_folder / repo_name
+
+    # Check if the repository is already cloned
+    if repo_path.exists():
+        yield f"Updating {github_url}..."
+        # Perform a 'git pull' to update the repository
+        try:
+            pull_output = subprocess.check_output(["git", "-C", repo_path, "pull"], stderr=subprocess.STDOUT)
+            yield "Done."
+            return pull_output.decode()
+        except subprocess.CalledProcessError as e:
+            return str(e)
+
+    # Clone the repository
+    try:
+        yield f"Cloning {github_url}..."
+        clone_output = subprocess.check_output(["git", "clone", github_url, repo_path], stderr=subprocess.STDOUT)
+        new_extensions.add(repo_name)
+        yield f"The extension `{repo_name}` has been downloaded.\n\nPlease close the web UI completely and launch it again to be able to load it."
+        return clone_output.decode()
+    except subprocess.CalledProcessError as e:
+        return str(e)


### PR DESCRIPTION
## Checklist:

- [ X ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

All this PR does is restore github.py, which was deleted after 3.4.1 (https://github.com/oobabooga/text-generation-webui/blob/v3.4.1/modules/github.py). Although text-generation-webui itself does not use github.py anymore due to the reorganization of the Sessions tab, at least two existing extensions still attempt to import the modules.github update function when they start:

https://github.com/SkinnyDevi/webui_tavernai_charas/blob/master/ui/downloaded.py
https://github.com/SkinnyDevi/skdv_comfyui/blob/master/ui/update_checker_tab.py

Because these both expect to find modules.github, they will both throw a "ModuleNotFoundError: No module named 'modules.github'" when they try to start up, meaning they won't get loaded.

Alternatively, you could just reject this PR and tell SkinnyDevi and other extension developers change their auto-updating processes; I just wanted to raise the issue and provide the option.