### PR TITLE
[experimental] Expose the "--rpc" option of llama.cpp

### DIFF
--- a/modules/llama_cpp_server.py
+++ b/modules/llama_cpp_server.py
@@ -414,6 +414,8 @@ class LlamaServer:
             cmd += ["--spec-ngram-size-m", str(shared.args.spec_ngram_size_m)]
             cmd += ["--spec-ngram-min-hits", str(shared.args.spec_ngram_min_hits)]
         cmd += ["--parallel", str(shared.args.parallel)]
+        if shared.args.rpc:
+            cmd += ["--rpc", shared.args.rpc]
         if shared.args.streaming_llm:
             cmd += ["--cache-reuse", "1"]
             cmd += ["--swa-full"]

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -108,6 +108,7 @@ group.add_argument('--threads', type=int, default=0, help='Number of threads to 
 group.add_argument('--threads-batch', type=int, default=0, help='Number of threads to use for batches/prompt processing.')
 group.add_argument('--numa', action='store_true', help='Activate NUMA task allocation for llama.cpp.')
 group.add_argument('--parallel', type=int, default=1, help='Number of parallel request slots. The context size is divided equally among slots. For example, to have 4 slots with 8192 context each, set ctx_size to 32768.')
+group.add_argument('--rpc', type=str, default=None, help='RPC server address for distributed inference. Example: 192.168.1.100:50052')
 group.add_argument('--fit-target', type=str, default='1024', help='Target VRAM margin per device for auto GPU layers, comma-separated list of values in MiB. A single value is broadcast across all devices. Default: 1024.')
 group.add_argument('--extra-flags', type=str, default=None, help='Extra flags to pass to llama-server. Format: "flag1=value1,flag2,flag3=value3". Example: "override-tensor=exps=CPU"')
 


### PR DESCRIPTION
:warning: Will not work with the shipped llama.cpp binary

This is a proof-of-concept for https://github.com/oobabooga/text-generation-webui/issues/7357

This PR provides the `--rpc` option of llama.cpp. It will not work out-of-the-box though, because the shipped llama.cpp binary is not built with RPC support. You have to build it yourself and replace it from source and enable RPC (`-DGGML_RPC=ON`, see https://github.com/ggml-org/llama.cpp/tree/master/tools/rpc).

The `llama_cpp_binaries/bin` directory is the important one (e.g. create a symlink to the "bin" directory of your local llama.cpp built):

venv/lib/python3.13/site-packages/llama_cpp_binaries/bin/

I can confirm that the setup works, but it is experimental.

For me, it also required tweaking the `--tensor-split` parameters; otherwise, the remote machine would run out of memory.

My understanding is that llama.cpp tends to start with putting the first layers on the remote host. So, this would put 51 layers on the remote host (running on 192.168.178.100) and 24 on the localhost:

```
--tensor-split 51,24 --rpc 192.168.178.100:50052
```

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
