### PR TITLE
Update requirements.txt

### DIFF
--- a/extensions/coqui_tts/requirements.txt
+++ b/extensions/coqui_tts/requirements.txt
@@ -1,1 +1,1 @@
-coqui-tts==0.25.1
+coqui-tts>=0.27.0


### PR DESCRIPTION
The idiap/coqui-ai-TTS fork is incompatible with transformers 4.55.  The idiap fork supports only transformers ≤4.46.2, making it incompatible with current webui's 4.55.* requirement.  The dependency conflict cannot be resolved by simply switching forks. However, this working solution bypass these limitations entirely.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
