### PR TITLE
Log error when llama-server request exceeds context size

### DIFF
--- a/modules/llama_cpp_server.py
+++ b/modules/llama_cpp_server.py
@@ -200,7 +200,10 @@ class LlamaServer:
         # Make the generation request
         response = self.session.post(url, json=payload, stream=True)
         try:
-            response.raise_for_status()  # Raise an exception for HTTP errors
+            if response.status_code == 400 and response.json()["error"]["type"] == "exceed_context_size_error":
+                logger.error("The request exceeds the available context size, try increasing it")
+            else:
+                response.raise_for_status()  # Raise an exception for HTTP errors
 
             full_text = ""
 


### PR DESCRIPTION
This PR checks if the prompt in a request to the llama-server exceeded the context size and logs an informative error instead of printing a generic stack trace.   
The change becomes relevant once the llama.cpp submodule inside [llama-cpp-binaries](github.com/oobabooga/llama-cpp-binaries) is updated to include https://github.com/ggml-org/llama.cpp/pull/16486.

Closes #7257
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
