### PR TITLE
Changing transformers_loader.py to Match User Expectations for --bf16 and Flash Attention 2

### DIFF
--- a/modules/transformers_loader.py
+++ b/modules/transformers_loader.py
@@ -133,18 +133,19 @@ def load_tokenizer(model_name, tokenizer_dir=None):
 def load_model_HF(model_name):
     torch._dynamo.config.disable = True
 
-    path_to_model = Path(f'{shared.args.model_dir}/{model_name}')
-       
+    path_to_model = Path(f'{shared.args.model_dir}/{model_name}'   
     params = {
         'low_cpu_mem_usage': True,
         'attn_implementation': shared.args.attn_implementation,
     }
-    
+
+    # We will use the default torch_dtype except if the user flagged --bf16
+    # or flagged flash_attention_2, which requires bf16 or f16.
     if shared.args.bf16:
         params['torch_dtype'] = torch.bfloat16
     elif params['attn_implementation'] == 'flash_attention_2':
         params['torch_dtype'] = torch.float16
-        logger.warning(r'Using Flash Attention 2 with float16 by default. To use Flash Attention 2 with bfloat16, set the --bf16 flag.')
+        logger.warning('Using Flash Attention 2 with float16 by default. To use Flash Attention 2 with bfloat16, set the --bf16 flag.')
 
     if shared.args.trust_remote_code:
         params['trust_remote_code'] = True

--- a/modules/transformers_loader.py
+++ b/modules/transformers_loader.py
@@ -137,15 +137,8 @@ def load_model_HF(model_name):
     params = {
         'low_cpu_mem_usage': True,
         'attn_implementation': shared.args.attn_implementation,
+        'torch_dtype': torch.bfloat16 if shared.args.bf16 else torch.float16,
     }
-
-    # We will use the default torch_dtype except if the user flagged --bf16
-    # or flagged flash_attention_2, which requires bf16 or f16.
-    if shared.args.bf16:
-        params['torch_dtype'] = torch.bfloat16
-    elif params['attn_implementation'] == 'flash_attention_2':
-        params['torch_dtype'] = torch.float16
-        logger.warning('Using Flash Attention 2 with float16 by default. To use Flash Attention 2 with bfloat16, set the --bf16 flag.')
 
     if shared.args.trust_remote_code:
         params['trust_remote_code'] = True

--- a/modules/transformers_loader.py
+++ b/modules/transformers_loader.py
@@ -133,7 +133,7 @@ def load_tokenizer(model_name, tokenizer_dir=None):
 def load_model_HF(model_name):
     torch._dynamo.config.disable = True
 
-    path_to_model = Path(f'{shared.args.model_dir}/{model_name}'   
+    path_to_model = Path(f'{shared.args.model_dir}/{model_name}')
     params = {
         'low_cpu_mem_usage': True,
         'attn_implementation': shared.args.attn_implementation,

--- a/modules/transformers_loader.py
+++ b/modules/transformers_loader.py
@@ -134,10 +134,17 @@ def load_model_HF(model_name):
     torch._dynamo.config.disable = True
 
     path_to_model = Path(f'{shared.args.model_dir}/{model_name}')
+       
     params = {
         'low_cpu_mem_usage': True,
         'attn_implementation': shared.args.attn_implementation,
     }
+    
+    if shared.args.bf16:
+        params['torch_dtype'] = torch.bfloat16
+    elif params['attn_implementation'] == 'flash_attention_2':
+        params['torch_dtype'] = torch.float16
+        logger.warning(r'Using Flash Attention 2 with float16 by default. To use Flash Attention 2 with bfloat16, set the --bf16 flag.')
 
     if shared.args.trust_remote_code:
         params['trust_remote_code'] = True


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

[A recent commit](https://github.com/oobabooga/text-generation-webui/commit/3b28dc182186308648af5cddb44c811f1608c70d) changed transformers_loader.py so that it no longer passes torch_dtype to the transformers loader. Without quantization, however, the autodetected dtype may be float32 by default, which (I assume) we will want to avoid in two circumstances.

1. When the user indicates --bf16 in the command line, settings, or checkbox in the UI, the user will expect it to load torch_dtype = bfloat16, so we should respect that over the default.
2. When the user indicates --attn-implementation flash_attention_2 in the command line, it will cause an error if torch_dtype = float32 because [FlashAttention2 is only supported for models with the fp16 or bf16 torch type.](https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention)

This PR should address both of those concerns. Note that if --bf16 is flagged, Flash Attention 2 will automatically work, so the user will only be need to alerted if they inadvertently use Flash Attention 2 with float16.

This partially addresses the issue [raised here](https://github.com/oobabooga/text-generation-webui/issues/7194) but rather than adding a new feature, it just conforms to the existing expectation for the flags.