### PR TITLE
Show errors for invalid preset filenames

### DIFF
--- a/modules/ui_file_saving.py
+++ b/modules/ui_file_saving.py
@@ -2,7 +2,7 @@ import gradio as gr
 
 from modules import chat, presets, shared, ui, utils
 from modules.logging_colors import logger
-from modules.utils import gradio, sanitize_filename
+from modules.utils import gradio, sanitize_filename, validate_filename
 
 
 def create_ui():
@@ -96,13 +96,16 @@ def create_event_handlers():
 
 def handle_save_preset_confirm_click(filename, contents):
     try:
-        filename = sanitize_filename(filename)
+        filename = validate_filename(filename)
         utils.save_file(str(shared.user_data_dir / "presets" / f"{filename}.yaml"), contents)
         available_presets = utils.get_available_presets()
         output = gr.update(choices=available_presets, value=filename)
-    except Exception:
-        output = gr.update()
+    except ValueError as exc:
+        logger.warning(f"Failed to save preset: {exc}")
+        raise gr.Error(str(exc)) from exc
+    except Exception as exc:
         logger.exception("Failed to save preset")
+        raise gr.Error(f"Failed to save preset: {exc}") from exc
 
     return [
         output,

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -26,6 +26,18 @@ def sanitize_filename(name):
     return name
 
 
+def validate_filename(name):
+    """Return a sanitized filename after checking cross-platform constraints."""
+    name = sanitize_filename(name)
+    if not name:
+        raise ValueError('File name cannot be empty.')
+
+    if re.search(r'[<>:"\\|?*\x00-\x1f]', name) or name.endswith(('.', ' ')):
+        raise ValueError('File name contains characters that are not supported on all operating systems.')
+
+    return name
+
+
 def _is_path_allowed(abs_path_str):
     """Check if a path is under the configured user_data directory."""
     # normpath (not resolve) preserves symlinks so a symlinked user_data/logs works.


### PR DESCRIPTION
Closes #7589.

Preset names such as `test: 1` can fail on Windows after the user has finished editing, with no useful error in the save dialog. This validates the base filename before writing and shows the failure through Gradio without closing the dialog. Successful saves still refresh the preset list and select the new entry.

I checked empty names, colons and other unsupported characters, trailing periods, path sanitization, and a successful write. `py_compile` for the changed modules and `git diff --check` also pass.

AI assistance was used during implementation; I reviewed the diff and the focused test results.

## Checklist

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/textgen/wiki/Contributing-guidelines).
