### PR TITLE
Fix: wrong chat deleted when selection changes before confirm

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1004,6 +1004,7 @@ function addMiniDeletes() {
 
     confirmBtn.onclick = (e) => {
       e.stopPropagation();
+      label.querySelector("input").click();
       document.querySelector("#delete_chat-confirm").click();
       resetButtons();
     };


### PR DESCRIPTION
Fixes #7472.

When you click the trash icon on Chat 1, then select Chat 2 before pressing confirm, Chat 2 gets deleted instead of Chat 1. The Gradio backend reads `state['unique_id']` from whichever chat is currently selected at confirm time, not the one that was originally targeted.

The fix re-selects the target chat before triggering the confirm button. The `label` variable is already captured in the closure (same one used in the trash-button handler at line 992), so this just mirrors the existing pattern.

**Repro:**
1. Create two chats
2. Click trash icon on Chat 1 (shows confirm/cancel)
3. Click Chat 2 to select it
4. Press confirm
5. Chat 2 is deleted instead of Chat 1

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).