### PR TITLE
Set TORCH_VERSION to 2.9.0 to match xformers 0.0.33's torch pin

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 
 # Define the required versions
-TORCH_VERSION = "2.9.1"
+TORCH_VERSION = "2.9.0"
 PYTHON_VERSION = "3.13"
 LIBSTDCXX_VERSION_LINUX = "12.1.0"
 


### PR DESCRIPTION
## Problem

Running the update wizard on a `NVIDIA_CUDA128` install silently replaces `torch 2.9.1+cu128` with `torch 2.9.0+cpu` — disabling CUDA for everything except the bundled `llama-server` binary. After running it, xformers logs `WARNING[XFORMERS]: xFormers can't load C++/CUDA extensions` and `torch.cuda.is_available()` returns `False`.

## Cause

xformers 0.0.33's wheel hard-pins `torch==2.9.0` (not `~=` or `>=`). Verified via pip's dependency-tree output:

```
... from sympy>=1.13.3 -> torch==2.9.0 -> xformers==0.0.33 -> -r requirements/full/requirements.txt (line 35)
```

The wizard's PyTorch step installs `torch==2.9.1+cu128` via `get_pytorch_update_command` (uses `TORCH_VERSION`). The subsequent `pip install -r temp_requirements.txt --upgrade` on `one_click.py:462` then has to satisfy xformers's `torch==2.9.0`, so it uninstalls `2.9.1+cu128` and installs `2.9.0`. That pip call has no `--extra-index-url` for cu128, so the reinstall falls back to PyPI — which serves the CPU build on Windows.

This is a follow-up to b863696b *"Downgrade xformers to make exllamav3 0.0.34 work"* — `TORCH_VERSION` wasn't lowered to match the xformers downgrade. When exllamav3 can be bumped to a version that allows xformers 0.0.35 again, `TORCH_VERSION` can return to 2.9.1 in the same commit.

## Reproduction

1. Fresh `NVIDIA_CUDA128` install on Windows, Python 3.13.
2. Run `update_wizard_windows.bat` → choose **A** (update web UI).
3. After completion:
   ```
   python -c \"import torch; print(torch.__version__, torch.cuda.is_available())\"
   ```
4. Observe: `2.9.0+cpu False`

## Fix

One-line change: `TORCH_VERSION = \"2.9.1\"` → `\"2.9.0\"`. After this, the wizard installs `2.9.0+cu128` in the PyTorch step, the requirements install sees xformers's `torch==2.9.0` already satisfied, and no downgrade cascade occurs. Confirmed locally — `torch.cuda.is_available()` stays `True` after running the wizard.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/textgen/wiki/Contributing-guidelines).