### PR TITLE
Bump sentence-transformers to 3.3.1 in superbooga to fix torch breakage

### DIFF
--- a/extensions/superbooga/requirements.txt
+++ b/extensions/superbooga/requirements.txt
@@ -2,5 +2,5 @@ beautifulsoup4==4.12.2
 chromadb==0.4.24
 pandas==2.0.3
 posthog==2.4.2
-sentence_transformers==2.2.2
+sentence_transformers==3.3.1
 lxml


### PR DESCRIPTION
## Summary

`sentence-transformers==2.2.2` (pinned in `extensions/superbooga/requirements.txt`) declares `torchvision` as a hard dependency. On CUDA 12.8, this silently upgrades the torch stack when `INSTALL_EXTENSIONS=TRUE` is set, breaking ABI-sensitive extensions like flash-attention and exllama.

`sentence-transformers>=3.3.1` removed `torchvision` as a hard dependency. This version (`3.3.1`) is already used by `superboogav2`, so this change aligns both extensions.

**Change:** `sentence_transformers==2.2.2` → `sentence_transformers==3.3.1`

Fixes #7385

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).