### PR TITLE
fix: mutable default argument in LogitsBiasProcessor

### DIFF
--- a/modules/transformers_loader.py
+++ b/modules/transformers_loader.py
@@ -44,8 +44,8 @@ class Stream(transformers.StoppingCriteria):
 
 
 class LogitsBiasProcessor(LogitsProcessor):
-    def __init__(self, logit_bias={}):
-        self.logit_bias = logit_bias
+    def __init__(self, logit_bias=None):
+        self.logit_bias = logit_bias if logit_bias is not None else {}
         if self.logit_bias:
             self.keys = list([int(key) for key in self.logit_bias.keys()])
             values = [self.logit_bias[str(key)] for key in self.keys]


### PR DESCRIPTION
## Summary

- Fix mutable default argument `logit_bias={}` in `LogitsBiasProcessor.__init__()` (`modules/transformers_loader.py`)

## Root cause

Using a mutable default argument (`def __init__(self, logit_bias={})`) is a well-known Python anti-pattern. The default dict is created once at function definition time, not per call. All instances that rely on the default share the **same** dict object.

## Fix

Change `logit_bias={}` to `logit_bias=None` and use `logit_bias if logit_bias is not None else {}` instead.

Closes #7421