### PR TITLE
Disable uncommonly used indented codeblocks

### DIFF
--- a/modules/sane_markdown_lists.py
+++ b/modules/sane_markdown_lists.py
@@ -122,8 +122,6 @@ class SaneOListProcessor(OListProcessor):
 
     def __init__(self, parser: blockparser.BlockParser):
         super().__init__(parser)
-        # This restriction stems from the 'CodeBlockProcessor' class,
-        # which automatically matches blocks with an indent = self.tab_length
         max_list_start_indent = self.tab_length
         # Detect an item (e.g., `1. item`)
         self.RE = re.compile(r'^[ ]{0,%d}[\*_]{0,2}\d+\.[ ]+(.*)' % max_list_start_indent)


### PR DESCRIPTION
This PR removes the ability of the markdown parser to render indentation style code blocks, in favor of allowing more leading spaces in nested lists.

I recently noticed that a nested list in a message was not being rendered as a list, but as a code block. This was due to the LLM having used 6 leading spaces to indent the list, which clashes with the `CodeBlockProcessor`'s matching logic. Here is an example:
```
- First item

      - Second item
```      
I realized that I had not once seen an LLM use indentation to create a code block. Instead, they always seem to use fenced code blocks delimited by three backticks. Therefore, I think the drawback of disabling the `CodeBlockProcessor` is far outweighed by more flexibility in indenting nested lists. 

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
