### PR TITLE
Fix 'start_*.sh' for portable build

### DIFF
--- a/start_linux.sh
+++ b/start_linux.sh
@@ -5,7 +5,7 @@ export PYTHONNOUSERSITE=1
 unset PYTHONPATH
 unset PYTHONHOME
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # Portable install case
 if [ -d "portable_env" ]; then

--- a/start_macos.sh
+++ b/start_macos.sh
@@ -5,7 +5,7 @@ export PYTHONNOUSERSITE=1
 unset PYTHONPATH
 unset PYTHONHOME
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # Portable install case
 if [ -d "portable_env" ]; then


### PR DESCRIPTION
Allows to run a portable Web UI build via a symlink instead of running `start_linux.sh` or `start_macos.sh` from the project root dir. 

## Reproduction

```bash
# Mind the portable build!
wget https://github.com/oobabooga/text-generation-webui/releases/download/v3.15/textgen-portable-3.15-linux-cpu.zip
unzip textgen-portable-3.15-linux-cpu.zip
ln -s $(realpath text-generation-webui-3.15/start_linux.sh) /usr/local/bin/webui
```

Then running `webui` will cause an unnecessary Conda installation, because the `portable_env` is not found.