### PR TITLE
docs(readme): add third-party installers and launchers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ docker compose up --build
 
 </details>
 
+### Third-Party Installers & Launchers
+
+- [LynxHub](https://github.com/KindaBrazy/LynxHub): Cross-platform visual management dashboard and terminal/browser for installing, configuring, and launching TextGen.
+
+
 ## Command-line flags
 
 <details>


### PR DESCRIPTION
Hi @oobabooga, I've added a new section in readme as Third-Party Installers & Launchers for community managers and installers.

Listed [LynxHub](https://github.com/KindaBrazy/LynxHub) in this section.

Currently placed under `Installation`, If you prefer a different location let me know and I will update it.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/textgen/wiki/Contributing-guidelines).
