### PR TITLE
fix(models): explain why a non-GGUF model can't be loaded by llama.cpp (#7626)

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -4,7 +4,7 @@ import time
 
 import modules.shared as shared
 from modules.logging_colors import logger
-from modules.models_settings import get_model_metadata
+from modules.models_settings import describe_non_gguf_model, get_model_metadata
 from modules.utils import resolve_model_path
 
 last_generation_time = time.time()
@@ -90,7 +90,12 @@ def llama_cpp_server_loader(model_name):
     else:
         gguf_files = sorted(path.glob('*.gguf'))
         if not gguf_files:
-            logger.error(f"No .gguf models found in the directory: {path}")
+            error_msg = f"No .gguf models found in the directory: {path}"
+            hint = describe_non_gguf_model(path)
+            if hint:
+                error_msg = f"{error_msg}. {hint}"
+
+            logger.error(error_msg)
             return None, None
 
         model_file = gguf_files[0]

--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -55,6 +55,10 @@ def get_model_metadata(model):
             gguf_files = list(path.glob('*.gguf'))
             if not gguf_files:
                 error_msg = f"No .gguf models found in directory: {path}"
+                hint = describe_non_gguf_model(path)
+                if hint:
+                    error_msg = f"{error_msg}. {hint}"
+
                 logger.error(error_msg)
                 raise FileNotFoundError(error_msg)
 
@@ -179,6 +183,36 @@ def get_model_metadata(model):
         model_settings['instruction_template_str'] = load_instruction_template(model_settings['instruction_template'])
 
     return model_settings
+
+
+def describe_non_gguf_model(path):
+    '''
+    Describe the model format found in a directory that has no GGUF files, so
+    that the llama.cpp loader can explain why the model is unsupported instead
+    of only reporting that no .gguf file was found.
+    '''
+    if not path.is_dir():
+        return None
+
+    if not any(any(path.glob(pattern)) for pattern in ('*.safetensors', '*.bin', '*.pt')):
+        return None
+
+    quant_method = None
+    config_path = path / 'config.json'
+    if config_path.exists():
+        try:
+            with open(config_path, 'r', encoding='utf-8') as f:
+                quant_method = (json.loads(f.read()).get('quantization_config') or {}).get('quant_method', None)
+        except (OSError, ValueError):
+            pass
+
+    format_name = quant_method.upper() if quant_method else 'Transformers'
+    if shared.args.portable:
+        advice = 'This portable build only supports GGUF models.'
+    else:
+        advice = 'Select a different loader or download a GGUF version of this model.'
+
+    return f"This directory contains {format_name} weights, which the llama.cpp loader cannot load. {advice}"
 
 
 def infer_loader(model_name, model_settings, hf_quant_method=None):


### PR DESCRIPTION
Closes #7626.

### Problem

The reporter downloaded [`unsloth/Qwen3.6-27B-NVFP4`](https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4) and got only:

```
No .gguf models found in the directory: user_data/models/Qwen3.6-27B-NVFP4
```

That message says what is missing but not what the directory actually holds, so there is no way to tell whether the download is broken, the path is wrong, or the format is simply unsupported. Their ask was "it would be really nice if the UI could just tell me what models it can or can't run".

This is worst in portable builds: `infer_loader()` returns `llama.cpp` unconditionally when `shared.args.portable` is set (`modules/models_settings.py`), so **every** Transformers-format model ends at this message regardless of its quantization.

### Change

Added `describe_non_gguf_model()` next to `infer_loader()`, and appended its result to the error at both places that raise it (`modules/models.py`, `modules/models_settings.py`).

It reports the quantization method from `config.json` when there is one, falls back to `Transformers`, and tailors the advice to portable vs. regular builds:

```
No .gguf models found in the directory: <path>. This directory contains NVFP4
weights, which the llama.cpp loader cannot load. This portable build only
supports GGUF models.
```

The helper returns `None` — leaving the message byte-for-byte as it is today — whenever the directory holds no weight files, so an empty or mistyped path is not mislabelled as an unsupported model.

### Verification

There is no test suite here, so I exercised the helper directly against generated fixture directories:

| case | portable | appended text |
|---|---|---|
| safetensors + `quant_method: nvfp4` | no | `This directory contains NVFP4 weights, which the llama.cpp loader cannot load. Select a different loader or download a GGUF version of this model.` |
| safetensors, no `config.json` | no | `... contains Transformers weights ...` |
| `pytorch_model.bin` | no | `... contains Transformers weights ...` |
| `config.json` only, no weights | no | *(none — message unchanged)* |
| empty directory | no | *(none — message unchanged)* |
| `quantization_config: null` | no | `... contains Transformers weights ...` |
| malformed `config.json` | no | `... contains Transformers weights ...` (no exception) |
| safetensors + `quant_method: awq` | yes | `This directory contains AWQ weights, which the llama.cpp loader cannot load. This portable build only supports GGUF models.` |
| a file rather than a directory | no | *(none — message unchanged)* |
| nonexistent path | no | *(none — message unchanged)* |

`pycodestyle --config=setup.cfg modules/models.py modules/models_settings.py` reports the same 8 pre-existing violations before and after this change; no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
