### PR TITLE
Only modify a copy when injecting the fake messages.

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -465,7 +465,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
             add_generation_prompt = False
 
         prompt = renderer(
-            messages=messages_copy,
+            messages=messages,
             add_generation_prompt=add_generation_prompt
         )
 


### PR DESCRIPTION
Currently, if the context is long enough that it will be trimmed down, the injected messages are being left from one extraction process into the next. This becomes a problem when attempting to resume partial assistant messages when over the context limit.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
