### PR TITLE
fix: prevent path traversal in load_template_by_name (CWE-22)

### DIFF
--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -399,12 +399,24 @@ def update_gpu_layers_and_vram(loader, model, gpu_layers, ctx_size, cache_type):
 
 def load_template_by_name(name):
     """Find and load a single instruction template by name. Returns '' if not found."""
+    # Prevent path traversal: strip all directory components, keep only the filename
+    name = Path(name).name
+    if not name:
+        return ''
+
     template_dir = shared.user_data_dir / 'instruction-templates'
     for ext in utils.TEMPLATE_EXTENSIONS:
         path = template_dir / f'{name}{ext}'
         if path.is_file():
             break
     else:
+        return ''
+
+    # Defense-in-depth: confirm resolved path stays inside template_dir
+    try:
+        path.resolve().relative_to(template_dir.resolve())
+    except ValueError:
+        logger.error(f'Path traversal blocked for instruction template name: {name!r}')
         return ''
 
     file_contents = path.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary

`load_template_by_name()` in `modules/models_settings.py` constructs a file path using an unsanitized `name` parameter sourced from the `instruction_template` field of the `POST /v1/internal/model/load` API. An attacker can supply `../` sequences to read arbitrary files with `.jinja`, `.jinja2`, `.yaml`, or `.yml` extensions outside the intended `instruction-templates/` directory.

In the default configuration (`--admin-key` not set), this endpoint is unauthenticated.

## Root Cause

```python
# Before (vulnerable)
path = template_dir / f'{name}{ext}'   # name not sanitized — allows ../
```

`pathlib`'s `/` operator preserves `..` components, and `path.is_file()` resolves them via `os.stat()`, so the traversal succeeds silently.

## Fix

```python
# After — two layers of defense
name = Path(name).name          # strips all directory components
if not name:
    return ''
# ... build path normally ...
try:
    path.resolve().relative_to(template_dir.resolve())   # boundary check
except ValueError:
    logger.error(f'Path traversal blocked for instruction template name: {name!r}')
    return ''
```

1. `Path(name).name` — keeps only the final path component, rejecting `../`, absolute paths, etc.
2. `path.resolve().relative_to(...)` — defense-in-depth to catch any edge case that slips through step 1.

## Impact (before fix)

- Any `.jinja`/`.jinja2` file readable by the server process → **full content disclosed** via `/v1/internal/chat-prompt`
- Any `.yaml`/`.yml` file that is invalid YAML → **full content disclosed**
- File **existence** of any matching file on the filesystem → always detectable
- No authentication required in default deployments

## Related

- CWE-22: Improper Limitation of a Pathname to a Restricted Directory
- Similar pattern already guarded in `modules/utils.py` (`sanitize_filename`, `_is_path_allowed`)