### PR TITLE
Allow disabling portable auto-launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ usage: server.py [-h] [--user-data-dir USER_DATA_DIR] [--multi-user] [--model MO
                  [--threads-batch THREADS_BATCH] [--numa] [--parallel PARALLEL] [--fit-target FIT_TARGET] [--extra-flags EXTRA_FLAGS] [--ik] [--cpu] [--cpu-memory CPU_MEMORY] [--disk]
                  [--disk-cache-dir DISK_CACHE_DIR] [--load-in-8bit] [--bf16] [--no-cache] [--trust-remote-code] [--force-safetensors] [--no_use_fast] [--attn-implementation IMPLEMENTATION]
                  [--load-in-4bit] [--use_double_quant] [--compute_dtype COMPUTE_DTYPE] [--quant_type QUANT_TYPE] [--gpu-split GPU_SPLIT] [--enable-tp] [--tp-backend TP_BACKEND] [--cfg-cache]
-                 [--listen] [--listen-port LISTEN_PORT] [--listen-host LISTEN_HOST] [--share] [--auto-launch] [--gradio-auth GRADIO_AUTH] [--gradio-auth-path GRADIO_AUTH_PATH]
+                 [--listen] [--listen-port LISTEN_PORT] [--listen-host LISTEN_HOST] [--share] [--auto-launch | --no-auto-launch] [--gradio-auth GRADIO_AUTH] [--gradio-auth-path GRADIO_AUTH_PATH]
                  [--ssl-keyfile SSL_KEYFILE] [--ssl-certfile SSL_CERTFILE] [--subpath SUBPATH] [--old-colors] [--portable] [--api] [--public-api] [--public-api-id PUBLIC_API_ID] [--api-port API_PORT]
                  [--api-key API_KEY] [--admin-key ADMIN_KEY] [--api-enable-ipv6] [--api-disable-ipv4] [--nowebui] [--temperature N] [--dynatemp-low N] [--dynatemp-high N] [--dynatemp-exponent N]
                  [--smoothing-factor N] [--smoothing-curve N] [--top-p N] [--top-k N] [--min-p N] [--top-n-sigma N] [--typical-p N] [--xtc-threshold N] [--xtc-probability N] [--epsilon-cutoff N]
@@ -383,7 +383,7 @@ Gradio:
   --listen-port LISTEN_PORT                            The listening port that the server will use.
   --listen-host LISTEN_HOST                            The hostname that the server will use.
   --share                                              Create a public URL. This is useful for running the web UI on Google Colab or similar.
-  --auto-launch                                        Open the web UI in the default browser upon launch.
+  --auto-launch, --no-auto-launch                      Open the web UI in the default browser upon launch. Enabled by default in portable builds.
   --gradio-auth GRADIO_AUTH                            Set Gradio authentication password in the format "username:password". Multiple credentials can also be supplied with "u1:p1,u2:p2,u3:p3".
   --gradio-auth-path GRADIO_AUTH_PATH                  Set the Gradio authentication file path. The file should contain one or more user:password pairs in the same format as above.
   --ssl-keyfile SSL_KEYFILE                            The path to the SSL certificate key file.

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -147,7 +147,7 @@ group.add_argument('--listen', action='store_true', help='Make the web UI reacha
 group.add_argument('--listen-port', type=int, help='The listening port that the server will use.')
 group.add_argument('--listen-host', type=str, help='The hostname that the server will use.')
 group.add_argument('--share', action='store_true', help='Create a public URL. This is useful for running the web UI on Google Colab or similar.')
-group.add_argument('--auto-launch', action='store_true', default=False, help='Open the web UI in the default browser upon launch.')
+group.add_argument('--auto-launch', action=argparse.BooleanOptionalAction, default=None, help='Open the web UI in the default browser upon launch. Enabled by default in portable builds.')
 group.add_argument('--gradio-auth', type=str, help='Set Gradio authentication password in the format "username:password". Multiple credentials can also be supplied with "u1:p1,u2:p2,u3:p3".', default=None)
 group.add_argument('--gradio-auth-path', type=str, help='Set the Gradio authentication file path. The file should contain one or more user:password pairs in the same format as above.', default=None)
 group.add_argument('--ssl-keyfile', type=str, help='The path to the SSL certificate key file.', default=None)
@@ -234,6 +234,9 @@ if cmd_flags_path.exists():
 
 
 args = parser.parse_args()
+if args.auto_launch is None:
+    args.auto_launch = args.portable
+
 user_data_dir = Path(args.user_data_dir)  # Update from parsed args (may differ from pre-parse)
 original_args = copy.deepcopy(args)
 args_defaults = parser.parse_args([])

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # Portable install case
 if [ -d "portable_env" ]; then
-    ./portable_env/bin/python3 server.py --portable --api --auto-launch "$@"
+    ./portable_env/bin/python3 server.py --portable --api "$@"
     exit $?
 fi
 

--- a/start_macos.sh
+++ b/start_macos.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # Portable install case
 if [ -d "portable_env" ]; then
-    ./portable_env/bin/python3 server.py --portable --api --auto-launch --api-port 5005 "$@"
+    ./portable_env/bin/python3 server.py --portable --api --api-port 5005 "$@"
     exit $?
 fi
 

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -11,7 +11,7 @@ cd /D "%~dp0"
 
 @rem Portable install case
 if exist "portable_env" (
-    .\portable_env\python.exe server.py --portable --api --auto-launch %*
+    .\portable_env\python.exe server.py --portable --api %*
     exit /b %errorlevel%
 )
 


### PR DESCRIPTION
Fixes #7475.

Portable builds enable browser auto-launch, but there was no supported way for `CMD_FLAGS.txt` to turn it off. Users had to edit the startup script again after an update.

This adds `--no-auto-launch` and moves the portable default into argument handling, so both `CMD_FLAGS.txt` and direct command-line arguments can override it consistently on Linux, macOS, and Windows. Non-portable launches keep their current default.

I checked portable and non-portable defaults, explicit enable/disable, the flags file, and command-line precedence. Python compilation, shell syntax checks for the Linux/macOS launchers, and `git diff --check` pass.

AI assistance was used to trace the startup paths and build the test cases; I reviewed the resulting diff and output.

## Checklist

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
- [x] I have performed a self-review of my code.
- [x] I have tested the change thoroughly.
