### PR TITLE
Fix loading models which have their eos token disabled

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -83,7 +83,11 @@ def get_model_metadata(model):
 
         if 'tokenizer.chat_template' in metadata:
             template = metadata['tokenizer.chat_template']
-            eos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.eos_token_id']]
+            if 'tokenizer.ggml.eos_token_id' in metadata:
+                eos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.eos_token_id']]
+            else:
+                eos_token = ""
+
             if 'tokenizer.ggml.bos_token_id' in metadata:
                 bos_token = metadata['tokenizer.ggml.tokens'][metadata['tokenizer.ggml.bos_token_id']]
             else:


### PR DESCRIPTION
Some models, for instance IQuest-Coder-V1-40B-Instruct do not use an eos token and disable it in the metadata:

     32: BOOL       |        1 | tokenizer.ggml.add_eos_token = False

We still try to access it, which leads to an error when attempting to load the model. Handle it the same way as missing bos tokens, by setting it to an empty string.

This fixes model loading, however the user must still manually specify the proper stopping string in the parameters tab for such models to work.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
