### PR TITLE
Update chat.py fixes loss of history for instruction mode

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -1194,7 +1194,7 @@ def find_all_histories_with_first_prompts(state):
         if re.match(r'^[0-9]{8}-[0-9]{2}-[0-9]{2}-[0-9]{2}$', filename):
             first_prompt = ""
             if data and 'visible' in data and len(data['visible']) > 0:
-                if data['internal'][0][0] == '<|BEGIN-VISIBLE-CHAT|>':
+                if len(data['internal']) > 1 and data['internal'][0][0] == '<|BEGIN-VISIBLE-CHAT|>':
                     if len(data['visible']) > 1:
                         first_prompt = html.unescape(data['visible'][1][0])
                     elif i == 0:


### PR DESCRIPTION
## Checklist:

- [ X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).

For more than a year, instruct mode history would not show the history when you switch to it from chat mode,
This will fix the history problem for instruct mode and not interfere with chat mode history
I've been making this change for over a year now, with no trouble.