### PR TITLE
Fix mutable default argument in LogitsBiasProcessor

### DIFF
--- a/modules/transformers_loader.py
+++ b/modules/transformers_loader.py
@@ -44,8 +44,8 @@ class Stream(transformers.StoppingCriteria):
 
 
 class LogitsBiasProcessor(LogitsProcessor):
-    def __init__(self, logit_bias={}):
-        self.logit_bias = logit_bias
+    def __init__(self, logit_bias=None):
+        self.logit_bias = logit_bias or {}
         if self.logit_bias:
             self.keys = list([int(key) for key in self.logit_bias.keys()])
             values = [self.logit_bias[str(key)] for key in self.keys]


### PR DESCRIPTION
## Summary

- Fix mutable default argument `logit_bias={}` in `LogitsBiasProcessor.__init__()` (`modules/transformers_loader.py`)

## Root cause

Using a mutable default argument (`def __init__(self, logit_bias={})`) is a well-known Python anti-pattern. The default dict is created once at function definition time, not per call. All instances that rely on the default share the **same** dict object. If the dict were ever mutated (e.g., adding/removing keys), changes would silently persist across instances, leading to unexpected logit bias behavior.

## Fix

Replace `logit_bias={}` with `logit_bias=None` and initialize to an empty dict inside the method body with `self.logit_bias = logit_bias or {}`. This ensures each instance gets its own independent dict.

## Test plan

- [ ] Verify `LogitsBiasProcessor()` (no args) creates an instance with an empty `logit_bias` dict
- [ ] Verify `LogitsBiasProcessor({"1": 5.0})` works as before
- [ ] Verify two default instances do not share state


🤖 Generated with [Claude Code](https://claude.com/claude-code)