### PR TITLE
Set multimodal status during Model Loading

### DIFF
--- a/modules/exllamav3.py
+++ b/modules/exllamav3.py
@@ -177,9 +177,6 @@ class Exllamav3Model:
         Process all possible image inputs and return modified prompt + embeddings.
         Returns: (processed_prompt, image_embeddings)
         """
-        if not self.is_multimodal():
-            return prompt, []
-
         # Collect images from various sources using shared utilities
         pil_images = []
 
@@ -234,8 +231,11 @@ class Exllamav3Model:
         """
         Generate text with streaming using native ExLlamaV3 API
         """
-        # Process images and modify prompt (ExLlamaV3-specific)
-        prompt, image_embeddings = self._process_images_for_generation(prompt, state)
+        image_embeddings = []
+
+        if shared.is_multimodal:
+            # Process images and modify prompt (ExLlamaV3-specific)
+            prompt, image_embeddings = self._process_images_for_generation(prompt, state)
 
         # Greedy decoding is a special case
         if state['temperature'] == 0:

--- a/modules/models.py
+++ b/modules/models.py
@@ -55,6 +55,10 @@ def load_model(model_name, loader=None):
     if loader.lower().startswith('exllama') or loader.lower().startswith('tensorrt') or loader == 'llama.cpp':
         shared.settings['truncation_length'] = shared.args.ctx_size
 
+    shared.is_multimodal = False    
+    if loader.lower() in ('ExLlamav3', 'llama.cpp'):
+        shared.is_multimodal = shared.model.is_multimodal()
+
     logger.info(f"Loaded \"{model_name}\" in {(time.time()-t0):.2f} seconds.")
     logger.info(f"LOADER: \"{loader}\"")
     logger.info(f"TRUNCATION LENGTH: {shared.settings['truncation_length']}")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -16,6 +16,7 @@ model = None
 tokenizer = None
 model_name = 'None'
 is_seq2seq = False
+is_multimodal = False
 model_dirty_from_training = False
 lora_names = []
 


### PR DESCRIPTION
[ X ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

I'm proposing this change to make it easier for future expansion (if other loaders may support multimodal, etc).

Instead of analyzing if the model is multimodal capable on every generation, **in `load_model()`**:
- Assert `False` by default
- if Exl3 or llama.cpp - check once and store the result in **`shared`**.
- Suggestion: Maybe use a placeholder **`is_multimodal()`** -> `False` in all other loader modules.

I'll bet you've thought of this already but `_process_images_for_generation` could maybe be a shared method, with subclassed special handling after the first chunk which is duplicated [here](https://github.com/oobabooga/text-generation-webui/blob/45e2935e87f19aa3d5afec9a403203259cb1eacc/modules/llama_cpp_server.py#L138-L145) and [here](https://github.com/oobabooga/text-generation-webui/blob/45e2935e87f19aa3d5afec9a403203259cb1eacc/modules/exllamav3.py#L187-L194) (I'm referencing your current code) - however I'm not versed enough in your code to handle this.