### PR TITLE
Improve `process_markdown_content`

### DIFF
--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -249,7 +249,7 @@ def process_markdown_content(string):
             content = match.group(1)
             modified_content = content.replace('*', LATEX_ASTERISK_PLACEHOLDER)
             modified_content = modified_content.replace('_', LATEX_UNDERSCORE_PLACEHOLDER)
-            return f'$${modified_content}$$'
+            return f'{modified_content}'
         elif match.group(2) is not None:  # Content from \[...\]
             content = match.group(2)
             modified_content = content.replace('*', LATEX_ASTERISK_PLACEHOLDER)
@@ -293,7 +293,7 @@ def process_markdown_content(string):
     string = re.sub(r"(.)```", r"\1\n```", string)
 
     # Protect asterisks and underscores within all LaTeX blocks before markdown conversion
-    latex_pattern = re.compile(r'(?:(?:^|[\r\n]|\s))\$\$([^`]*?)\$\$|\\\[(.*?)\\\]|\\\((.*?)\\\)',
+    latex_pattern = re.compile(r'((?:^|[\r\n\s])\$\$[^`]*?\$\$)|\\\[(.*?)\\\]|\\\((.*?)\\\)',
                                re.DOTALL)
     string = latex_pattern.sub(protect_asterisks_underscores_in_latex, string)
 


### PR DESCRIPTION
This PR contains the following fixes and improvements to the `process_markdown_content` function:
1. Protect underscores in LaTeX blocks.
2. Make regex pattern used to match LaTeX blocks stricter (right now only applies to blocks delimited by `$$`). Only match blocks that start at the beginning of a line or are preceded by a space.
3. Add exceptions in "Manual line iteration for robust structure parsing" for cases where a LaTeX block is used inline, meaning that the block starts and ends on the same line.  
Without these exceptions, the aforementioned cases can lead to `is_latex` not being toggled off, despite being outside of a LaTeX block.

Closes #7394

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
