### PR TITLE
Preserve plain numeric lines in chat output

### DIFF
--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -343,12 +343,9 @@ def process_markdown_content(string):
 
     # Unfinished list, like "\n1.". A |delete| string is added and then
     # removed to force a <ol> or <ul> to be generated instead of a <p>.
-    list_item_pattern = r'(\n\d+\.?|\n\s*[-*+]\s*([*_~]{1,3})?)$'
+    list_item_pattern = r'(\n\d+\.|\n\s*[-*+]\s*([*_~]{1,3})?)$'
     if re.search(list_item_pattern, result):
         delete_str = '|delete|'
-
-        if re.search(r'(\d+\.?)$', result) and not result.endswith('.'):
-            result += '.'
 
         # Add the delete string after the list item
         result = re.sub(list_item_pattern, r'\g<1> ' + delete_str, result)


### PR DESCRIPTION
Closes #7535.

A trailing line containing only a number, for example `7`, matched the streaming workaround for an unfinished ordered list. The renderer then inserted a dot and changed the model's output into a list item.

The workaround now applies to actual markers such as `7.` and `-`, while a plain numeric line remains ordinary text. I ran the issue reproduction through the real Markdown pipeline and checked both list cases as regressions. `py_compile` and `git diff --check` pass.

AI assistance was used during implementation; I reviewed the diff and the focused test results.

## Checklist

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/textgen/wiki/Contributing-guidelines).
