### PR TITLE
fix(chat): keep the continued reply renderable when history is truncated (#7629)

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -675,11 +675,17 @@ def generate_chat_prompt(user_input, state, **kwargs):
     if shared.tokenizer is not None:
         max_length = get_max_prompt_length(state)
         encoded_length = get_encoded_length(prompt)
+
+        # make_prompt() renders messages[:-1] while continuing, so one message
+        # more than usual has to survive the pops; otherwise the chat template
+        # is handed an empty list and fails on messages[0].
+        min_messages = 2 if _continue else 1
+
         while len(messages) > 0 and encoded_length > max_length:
 
-            if len(messages) > 2 and messages[0]['role'] == 'system':
+            if len(messages) > min_messages + 1 and messages[0]['role'] == 'system':
                 pop_idx = 1
-            elif len(messages) > 1 and messages[0]['role'] != 'system':
+            elif len(messages) > min_messages and messages[0]['role'] != 'system':
                 pop_idx = 0
             else:
                 pop_idx = None
@@ -698,7 +704,10 @@ def generate_chat_prompt(user_input, state, **kwargs):
 
             # Resort to truncating the user input
             else:
-                user_message = messages[-1]['content']
+                # While continuing, messages[-1] holds the partial reply being
+                # extended, so the oversized input is the message before it.
+                trunc_idx = -2 if _continue and len(messages) > 1 else -1
+                user_message = messages[trunc_idx]['content']
 
                 # Bisect the truncation point
                 left, right = 0, len(user_message)
@@ -706,7 +715,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
                 while left < right:
                     mid = (left + right + 1) // 2
 
-                    messages[-1]['content'] = user_message[:mid]
+                    messages[trunc_idx]['content'] = user_message[:mid]
                     prompt = make_prompt(messages)
                     encoded_length = get_encoded_length(prompt)
 
@@ -715,7 +724,7 @@ def generate_chat_prompt(user_input, state, **kwargs):
                     else:
                         right = mid - 1
 
-                messages[-1]['content'] = user_message[:left]
+                messages[trunc_idx]['content'] = user_message[:left]
                 prompt = make_prompt(messages)
                 encoded_length = get_encoded_length(prompt)
                 if encoded_length > max_length:


### PR DESCRIPTION
Fixes #7629.

### The bug

Clicking **Continue** after a single message that (nearly) fills the context crashes:

```
File "modules/chat.py", line 738, in generate_chat_prompt
    prompt = make_prompt(messages)
File "modules/chat.py", line 598, in make_prompt
    prompt = renderer(
jinja2.exceptions.UndefinedError: list object has no element 0
```

`generate_chat_prompt()` pops messages off the front until the prompt fits, and the guards there (`len(messages) > 2` / `> 1`) keep one message alive so the template always has something to render.

But `make_prompt()` renders `messages[:-1]` while continuing — the partial reply is spliced back in as raw text rather than rendered. So with `[user(32k), assistant(partial)]` the loop pops the user message, leaving `[assistant]`, and `make_prompt()` hands the template an empty list.

### The fix

* Reserve one extra message while continuing (`min_messages = 2 if _continue else 1`), so the pops stop one step earlier and fall through to the bisect that already exists.
* Point that bisect at the message *before* the partial reply while continuing — that is where the oversized input actually lives; `messages[-1]` is the reply being extended.

This restores the older behaviour the issue describes (truncate *within* the oversized text) instead of discarding the message and crashing.

Non-continue paths are untouched: `min_messages` is `1` and `trunc_idx` is `-1`, identical to before.

### Verification

The repo has no test suite for this module, so I re-implemented the truncation loop and the continue-time `make_prompt()` semantics in a standalone harness and ran old vs. new side by side:

| case | before | after |
|---|---|---|
| single huge user msg + partial reply, Continue (**#7629**) | `UndefinedError: list object has no element 0` | prompt built, user message truncated to fit |
| system + huge user msg + partial reply, Continue | user message silently dropped, only the system prompt rendered | system + truncated user + reply |
| long multi-turn history, Continue | pops oldest turns | identical |
| normal generate, huge user msg | bisect-truncates the input | identical |
| normal generate, multi-turn history | pops oldest turns | identical |
| fits in context, Continue | no truncation | identical |

`python -m pycodestyle --max-line-length=120 --ignore=E402,E501,E722 modules/chat.py` reports nothing new (the remaining hits are pre-existing).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
