### PR TITLE
Fix: No successful downloads to add as attachments when using Activate web search feature

### DIFF
--- a/modules/web_search.py
+++ b/modules/web_search.py
@@ -281,7 +281,6 @@ def truncate_content_by_tokens(content, max_tokens=8192):
 
 def add_web_search_attachments(history, row_idx, user_message, search_query, state):
     """Perform web search and add results as attachments"""
-    logger.debug(f"add_web_search_attachments")
     if not search_query:
         logger.warning("No search query provided")
         return


### PR DESCRIPTION
Issue:

Activate web search, when checked, does not come up with any findings. 

This fixes some of the page retrieval logic and improves the chance of successfully fetching website content to add to your context.

**Note: you will need to install html2text and brotli**

```
# activate conda as needed 
pip install html2text brotli 
```

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
