### PR TITLE
Fix file handle leaks and redundant re-read in get_model_metadata

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -38,7 +38,8 @@ def get_model_metadata(model):
 
     path = model_path / 'config.json'
     if path.exists():
-        hf_metadata = json.loads(open(path, 'r', encoding='utf-8').read())
+        with open(path, 'r', encoding='utf-8') as f:
+            hf_metadata = json.loads(f.read())
     else:
         hf_metadata = None
 
@@ -103,7 +104,7 @@ def get_model_metadata(model):
     else:
         # Transformers metadata
         if hf_metadata is not None:
-            metadata = json.loads(open(path, 'r', encoding='utf-8').read())
+            metadata = hf_metadata
             if 'pretrained_config' in metadata:
                 metadata = metadata['pretrained_config']
 
@@ -153,7 +154,8 @@ def get_model_metadata(model):
 
     # 3. Fall back to tokenizer_config.json metadata
     if path.exists():
-        metadata = json.loads(open(path, 'r', encoding='utf-8').read())
+        with open(path, 'r', encoding='utf-8') as f:
+            metadata = json.loads(f.read())
 
         # Only read from metadata if we haven't already loaded from .jinja or .json
         if template is None and 'chat_template' in metadata:


### PR DESCRIPTION
## Summary

- Fix 3 unclosed file handles in `get_model_metadata()` (`modules/models_settings.py`)
- Remove a redundant re-read of `config.json` that was already loaded into memory

## Root cause

`get_model_metadata()` uses the pattern `json.loads(open(path, 'r', encoding='utf-8').read())` in three places. This creates file handles that are never explicitly closed:

1. **Line 41** (`config.json`): File handle leaked after reading HF metadata.
2. **Line 107** (`config.json` again): This re-reads the exact same file that was already loaded into `hf_metadata` on line 41 -- both a file handle leak and redundant disk I/O.
3. **Line 156** (`tokenizer_config.json`): File handle leaked after reading tokenizer config.

While CPython's reference counting usually closes these promptly, the handles are not guaranteed to be closed on alternative Python implementations (PyPy, etc.), and relying on the GC for resource cleanup is a known anti-pattern per [PEP 343](https://peps.python.org/pep-0343/).

## Fix

1. Wrap `open()` calls in `with` statements for deterministic cleanup (lines 41, 156).
2. Replace the redundant re-read on line 107 with a direct reference to the already-loaded `hf_metadata` variable, eliminating both the leak and the unnecessary I/O.

## Test plan

- [ ] Load a Transformers model and verify metadata (context length, rope settings, etc.) is read correctly
- [ ] Load a GGUF model via llama.cpp and verify metadata is read correctly
- [ ] Verify instruction template detection still works from all 3 sources (`.jinja`, `chat_template.json`, `tokenizer_config.json`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)